### PR TITLE
Fix #48 (GetScreenshot method missing)

### DIFF
--- a/appium-dotnet-driver/Appium/AppiumDriver.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriver.cs
@@ -576,6 +576,18 @@ namespace OpenQA.Selenium.Appium
         }
         #endregion Orientation
 
+        #region Screenshot
+        /// <summary>
+        /// Return a screenshot of the session
+        /// </summary>
+        /// <returns>Screenshot</returns>
+        new public Screenshot GetScreenshot()
+        {
+            var commandResponse = this.Execute(AppiumDriverCommand.GetScreenshot, null);
+            return new Screenshot(commandResponse.Value.ToString());
+        }
+        #endregion
+
         #region Connection Type
         /// <summary>
         /// Get the Connection Type

--- a/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
@@ -209,6 +209,11 @@ namespace OpenQA.Selenium.Appium
         /// </summary>
         public const string DeactivateEngine = "deactivateEngine";
 
+        /// <summary>
+        /// Represents the Screenshot Command
+        /// </summary>
+        public const string GetScreenshot = "screenshot";
+
         #endregion JSON Wire Protocol
     }
 }


### PR DESCRIPTION
Override added for existing method as it does not work (nothing shows on the Appium server when running the `GetScreenshot` method included in `RemoteWebDriver`).
