### PR TITLE
Generic AppiumDriver

### DIFF
--- a/appium-dotnet-driver/Appium/Android/AndroidDriver.cs
+++ b/appium-dotnet-driver/Appium/Android/AndroidDriver.cs
@@ -6,15 +6,16 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.Contracts;
-using System.Linq;
-using System.Text;
 
 namespace OpenQA.Selenium.Appium.Android
 {
-    public class AndroidDriver : AppiumDriver, IFindByAndroidUIAutomator, IStartsActivity, IHasNetworkConnection, 
-        IAndroidDeviceActionShortcuts, IPushesFiles
+    public class AndroidDriver<W> : AppiumDriver<W>, IFindByAndroidUIAutomator<W>, IStartsActivity, 
+        IHasNetworkConnection, 
+        IAndroidDeviceActionShortcuts, 
+        IPushesFiles where W : IWebElement
     {
         private static readonly string Platform = MobilePlatform.Android;
+
 
         /// <summary>
         /// Initializes a new instance of the AndroidDriver class
@@ -57,37 +58,18 @@ namespace OpenQA.Selenium.Appium.Android
         }
 
         #region IFindByAndroidUIAutomator Members
-        /// <summary>
-        /// Finds the first element in the page that matches the Android UIAutomator selector supplied
-        /// </summary>
-        /// <param name="selector">Selector for the element.</param>
-        /// <returns>IWebElement object so that you can interact that object</returns>
-        /// <example>
-        /// <code>
-        /// IWebDriver driver = new RemoteWebDriver(DesiredCapabilities.Firefox());
-        /// IWebElement elem = driver.FindElementByAndroidUIAutomator('elements()'))
-        /// </code>
-        /// </example>
-        public IWebElement FindElementByAndroidUIAutomator(string selector)
+
+        public W FindElementByAndroidUIAutomator(string selector)
         {
-            return this.FindElement("-android uiautomator", selector);
+            return (W) this.FindElement("-android uiautomator", selector);
         }
 
-        /// <summary>
-        /// Finds a list of elements that match the Android UIAutomator selector supplied
-        /// </summary>
-        /// <param name="selector">Selector for the elements.</param>
-        /// <returns>ReadOnlyCollection of IWebElement object so that you can interact with those objects</returns>
-        /// <example>
-        /// <code>
-        /// IWebDriver driver = new RemoteWebDriver(DesiredCapabilities.Firefox());
-        /// ReadOnlyCollection<![CDATA[<IWebElement>]]> elem = driver.FindElementsByAndroidUIAutomator(elements())
-        /// </code>
-        /// </example>
-        public ReadOnlyCollection<IWebElement> FindElementsByAndroidUIAutomator(string selector)
+        public ReadOnlyCollection<W> FindElementsByAndroidUIAutomator(string selector)
         {
-            return this.FindElements("-android uiautomator", selector);
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<W>(this.FindElements("-android uiautomator", selector));
         }
+
         #endregion IFindByAndroidUIAutomator Members
 
         /// <summary>

--- a/appium-dotnet-driver/Appium/Android/AndroidElement.cs
+++ b/appium-dotnet-driver/Appium/Android/AndroidElement.cs
@@ -1,4 +1,5 @@
 ﻿using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -7,37 +8,29 @@ using System.Text;
 
 namespace OpenQA.Selenium.Appium.Android
 {
-    public class AndroidElement : AppiumWebElement, IFindByAndroidUIAutomator
+    public class AndroidElement : AppiumWebElement, IFindByAndroidUIAutomator<AppiumWebElement>
     {
         /// <summary>
         /// Initializes a new instance of the AndroidElement class.
         /// </summary>
         /// <param name="parent">Driver in use.</param>
         /// <param name="id">ID of the element.</param>
-        public AndroidElement(AppiumDriver parent, string id)
+        public AndroidElement(RemoteWebDriver parent, string id)
             : base(parent, id)
         {
         }
 
         #region IFindByAndroidUIAutomator Members
-        /// <summary>
-        /// Finds the first of elements that match the Android UIAutomator selector supplied
-        /// </summary>
-        /// <param name="selector">an Android UIAutomator selector</param>
-        /// <returns>IWebElement object so that you can interact that object</returns>
-        public IWebElement FindElementByAndroidUIAutomator(string selector)
+
+        public AppiumWebElement FindElementByAndroidUIAutomator(string selector)
         {
-            return this.FindElement("-android uiautomator", selector);
+            return (AppiumWebElement) this.FindElement("-android uiautomator", selector);
         }
 
-        /// <summary>
-        /// Finds a list of elements that match the Android UIAutomator selector supplied
-        /// </summary>
-        /// <param name="selector">an Android UIAutomator selector</param>
-        /// <returns>IWebElement object so that you can interact that object</returns>
-        public ReadOnlyCollection<IWebElement> FindElementsByAndroidUIAutomator(string selector)
+        public ReadOnlyCollection<AppiumWebElement> FindElementsByAndroidUIAutomator(string selector)
         {
-            return this.FindElements("-android uiautomator", selector);
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<AppiumWebElement>(this.FindElements("-android uiautomator", selector));
         }
         #endregion IFindByAndroidUIAutomator Members
     }

--- a/appium-dotnet-driver/Appium/AppiumDriver.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriver.cs
@@ -28,6 +28,7 @@ using System.Linq;
 using System.Reflection;
 using System.Diagnostics.Contracts;
 using Newtonsoft.Json;
+using Appium.Interfaces.Generic.SearchContext;
 
 namespace OpenQA.Selenium.Appium
 {
@@ -69,8 +70,10 @@ namespace OpenQA.Selenium.Appium
     /// }
     /// </code>
     /// </example>
-    public abstract class AppiumDriver : RemoteWebDriver, IFindByAccessibilityId, IDeviceActionShortcuts, IInteractsWithFiles,
-        IInteractsWithApps, IPerformsTouchActions, IRotatable, IContextAware
+    public abstract class AppiumDriver<W> : RemoteWebDriver, IFindByAccessibilityId<W>, IDeviceActionShortcuts, IInteractsWithFiles,
+        IInteractsWithApps, IPerformsTouchActions, IRotatable, IContextAware, IGenericSearchContext<W>, IGenericFindsByClassName<W>,
+        IGenericFindsById<W>, IGenericFindsByCssSelector<W>, IGenericFindsByLinkText<W>, IGenericFindsByName<W>,
+        IGenericFindsByPartialLinkText<W>, IGenericFindsByTagName<W>, IGenericFindsByXPath<W> where W : IWebElement
     {
         #region Constructors
         /// <summary>
@@ -117,44 +120,127 @@ namespace OpenQA.Selenium.Appium
         }
         #endregion Constructors
 
-        #region Public Methods
+        #region Generic FindMethods
+        public W FindElement(By by)
+        {
+            return (W)base.FindElement(by);
+        }
 
-        #region FindMethods
+        public ReadOnlyCollection<W> FindElements(By by)
+        {
+            return CollectionConverterUnility.
+                ConvertToExtendedWebElementCollection<W>(base.FindElements(by));
+        }
+
+        public W FindElementByClassName(string className)
+        {
+            return (W)base.FindElementByClassName(className);
+        }
+
+        public ReadOnlyCollection<W> FindElementsByClassName(string className)
+        {
+            return CollectionConverterUnility.
+                ConvertToExtendedWebElementCollection<W>(base.FindElementsByClassName(className));
+        }
+
+        public W FindElementById(string id)
+        {
+            return (W) base.FindElementById(id);
+        }
+
+
+        public ReadOnlyCollection<W> FindElementsById(string id)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<W>(base.FindElementsById(id));
+        }
+
+        public W FindElementByCssSelector(string cssSelector)
+        {
+            return (W)base.FindElementByCssSelector(cssSelector); 
+        }
+
+
+        public ReadOnlyCollection<W> FindElementsByCssSelector(string cssSelector)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<W>(base.FindElementsByCssSelector(cssSelector));
+        }
+
+        public W FindElementByLinkText(string linkText)
+        {
+            return (W) base.FindElementByLinkText(linkText); 
+        }
+
+        public ReadOnlyCollection<W> FindElementsByLinkText(string linkText)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<W>(base.FindElementsByLinkText(linkText));
+        }
+
+        public W FindElementByName(string name)
+        {
+            return (W)base.FindElementByName(name); 
+        }
+
+        public ReadOnlyCollection<W> FindElementsByName(string name)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<W>(base.FindElementsByName(name));
+        }
+
+        public W FindElementByPartialLinkText(string partialLinkText)
+        {
+            return (W) base.FindElementByPartialLinkText(partialLinkText); 
+        }
+
+        public ReadOnlyCollection<W> FindElementsByPartialLinkText(string partialLinkText)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<W>(base.FindElementsByPartialLinkText(partialLinkText));
+        }
+
+        public W FindElementByTagName(string tagName)
+        {
+            return (W) base.FindElementByTagName(tagName); 
+        }
+
+        public ReadOnlyCollection<W> FindElementsByTagName(string tagName)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<W>(base.FindElementsByTagName(tagName));
+        }
+
+        public W FindElementByXPath(string xpath)
+        {
+            return (W) base.FindElementByXPath(xpath); 
+        }
+
+        public ReadOnlyCollection<W> FindElementsByXPath(string xpath)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<W>(base.FindElementsByXPath(xpath));
+        }
 
         #region IFindByAccessibilityId Members
-        /// <summary>
-        /// Finds the first element in the page that matches the Accessibility Id selector supplied
-        /// </summary>
-        /// <param name="selector">Selector for the element.</param>
-        /// <returns>IWebElement object so that you can interact that object</returns>
-        /// <example>
-        /// <code>
-        /// IWebDriver driver = new RemoteWebDriver(DesiredCapabilities.Firefox());
-        /// IWebElement elem = driver.FindElementByAccessibilityId('elements()'))
-        /// </code>
-        /// </example>
-        public IWebElement FindElementByAccessibilityId(string selector)
+
+        public W FindElementByAccessibilityId(string selector)
         {
-            return this.FindElement("accessibility id", selector);
+            return (W) this.FindElement("accessibility id", selector);
         }
 
-        /// <summary>
-        /// Finds a list of elements that match the Accessibility Id selector supplied
-        /// </summary>
-        /// <param name="selector">Selector for the elements.</param>
-        /// <returns>ReadOnlyCollection of IWebElement object so that you can interact with those objects</returns>
-        /// <example>
-        /// <code>
-        /// IWebDriver driver = new RemoteWebDriver(DesiredCapabilities.Firefox());
-        /// ReadOnlyCollection<![CDATA[<IWebElement>]]> elem = driver.FindElementsByAccessibilityId(elements())
-        /// </code>
-        /// </example>
-        public ReadOnlyCollection<IWebElement> FindElementsByAccessibilityId(string selector)
+        public ReadOnlyCollection<W> FindElementsByAccessibilityId(string selector)
         {
-            return this.FindElements("accessibility id", selector);
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<W>(base.FindElements("accessibility id", selector));
         }
+
         #endregion IFindByAccessibilityId Members
+
         #endregion
+
+        #region Public Methods
+
 
         #region MJsonMethod Members
         /// <summary>
@@ -320,6 +406,7 @@ namespace OpenQA.Selenium.Appium
         /// <summary>
         /// Hides the device keyboard.
         /// </summary>
+        /// <param name="keyName">The button pressed by the mobile driver to attempt hiding the keyboard.</param>
         public void HideKeyboard()
         {
             this.HideKeyboard(null, null);

--- a/appium-dotnet-driver/Appium/AppiumWebElement.cs
+++ b/appium-dotnet-driver/Appium/AppiumWebElement.cs
@@ -19,8 +19,8 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using OpenQA.Selenium.Appium.Interfaces;
-using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Remote;
+using Appium.Interfaces.Generic.SearchContext;
 
 namespace OpenQA.Selenium.Appium
 {
@@ -40,14 +40,18 @@ namespace OpenQA.Selenium.Appium
     /// }
     /// </code>
     /// </example>
-    public abstract class AppiumWebElement : RemoteWebElement, IFindByAccessibilityId
+    public abstract class AppiumWebElement : RemoteWebElement, IFindByAccessibilityId<AppiumWebElement>, IGenericSearchContext<AppiumWebElement>,
+        IGenericFindsByClassName<AppiumWebElement>,
+        IGenericFindsById<AppiumWebElement>, IGenericFindsByCssSelector<AppiumWebElement>, IGenericFindsByLinkText<AppiumWebElement>, 
+        IGenericFindsByName<AppiumWebElement>,
+        IGenericFindsByPartialLinkText<AppiumWebElement>, IGenericFindsByTagName<AppiumWebElement>, IGenericFindsByXPath<AppiumWebElement>
     {
         /// <summary>
         /// Initializes a new instance of the AppiumWebElement class.
         /// </summary>
         /// <param name="parent">Driver in use.</param>
         /// <param name="id">ID of the element.</param>
-        public AppiumWebElement(AppiumDriver parent, string id)
+        public AppiumWebElement(RemoteWebDriver parent, string id)
             : base(parent, id)
         {
         }
@@ -89,26 +93,122 @@ namespace OpenQA.Selenium.Appium
         #region FindMethods
 
         #region IFindByAccessibilityId Members
-        /// <summary>
-        /// Finds the first of elements that match the Accessibility Id selector supplied
-        /// </summary>
-        /// <param name="selector">an Accessibility Id selector</param>
-        /// <returns>IWebElement object so that you can interact that object</returns>
-        public IWebElement FindElementByAccessibilityId(string selector)
+
+        public AppiumWebElement FindElementByAccessibilityId(string selector)
         {
-            return this.FindElement("accessibility id", selector);
+            return (AppiumWebElement) this.FindElement("accessibility id", selector);
         }
 
-        /// <summary>
-        /// Finds a list of elements that match the Accessibility Id selector supplied
-        /// </summary>
-        /// <param name="selector">an Accessibility Id selector</param>
-        /// <returns>IWebElement object so that you can interact that object</returns>
-        public ReadOnlyCollection<IWebElement> FindElementsByAccessibilityId(string selector)
+        public ReadOnlyCollection<AppiumWebElement> FindElementsByAccessibilityId(string selector)
         {
-            return this.FindElements("accessibility id", selector);
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<AppiumWebElement>(this.FindElements("accessibility id", selector));
         }
+
         #endregion IFindByAccessibilityId Members
+
+        public AppiumWebElement FindElement(By by)
+        {
+            return (AppiumWebElement) base.FindElement(by);
+        }
+
+        public ReadOnlyCollection<AppiumWebElement> FindElements(By by)
+        {
+            return CollectionConverterUnility.
+                ConvertToExtendedWebElementCollection<AppiumWebElement>(base.FindElements(by));
+        }
+
+        public AppiumWebElement FindElementByClassName(string className)
+        {
+            return (AppiumWebElement) base.FindElementByClassName(className);
+        }
+
+        public ReadOnlyCollection<AppiumWebElement> FindElementsByClassName(string className)
+        {
+            return CollectionConverterUnility.
+                ConvertToExtendedWebElementCollection<AppiumWebElement>(base.FindElementsByClassName(className));
+        }
+
+        public AppiumWebElement FindElementById(string id)
+        {
+            return (AppiumWebElement) base.FindElementById(id);
+        }
+
+
+        public ReadOnlyCollection<AppiumWebElement> FindElementsById(string id)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<AppiumWebElement>(base.FindElementsById(id));
+        }
+
+        public AppiumWebElement FindElementByCssSelector(string cssSelector)
+        {
+            return (AppiumWebElement) base.FindElementByCssSelector(cssSelector);
+        }
+
+
+        public ReadOnlyCollection<AppiumWebElement> FindElementsByCssSelector(string cssSelector)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<AppiumWebElement>(base.FindElementsByCssSelector(cssSelector));
+        }
+
+        public AppiumWebElement FindElementByLinkText(string linkText)
+        {
+            return (AppiumWebElement) base.FindElementByLinkText(linkText);
+        }
+
+        public ReadOnlyCollection<AppiumWebElement> FindElementsByLinkText(string linkText)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<AppiumWebElement>(base.FindElementsByLinkText(linkText));
+        }
+
+        public AppiumWebElement FindElementByName(string name)
+        {
+            return (AppiumWebElement) base.FindElementByName(name);
+        }
+
+        public ReadOnlyCollection<AppiumWebElement> FindElementsByName(string name)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<AppiumWebElement>(base.FindElementsByName(name));
+        }
+
+        public AppiumWebElement FindElementByPartialLinkText(string partialLinkText)
+        {
+            return (AppiumWebElement) base.FindElementByPartialLinkText(partialLinkText);
+        }
+
+        public ReadOnlyCollection<AppiumWebElement> FindElementsByPartialLinkText(string partialLinkText)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<AppiumWebElement>(base.FindElementsByPartialLinkText(partialLinkText));
+        }
+
+        public AppiumWebElement FindElementByTagName(string tagName)
+        {
+            return (AppiumWebElement) base.FindElementByTagName(tagName);
+        }
+
+        public ReadOnlyCollection<AppiumWebElement> FindElementsByTagName(string tagName)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<AppiumWebElement>(base.FindElementsByTagName(tagName));
+        }
+
+        public AppiumWebElement FindElementByXPath(string xpath)
+        {
+            return (AppiumWebElement)base.FindElementByXPath(xpath);
+        }
+
+        public ReadOnlyCollection<AppiumWebElement> FindElementsByXPath(string xpath)
+        {
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<AppiumWebElement>(base.FindElementsByXPath(xpath));
+        }
+
+
 
         #endregion
     }

--- a/appium-dotnet-driver/Appium/ByAccessibilityId.cs
+++ b/appium-dotnet-driver/Appium/ByAccessibilityId.cs
@@ -20,6 +20,8 @@ using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using OpenQA.Selenium.Appium.Interfaces;
+using System.Reflection;
+using System.Collections;
 
 namespace OpenQA.Selenium.Appium
 {
@@ -29,6 +31,7 @@ namespace OpenQA.Selenium.Appium
     public class ByAccessibilityId : By
     {
         private string selector = string.Empty;
+        private readonly string InterfaceNameRegExp = "IFindByAccessibilityId`1";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ByAccessibilityId"/> class.
@@ -51,12 +54,14 @@ namespace OpenQA.Selenium.Appium
         /// <returns>The element that matches</returns>
         public override IWebElement FindElement(ISearchContext context)
         {
-            var tmpContext = context as IFindByAccessibilityId;
-            if (null == tmpContext)
+            Type contextType = context.GetType();
+            Type findByAccessibilityId = contextType.GetInterface(InterfaceNameRegExp, false);
+            if (null == findByAccessibilityId)
             {
-                throw new InvalidCastException("Unable to cast ISearchContext to IFindByAccessibilityId");
+                throw new InvalidCastException("Unable to cast " + contextType.ToString() + " to IFindByAccessibilityId");
             }
-            return tmpContext.FindElementByAccessibilityId(selector);
+            MethodInfo m = findByAccessibilityId.GetMethod("FindElementByAccessibilityId", new Type[] { typeof(string) });
+            return (IWebElement) m.Invoke(context, new object[] { selector });
         }
 
         /// <summary>
@@ -66,12 +71,15 @@ namespace OpenQA.Selenium.Appium
         /// <returns>A readonly collection of elements that match.</returns>
         public override ReadOnlyCollection<IWebElement> FindElements(ISearchContext context)
         {
-            var tmpContext = context as IFindByAccessibilityId;
-            if (null == tmpContext)
+            Type contextType = context.GetType();
+            Type findByAccessibilityId = contextType.GetInterface(InterfaceNameRegExp, false);
+            if (null == findByAccessibilityId)
             {
-                throw new InvalidCastException("Unable to cast ISearchContext to IFindByAccessibilityId");
+                throw new InvalidCastException("Unable to cast " + contextType.ToString() + " to IFindByAccessibilityId");
             }
-            return tmpContext.FindElementsByAccessibilityId(selector);
+            MethodInfo m = findByAccessibilityId.GetMethod("FindElementsByAccessibilityId", new Type[] { typeof(string) });
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<IWebElement>((IList) m.Invoke(context, new object[] { selector }));
         }
 
         /// <summary>

--- a/appium-dotnet-driver/Appium/ByAndroidUIAutomator.cs
+++ b/appium-dotnet-driver/Appium/ByAndroidUIAutomator.cs
@@ -20,6 +20,8 @@ using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using OpenQA.Selenium.Appium.Interfaces;
+using System.Reflection;
+using System.Collections;
 
 namespace OpenQA.Selenium.Appium
 {
@@ -29,7 +31,7 @@ namespace OpenQA.Selenium.Appium
     public class ByAndroidUIAutomator : By
     {
         private string _Selector = string.Empty;
-        private const string _UnableToCastError = "Unable to cast ISearchContext to IFindByAndroidUIAutomator";
+        private readonly string InterfaceNameRegExp = "IFindByAndroidUIAutomator`1";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ByAndroidUIAutomator"/> class.
@@ -52,12 +54,14 @@ namespace OpenQA.Selenium.Appium
         /// <returns>The element that matches</returns>
         public override IWebElement FindElement(ISearchContext context)
         {
-            var tmpContext = context as IFindByAndroidUIAutomator;
-            if (null == tmpContext)
+            Type contextType = context.GetType();
+            Type findByAccessibilityId = contextType.GetInterface(InterfaceNameRegExp, false);
+            if (null == findByAccessibilityId)
             {
-                throw new InvalidCastException(_UnableToCastError);
+                throw new InvalidCastException("Unable to cast " + contextType.ToString() + " to IFindByAndroidUIAutomator");
             }
-            return tmpContext.FindElementByAndroidUIAutomator(_Selector);
+            MethodInfo m = findByAccessibilityId.GetMethod("FindElementByAndroidUIAutomator", new Type[] { typeof(string) });
+            return (IWebElement) m.Invoke(context, new object[] { _Selector});
         }
 
         /// <summary>
@@ -67,12 +71,15 @@ namespace OpenQA.Selenium.Appium
         /// <returns>A readonly collection of elements that match.</returns>
         public override ReadOnlyCollection<IWebElement> FindElements(ISearchContext context)
         {
-            var tmpContext = context as IFindByAndroidUIAutomator;
-            if (null == tmpContext)
+            Type contextType = context.GetType();
+            Type findByAccessibilityId = contextType.GetInterface(InterfaceNameRegExp, false);
+            if (null == findByAccessibilityId)
             {
-                throw new InvalidCastException(_UnableToCastError);
+                throw new InvalidCastException("Unable to cast " + contextType.ToString() + " to IFindByAndroidUIAutomator");
             }
-            return tmpContext.FindElementsByAndroidUIAutomator(_Selector);
+            MethodInfo m = findByAccessibilityId.GetMethod("FindElementsByAndroidUIAutomator", new Type[] { typeof(string) });
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<IWebElement>((IList) m.Invoke(context, new object[] { _Selector }));
         }
 
         /// <summary>

--- a/appium-dotnet-driver/Appium/ByIosUIAutomation.cs
+++ b/appium-dotnet-driver/Appium/ByIosUIAutomation.cs
@@ -20,6 +20,8 @@ using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using OpenQA.Selenium.Appium.Interfaces;
+using System.Reflection;
+using System.Collections;
 
 namespace OpenQA.Selenium.Appium
 {
@@ -29,7 +31,7 @@ namespace OpenQA.Selenium.Appium
     public class ByIosUIAutomation : By
     {
         private string _Selector = string.Empty;
-        private const string _UnableToCast = "Unable to cast ISearchContext to IFindByIosUIAutomation";
+        private readonly string InterfaceNameRegExp = "IFindByIosUIAutomation`1";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ByIosUIAutomation"/> class.
@@ -52,12 +54,14 @@ namespace OpenQA.Selenium.Appium
         /// <returns>The element that matches</returns>
         public override IWebElement FindElement(ISearchContext context)
         {
-            var tmpContext = context as IFindByIosUIAutomation;
-            if (null == tmpContext)
+            Type contextType = context.GetType();
+            Type findByAccessibilityId = contextType.GetInterface(InterfaceNameRegExp, false);
+            if (null == findByAccessibilityId)
             {
-                throw new InvalidCastException(_UnableToCast);
+                throw new InvalidCastException("Unable to cast " + contextType.ToString() + " to IFindByIosUIAutomation");
             }
-            return tmpContext.FindElementByIosUIAutomation(_Selector);
+            MethodInfo m = findByAccessibilityId.GetMethod("FindElementByIosUIAutomation", new Type[] { typeof(string) });
+            return (IWebElement)m.Invoke(context, new object[] { _Selector });
         }
 
         /// <summary>
@@ -67,12 +71,15 @@ namespace OpenQA.Selenium.Appium
         /// <returns>A readonly collection of elements that match.</returns>
         public override ReadOnlyCollection<IWebElement> FindElements(ISearchContext context)
         {
-            var tmpContext = context as IFindByIosUIAutomation;
-            if (null == tmpContext)
+            Type contextType = context.GetType();
+            Type findByAccessibilityId = contextType.GetInterface(InterfaceNameRegExp, false);
+            if (null == findByAccessibilityId)
             {
-                throw new InvalidCastException(_UnableToCast);
+                throw new InvalidCastException("Unable to cast " + contextType.ToString() + " to IFindByIosUIAutomation");
             }
-            return tmpContext.FindElementsByIosUIAutomation(_Selector);
+            MethodInfo m = findByAccessibilityId.GetMethod("FindElementsByIosUIAutomation", new Type[] { typeof(string) });
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<IWebElement>((IList) m.Invoke(context, new object[] { _Selector }));
         }
 
         /// <summary>

--- a/appium-dotnet-driver/Appium/CollectionConverterUnility.cs
+++ b/appium-dotnet-driver/Appium/CollectionConverterUnility.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium
+{
+    internal class CollectionConverterUnility
+    {
+        public static ReadOnlyCollection<T> ConvertToExtendedWebElementCollection<T>(IList list) where T : IWebElement
+        {
+            List<T> result = new List<T>();
+            foreach (var element in list)
+            {
+                result.Add((T) element);
+            }
+            return result.AsReadOnly();
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByClassName.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByClassName.cs
@@ -1,0 +1,45 @@
+// <copyright file="IGenericFindsByClassName.cs" company="Appium Committers">
+// Copyright 2015 Software Freedom Conservancy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenQA.Selenium;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Appium.Interfaces.Generic.SearchContext
+{
+    /// <summary>
+    /// Defines the interface through which the user finds elements by their CSS class.
+    /// </summary>
+    public interface IGenericFindsByClassName<W> where W : IWebElement
+    {
+        /// <summary>
+        /// Finds the first element matching the specified CSS class.
+        /// </summary>
+        /// <param name="className">The CSS class to match.</param>
+        /// <returns>The first <see cref="IWebElement"/> matching the criteria.</returns>
+        W FindElementByClassName(string className);
+
+        /// <summary>
+        /// Finds all elements matching the specified CSS class.
+        /// </summary>
+        /// <param name="className">The CSS class to match.</param>
+        /// <returns>A <see cref="ReadOnlyCollection{T}"/> containing all
+        /// <see cref="IWebElement">IWebElements</see> matching the criteria.</returns>
+        ReadOnlyCollection<W> FindElementsByClassName(string className);
+    }
+}

--- a/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByCssSelector.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByCssSelector.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="IGenericFindsByCssSelector.cs" company="Appium Committers">
+// Copyright 2015 Software Freedom Conservancy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using OpenQA.Selenium;
+
+namespace Appium.Interfaces.Generic.SearchContext
+{
+    /// <summary>
+    /// Defines the interface through which the user finds elements by their cascading style sheet (CSS) selector.
+    /// </summary>
+    public interface IGenericFindsByCssSelector<W> where W : IWebElement
+    {
+        /// <summary>
+        /// Finds the first element matching the specified CSS selector.
+        /// </summary>
+        /// <param name="cssSelector">The id to match.</param>
+        /// <returns>The first <see cref="IWebElement"/> matching the criteria.</returns>
+        W FindElementByCssSelector(string cssSelector);
+
+        /// <summary>
+        /// Finds all elements matching the specified CSS selector.
+        /// </summary>
+        /// <param name="cssSelector">The CSS selector to match.</param>
+        /// <returns>A <see cref="ReadOnlyCollection{T}"/> containing all
+        /// <see cref="IWebElement">IWebElements</see> matching the criteria.</returns>
+        ReadOnlyCollection<W> FindElementsByCssSelector(string cssSelector);
+    }
+}

--- a/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsById.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsById.cs
@@ -1,0 +1,45 @@
+// <copyright file="IGenericFindsById.cs" company="Appium Committers">
+// Copyright 2015 Software Freedom Conservancy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenQA.Selenium;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Appium.Interfaces.Generic.SearchContext
+{
+    /// <summary>
+    /// Defines the interface through which the user finds elements by their ID.
+    /// </summary>
+    public interface IGenericFindsById<W> where W : IWebElement
+    {
+        /// <summary>
+        /// Finds the first element matching the specified id.
+        /// </summary>
+        /// <param name="id">The id to match.</param>
+        /// <returns>The first <see cref="IWebElement"/> matching the criteria.</returns>
+        W FindElementById(string id);
+
+        /// <summary>
+        /// Finds all elements matching the specified id.
+        /// </summary>
+        /// <param name="id">The id to match.</param>
+        /// <returns>A <see cref="ReadOnlyCollection{T}"/> containing all
+        /// <see cref="IWebElement">IWebElements</see> matching the criteria.</returns>
+        ReadOnlyCollection<W> FindElementsById(string id);
+    }
+}

--- a/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByLinkText.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByLinkText.cs
@@ -1,0 +1,45 @@
+// <copyright file="IGenericFindsByLinkText.cs" company="Appium Committers">
+// Copyright 2015 Software Freedom Conservancy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenQA.Selenium;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Appium.Interfaces.Generic.SearchContext
+{
+    /// <summary>
+    /// Defines the interface through which the user finds elements by their link text.
+    /// </summary>
+    public interface IGenericFindsByLinkText<W> where W : IWebElement
+    {
+        /// <summary>
+        /// Finds the first element matching the specified link text.
+        /// </summary>
+        /// <param name="linkText">The link text to match.</param>
+        /// <returns>The first <see cref="IWebElement"/> matching the criteria.</returns>
+        W FindElementByLinkText(string linkText);
+
+        /// <summary>
+        /// Finds all elements matching the specified link text.
+        /// </summary>
+        /// <param name="linkText">The link text to match.</param>
+        /// <returns>A <see cref="ReadOnlyCollection{T}"/> containing all
+        /// <see cref="IWebElement">IWebElements</see> matching the criteria.</returns>
+        ReadOnlyCollection<W> FindElementsByLinkText(string linkText);
+    }
+}

--- a/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByName.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByName.cs
@@ -1,0 +1,45 @@
+// <copyright file="IGenericFindsByName.cs" company="Appium Committers">
+// Copyright 2015 Software Freedom Conservancy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenQA.Selenium;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Appium.Interfaces.Generic.SearchContext
+{
+    /// <summary>
+    /// Defines the interface through which the user finds elements by their name.
+    /// </summary>
+    public interface IGenericFindsByName<W> where W : IWebElement
+    {
+        /// <summary>
+        /// Finds the first element matching the specified name.
+        /// </summary>
+        /// <param name="name">The name to match.</param>
+        /// <returns>The first <see cref="IWebElement"/> matching the criteria.</returns>
+        W FindElementByName(string name);
+
+        /// <summary>
+        /// Finds all elements matching the specified name.
+        /// </summary>
+        /// <param name="name">The name to match.</param>
+        /// <returns>A <see cref="ReadOnlyCollection{T}"/> containing all
+        /// <see cref="IWebElement">IWebElements</see> matching the criteria.</returns>
+        ReadOnlyCollection<W> FindElementsByName(string name);
+    }
+}

--- a/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByPartialLinkText.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByPartialLinkText.cs
@@ -1,0 +1,45 @@
+// <copyright file="IGenericFindsByPartialLinkText.cs" company="Appium Committers">
+// Copyright 2015 Software Freedom Conservancy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenQA.Selenium;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Appium.Interfaces.Generic.SearchContext
+{
+    /// <summary>
+    /// Defines the interface through which the user finds elements by a partial match on their link text.
+    /// </summary>
+    public interface IGenericFindsByPartialLinkText<W> where W : IWebElement
+    {
+        /// <summary>
+        /// Finds the first element matching the specified partial link text.
+        /// </summary>
+        /// <param name="partialLinkText">The partial link text to match.</param>
+        /// <returns>The first <see cref="IWebElement"/> matching the criteria.</returns>
+        W FindElementByPartialLinkText(string partialLinkText);
+
+        /// <summary>
+        /// Finds all elements matching the specified partial link text.
+        /// </summary>
+        /// <param name="partialLinkText">The partial link text to match.</param>
+        /// <returns>A <see cref="ReadOnlyCollection{T}"/> containing all
+        /// <see cref="IWebElement">IWebElements</see> matching the criteria.</returns>
+        ReadOnlyCollection<W> FindElementsByPartialLinkText(string partialLinkText);
+    }
+}

--- a/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByTagName.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByTagName.cs
@@ -1,0 +1,45 @@
+// <copyright file="IGenericFindsByTagName.cs" company="Appium Committers">
+// Copyright 2015 Software Freedom Conservancy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenQA.Selenium;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Appium.Interfaces.Generic.SearchContext
+{
+    /// <summary>
+    /// Defines the interface through which the user finds elements by their tag name.
+    /// </summary>
+    public interface IGenericFindsByTagName<W> where W : IWebElement
+    {
+        /// <summary>
+        /// Finds the first element matching the specified tag name.
+        /// </summary>
+        /// <param name="tagName">The tag name to match.</param>
+        /// <returns>The first <see cref="IWebElement"/> matching the criteria.</returns>
+        W FindElementByTagName(string tagName);
+
+        /// <summary>
+        /// Finds all elements matching the specified tag name.
+        /// </summary>
+        /// <param name="tagName">The tag name to match.</param>
+        /// <returns>A <see cref="ReadOnlyCollection{T}"/> containing all
+        /// <see cref="IWebElement">IWebElements</see> matching the criteria.</returns>
+        ReadOnlyCollection<W> FindElementsByTagName(string tagName);
+    }
+}

--- a/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByXPath.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericFindsByXPath.cs
@@ -1,0 +1,45 @@
+// <copyright file="IGenericFindsByXPath.cs" company="Appium Committers">
+// Copyright 2015 Software Freedom Conservancy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenQA.Selenium;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Appium.Interfaces.Generic.SearchContext
+{
+    /// <summary>
+    /// Defines the interface through which the user finds elements by XPath.
+    /// </summary>
+    public interface IGenericFindsByXPath<W> where W : IWebElement
+    {
+        /// <summary>
+        /// Finds the first element matching the specified XPath query.
+        /// </summary>
+        /// <param name="xpath">The XPath query to match.</param>
+        /// <returns>The first <see cref="IWebElement"/> matching the criteria.</returns>
+        W FindElementByXPath(string xpath);
+
+        /// <summary>
+        /// Finds all elements matching the specified XPath query.
+        /// </summary>
+        /// <param name="xpath">The XPath query to match.</param>
+        /// <returns>A <see cref="ReadOnlyCollection{T}"/> containing all
+        /// <see cref="IWebElement">IWebElements</see> matching the criteria.</returns>
+        ReadOnlyCollection<W> FindElementsByXPath(string xpath);
+    }
+}

--- a/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericSearchContext.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/Generic/SearchContext/IGenericSearchContext.cs
@@ -1,0 +1,47 @@
+// <copyright file="IGenericSearchContext.cs" company="Appium Committers">
+// Copyright 2015 Software Freedom Conservancy
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using OpenQA.Selenium;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Appium.Interfaces.Generic.SearchContext
+{
+    /// <summary>
+    /// Defines the interface used to search for elements.
+    /// </summary>
+    public interface IGenericSearchContext<W> where W : IWebElement
+    {
+        /// <summary>
+        /// Finds the first <see cref="IWebElement"/> using the given method. 
+        /// </summary>
+        /// <param name="by">The locating mechanism to use.</param>
+        /// <returns>The first matching <see cref="IWebElement"/> on the current context.</returns>
+        /// <exception cref="NoSuchElementException">If no element matches the criteria.</exception>
+        W FindElement(By by);
+
+        /// <summary>
+        /// Finds all <see cref="IWebElement">IWebElements</see> within the current context 
+        /// using the given mechanism.
+        /// </summary>
+        /// <param name="by">The locating mechanism to use.</param>
+        /// <returns>A <see cref="ReadOnlyCollection{T}"/> of all <see cref="IWebElement">WebElements</see>
+        /// matching the current criteria, or an empty list if nothing matches.</returns>
+        ReadOnlyCollection<W> FindElements(By by);
+    }
+}

--- a/appium-dotnet-driver/Appium/Interfaces/IContextAware.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/IContextAware.cs
@@ -4,11 +4,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 
-/// <summary>
-/// This interface is temporary. Let it be here till 
-///https://github.com/SeleniumHQ/selenium/pull/301
-///is merged and new Webdriver for .Net is published.
-///
+
 namespace OpenQA.Selenium.Appium.Interfaces
 {
     /// <summary>

--- a/appium-dotnet-driver/Appium/Interfaces/IFindByAccessibilityId.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/IFindByAccessibilityId.cs
@@ -2,20 +2,20 @@
 
 namespace OpenQA.Selenium.Appium.Interfaces
 {
-    public interface IFindByAccessibilityId
+    public interface IFindByAccessibilityId<W> where W : IWebElement
     {
         /// <summary>
         /// Finds the first of elements that match the Accessibility Id selector supplied
         /// </summary>
         /// <param name="selector">an Accessibility Id selector</param>
         /// <returns>IWebElement object so that you can interact that object</returns>
-        IWebElement FindElementByAccessibilityId(string selector);
+        W FindElementByAccessibilityId(string selector);
 
         /// <summary>
         /// Finds a list of elements that match the Accessibility Id selector supplied
         /// </summary>
         /// <param name="selector">an Accessibility Id selector</param>
         /// <returns>IWebElement object so that you can interact that object</returns>
-        ReadOnlyCollection<IWebElement> FindElementsByAccessibilityId(string selector);
+        ReadOnlyCollection<W> FindElementsByAccessibilityId(string selector);
     }
 }

--- a/appium-dotnet-driver/Appium/Interfaces/IFindByAndroidUIAutomator.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/IFindByAndroidUIAutomator.cs
@@ -2,7 +2,7 @@
 
 namespace OpenQA.Selenium.Appium.Interfaces
 {
-    public interface IFindByAndroidUIAutomator
+    public interface IFindByAndroidUIAutomator<W> where W : IWebElement
     {
         /// <summary>
         /// Finds the first element in the page that matches the Android UIAutomator selector supplied
@@ -15,7 +15,7 @@ namespace OpenQA.Selenium.Appium.Interfaces
         /// IWebElement elem = driver.FindElementByAndroidUIAutomator('elements()'))
         /// </code>
         /// </example>
-        IWebElement FindElementByAndroidUIAutomator(string selector);
+        W FindElementByAndroidUIAutomator(string selector);
 
         /// <summary>
         /// Finds a list of elements that match the Android UIAutomator selector supplied
@@ -28,6 +28,6 @@ namespace OpenQA.Selenium.Appium.Interfaces
         /// ReadOnlyCollection<![CDATA[<IWebElement>]]> elem = driver.FindElementsByAndroidUIAutomator(elements())
         /// </code>
         /// </example>
-        ReadOnlyCollection<IWebElement> FindElementsByAndroidUIAutomator(string selector);
+        ReadOnlyCollection<W> FindElementsByAndroidUIAutomator(string selector);
     }
 }

--- a/appium-dotnet-driver/Appium/Interfaces/IFindByIosUIAutomation.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/IFindByIosUIAutomation.cs
@@ -2,20 +2,20 @@
 
 namespace OpenQA.Selenium.Appium.Interfaces
 {
-    public interface IFindByIosUIAutomation
+    public interface IFindByIosUIAutomation<W> where W : IWebElement
     {
         /// <summary>
         /// Finds the first of elements that match the Ios UIAutomation selector supplied
         /// </summary>
         /// <param name="selector">an Ios UIAutomation selector</param>
         /// <returns>IWebElement object so that you can interact that object</returns>
-        IWebElement FindElementByIosUIAutomation(string selector);
+        W FindElementByIosUIAutomation(string selector);
 
         /// <summary>
         /// Finds a list of elements that match the Ios UIAutomation selector supplied
         /// </summary>
         /// <param name="selector">an Ios UIAutomation selector</param>
         /// <returns>IWebElement object so that you can interact that object</returns>
-        ReadOnlyCollection<IWebElement> FindElementsByIosUIAutomation(string selector);
+        ReadOnlyCollection<W> FindElementsByIosUIAutomation(string selector);
     }
 }

--- a/appium-dotnet-driver/Appium/MultiAction/MultiAction.cs
+++ b/appium-dotnet-driver/Appium/MultiAction/MultiAction.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using OpenQA.Selenium.Appium.Interfaces;
 using System.Reflection;
+using OpenQA.Selenium.Remote;
 
 namespace OpenQA.Selenium.Appium.MultiTouch
 {
@@ -10,7 +11,7 @@ namespace OpenQA.Selenium.Appium.MultiTouch
     {
 		private IList<ITouchAction> actions = new List<ITouchAction>();
 
-		private AppiumDriver driver;
+		private IPerformsTouchActions TouchActionPerformer;
 		private IWebElement element;
 
 		private string getIdForElement(IWebElement el) {
@@ -22,9 +23,9 @@ namespace OpenQA.Selenium.Appium.MultiTouch
 		/// </summary>
 		/// <param name="driver">The <see cref="IWebDriver"/> the driver to be used.</param>
 		/// <param name="element">The <see cref="IWebDriver"/> the element on which the actions built will be performed.</param>
-		public MultiAction(AppiumDriver driver, IWebElement element)
+        public MultiAction(IPerformsTouchActions touchActionPerformer, IWebElement element)
+            :this(touchActionPerformer)
 		{
-			this.driver = driver;
 			this.element = element;
 		}
 
@@ -32,9 +33,9 @@ namespace OpenQA.Selenium.Appium.MultiTouch
 		/// Initializes a new instance of the <see cref="MultiTouchAction"/> class.
 		/// </summary>
 		/// <param name="driver">The <see cref="IWebDriver"/> the driver to be used.</param>
-		public MultiAction(AppiumDriver driver)
+        public MultiAction(IPerformsTouchActions touchActionPerformer)
 		{
-			this.driver = driver;
+            this.TouchActionPerformer = touchActionPerformer;
 		}
 
 		/// <summary>
@@ -53,13 +54,6 @@ namespace OpenQA.Selenium.Appium.MultiTouch
 		{
 		}
 			
-		/// <summary>
-		/// Sets the driver.
-		/// </summary>
-		/// <param name="driver">The <see cref="IWebDriver"/> the driver to be used.</param>
-		public void setDriver (AppiumDriver driver) {
-			this.driver = driver;
-		}
 
 		/// <summary>
 		/// Sets the element.
@@ -107,8 +101,6 @@ namespace OpenQA.Selenium.Appium.MultiTouch
 		/// </summary>
 		public void Cancel()
 		{
-			this.driver = null;
-			this.element = null;
 			actions.Clear ();
 		}
 
@@ -117,7 +109,7 @@ namespace OpenQA.Selenium.Appium.MultiTouch
         /// </summary>
         public void Perform()
         {
-			this.driver.PerformMultiAction (this);
+			TouchActionPerformer.PerformMultiAction (this);
         }
     }
 }

--- a/appium-dotnet-driver/Appium/MultiAction/TouchAction.cs
+++ b/appium-dotnet-driver/Appium/MultiAction/TouchAction.cs
@@ -2,6 +2,7 @@
 using OpenQA.Selenium.Appium.Interfaces;
 using System.Collections.Generic;
 using System.Reflection;
+using OpenQA.Selenium.Remote;
 
 namespace OpenQA.Selenium.Appium.MultiTouch
 {
@@ -47,16 +48,16 @@ namespace OpenQA.Selenium.Appium.MultiTouch
 			}
 		}
 
-		private AppiumDriver driver;
+		private IPerformsTouchActions TouchActionPerformer;
 		private List<Step> steps = new List<Step>();
 
 		public TouchAction ()
 		{
 		}
 
-		public TouchAction (AppiumDriver driver)
+        public TouchAction(IPerformsTouchActions touchActionPerformer)
 		{
-			this.driver = driver;
+            this.TouchActionPerformer = touchActionPerformer;
 		}
 
 		/// <summary>
@@ -238,7 +239,7 @@ namespace OpenQA.Selenium.Appium.MultiTouch
 		/// </summary>
 		public void Cancel()
 		{
-			this.driver = null;
+            this.TouchActionPerformer = null;
 			steps.Clear ();
 		}
 
@@ -247,7 +248,7 @@ namespace OpenQA.Selenium.Appium.MultiTouch
 		/// </summary>
 		public void Perform()
 		{
-			this.driver.PerformTouchAction (this);
+            this.TouchActionPerformer.PerformTouchAction(this);
 		}
 
 	}

--- a/appium-dotnet-driver/Appium/iOS/IOSDriver.cs
+++ b/appium-dotnet-driver/Appium/iOS/IOSDriver.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace OpenQA.Selenium.Appium.iOS
 {
-    public class IOSDriver : AppiumDriver, IFindByIosUIAutomation, IIOSDeviceActionShortcuts
+    public class IOSDriver<W> : AppiumDriver<W>, IFindByIosUIAutomation<W>, IIOSDeviceActionShortcuts where W : IWebElement 
     {
         private static readonly string Platform = MobilePlatform.IOS;
          /// <summary>
@@ -54,36 +54,15 @@ namespace OpenQA.Selenium.Appium.iOS
         }
 
         #region IFindByIosUIAutomation Members
-        /// <summary>
-        /// Finds the first element in the page that matches the Ios UIAutomation selector supplied
-        /// </summary>
-        /// <param name="selector">Selector for the element.</param>
-        /// <returns>IWebElement object so that you can interact that object</returns>
-        /// <example>
-        /// <code>
-        /// IWebDriver driver = new RemoteWebDriver(DesiredCapabilities.Firefox());
-        /// IWebElement elem = driver.FindElementByIosUIAutomation('elements()'))
-        /// </code>
-        /// </example>
-        public IWebElement FindElementByIosUIAutomation(string selector)
+        public W FindElementByIosUIAutomation(string selector)
         {
-            return this.FindElement("-ios uiautomation", selector);
+            return (W) this.FindElement("-ios uiautomation", selector);
         }
 
-        /// <summary>
-        /// Finds a list of elements that match the Ios UIAutomation selector supplied
-        /// </summary>
-        /// <param name="selector">Selector for the elements.</param>
-        /// <returns>ReadOnlyCollection of IWebElement object so that you can interact with those objects</returns>
-        /// <example>
-        /// <code>
-        /// IWebDriver driver = new RemoteWebDriver(DesiredCapabilities.Firefox());
-        /// ReadOnlyCollection<![CDATA[<IWebElement>]]> elem = driver.FindElementsByIosUIAutomation(elements())
-        /// </code>
-        /// </example>
-        public ReadOnlyCollection<IWebElement> FindElementsByIosUIAutomation(string selector)
+        public ReadOnlyCollection<W> FindElementsByIosUIAutomation(string selector)
         {
-            return this.FindElements("-ios uiautomation", selector);
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<W>(this.FindElements("-ios uiautomation", selector));
         }
         #endregion IFindByIosUIAutomation Members
 

--- a/appium-dotnet-driver/Appium/iOS/IOSElement.cs
+++ b/appium-dotnet-driver/Appium/iOS/IOSElement.cs
@@ -1,4 +1,5 @@
 ﻿using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -7,38 +8,30 @@ using System.Text;
 
 namespace OpenQA.Selenium.Appium.iOS
 {
-    public class IOSElement : AppiumWebElement, IFindByIosUIAutomation
+    public class IOSElement : AppiumWebElement, IFindByIosUIAutomation<AppiumWebElement>
     {
         /// <summary>
         /// Initializes a new instance of the IOSElement class.
         /// </summary>
         /// <param name="parent">Driver in use.</param>
         /// <param name="id">ID of the element.</param>
-        public IOSElement(AppiumDriver parent, string id)
+        public IOSElement(RemoteWebDriver parent, string id)
             : base(parent, id)
         {
         }
 
 
         #region IFindByIosUIAutomation Members
-        /// <summary>
-        /// Finds the first of elements that match the Ios UIAutomation selector supplied
-        /// </summary>
-        /// <param name="selector">an Ios UIAutomation selector</param>
-        /// <returns>IWebElement object so that you can interact that object</returns>
-        public IWebElement FindElementByIosUIAutomation(string selector)
+
+        public AppiumWebElement FindElementByIosUIAutomation(string selector)
         {
-            return this.FindElement("-ios uiautomation", selector);
+            return (AppiumWebElement) this.FindElement("-ios uiautomation", selector);
         }
 
-        /// <summary>
-        /// Finds a list of elements that match the Ios UIAutomation selector supplied
-        /// </summary>
-        /// <param name="selector">an Ios UIAutomation selector</param>
-        /// <returns>IWebElement object so that you can interact that object</returns>
-        public ReadOnlyCollection<IWebElement> FindElementsByIosUIAutomation(string selector)
+        public ReadOnlyCollection<AppiumWebElement> FindElementsByIosUIAutomation(string selector)
         {
-            return this.FindElements("-ios uiautomation", selector);
+            return CollectionConverterUnility.
+                            ConvertToExtendedWebElementCollection<AppiumWebElement>(this.FindElements("-ios uiautomation", selector));
         }
         #endregion IFindByIosUIAutomation Members
     }

--- a/appium-dotnet-driver/appium-dotnet-driver.csproj
+++ b/appium-dotnet-driver/appium-dotnet-driver.csproj
@@ -55,6 +55,15 @@
     <Compile Include="Appium\Enums\MobileBrowserType.cs" />
     <Compile Include="Appium\Enums\MobileCapabilityType.cs" />
     <Compile Include="Appium\Android\Enums\ConnectionType.cs" />
+    <Compile Include="Appium\Interfaces\Generic\SearchContext\IGenericFindsByClassName.cs" />
+    <Compile Include="Appium\Interfaces\Generic\SearchContext\IGenericFindsByCssSelector.cs" />
+    <Compile Include="Appium\Interfaces\Generic\SearchContext\IGenericFindsById.cs" />
+    <Compile Include="Appium\Interfaces\Generic\SearchContext\IGenericFindsByLinkText.cs" />
+    <Compile Include="Appium\Interfaces\Generic\SearchContext\IGenericFindsByName.cs" />
+    <Compile Include="Appium\Interfaces\Generic\SearchContext\IGenericFindsByPartialLinkText.cs" />
+    <Compile Include="Appium\Interfaces\Generic\SearchContext\IGenericFindsByTagName.cs" />
+    <Compile Include="Appium\Interfaces\Generic\SearchContext\IGenericFindsByXPath.cs" />
+    <Compile Include="Appium\Interfaces\Generic\SearchContext\IGenericSearchContext.cs" />
     <Compile Include="Appium\Interfaces\IContextAware.cs" />
     <Compile Include="Appium\Interfaces\IDeviceActionShortcuts.cs" />
     <Compile Include="Appium\Interfaces\IInteractsWithApps.cs" />
@@ -65,6 +74,7 @@
     <Compile Include="Appium\iOS\Interfaces\IIOSDeviceActionShortcuts.cs" />
     <Compile Include="Appium\iOS\IOSDriver.cs" />
     <Compile Include="Appium\iOS\IOSElement.cs" />
+    <Compile Include="Appium\CollectionConverterUnility.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Appium\AppiumDriver.cs" />
     <Compile Include="Appium\AppiumDriverCommand.cs" />

--- a/samples/AndroidComplexTest.cs
+++ b/samples/AndroidComplexTest.cs
@@ -19,7 +19,7 @@ namespace Appium.Samples
 	[TestFixture ()]
 	public class AndroidComplexTest
 	{
-		private AppiumDriver driver;
+		private AndroidDriver<AppiumWebElement> driver;
 		private bool allPassed = true;
 
 		[SetUp]
@@ -34,7 +34,7 @@ namespace Appium.Samples
 				capabilities.SetCapability("tags", new string[]{"sample"});
 			}
 			Uri serverUri = Env.isSauce () ? AppiumServers.sauceURI : AppiumServers.localURI;
-			driver = new AndroidDriver(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
+            driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
 			driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
 		}
 
@@ -52,31 +52,31 @@ namespace Appium.Samples
 			driver.FindElementByXPath ("//android.widget.TextView[@text='Animation']");
 			Assert.AreEqual( driver.FindElementByXPath ("//android.widget.TextView").Text,
 				"API Demos");
-			IList<IWebElement> els = driver.FindElementsByXPath ("//android.widget.TextView[contains(@text, 'Animat')]");
-			els = Filters.FilterDisplayed (els);
+			IList<AppiumWebElement> els = driver.FindElementsByXPath ("//android.widget.TextView[contains(@text, 'Animat')]");
+            var elsres = Filters.FilterDisplayed<AppiumWebElement>(els);
 			if (!Env.isSauce ()) {
-				Assert.AreEqual (els [0].Text, "Animation");
+				Assert.AreEqual (elsres [0].Text, "Animation");
 			}
 			driver.FindElementByName ("App").Click();
 			Thread.Sleep (3000);
-			els = ((AndroidDriver) driver).FindElementsByAndroidUIAutomator ("new UiSelector().clickable(true)");
+            els = driver.FindElementsByAndroidUIAutomator("new UiSelector().clickable(true)");
 			Assert.GreaterOrEqual (els.Count, 10);
 			Assert.IsNotNull (
 				driver.FindElementByXPath("//android.widget.TextView[@text='Action Bar']"));
 			els = driver.FindElementsByXPath ("//android.widget.TextView");
-			els = Filters.FilterDisplayed (els);
-			Assert.AreEqual (els[0].Text, "API Demos");
+            elsres = Filters.FilterDisplayed<AppiumWebElement>(els);
+            Assert.AreEqual(elsres[0].Text, "API Demos");
 			driver.Navigate ().Back ();
 		}
 
 		[Test]
 		public void StartActivityInThisAppTestCase()
 		{
-            ((AndroidDriver) driver).StartActivity("io.appium.android.apis", ".ApiDemos");
+            driver.StartActivity("io.appium.android.apis", ".ApiDemos");
 
 			_AssertActivityNameContains("Demos");
 
-            ((AndroidDriver) driver).StartActivity("io.appium.android.apis", ".accessibility.AccessibilityNodeProviderActivity");
+            driver.StartActivity("io.appium.android.apis", ".accessibility.AccessibilityNodeProviderActivity");
 
 			_AssertActivityNameContains("Node");
 		}
@@ -84,11 +84,11 @@ namespace Appium.Samples
 		[Test]
 		public void StartActivityInNewAppTestCase()
 		{
-            ((AndroidDriver) driver).StartActivity("io.appium.android.apis", ".ApiDemos");
+            driver.StartActivity("io.appium.android.apis", ".ApiDemos");
 
 			_AssertActivityNameContains("Demos");
 
-            ((AndroidDriver) driver).StartActivity("com.android.contacts", ".ContactsListActivity");
+            driver.StartActivity("com.android.contacts", ".ContactsListActivity");
 
 			_AssertActivityNameContains("Contact");
 		}
@@ -97,7 +97,7 @@ namespace Appium.Samples
 		{
 			Contract.Requires(!String.IsNullOrWhiteSpace(activityName));
 
-            String activity = ((AndroidDriver) driver).CurrentActivity;
+            String activity = driver.CurrentActivity;
 			Debug.WriteLine (activity);
 
 			Assert.IsNotNullOrEmpty(activity);
@@ -108,7 +108,7 @@ namespace Appium.Samples
 		public void ScrollTestCase ()
 		{
 			driver.FindElementByXPath (".//android.widget.TextView[@text='Animation']");
-			IList<IWebElement> els = driver.FindElementsByXPath (".//android.widget.TextView");
+			IList<AppiumWebElement> els = driver.FindElementsByXPath (".//android.widget.TextView");
 			var loc1 = els [7].Location;
 			var loc2 = els [3].Location;
 			var swipe = Actions.Swipe (driver, loc1.X, loc1.Y, loc2.X, loc2.Y, 800);
@@ -216,7 +216,7 @@ namespace Appium.Samples
         [Test()]
         public void HideKeyBoardTestCase()
         {
-            ((AndroidDriver)driver).StartActivity("io.appium.android.apis", ".app.CustomTitle");
+            driver.StartActivity("io.appium.android.apis", ".app.CustomTitle");
             driver.FindElement(By.Id("io.appium.android.apis:id/left_text_edit")).Clear();
             driver.HideKeyboard();
         }

--- a/samples/AndroidConnectionTest.cs
+++ b/samples/AndroidConnectionTest.cs
@@ -14,7 +14,7 @@ namespace Appium.Samples
     [TestFixture()]
     class AndroidConnectionTest
     {
-        private AppiumDriver driver;
+        private AppiumDriver<IWebElement> driver;
         private bool allPassed = true;
 
         [TestFixtureSetUp]
@@ -31,7 +31,7 @@ namespace Appium.Samples
                 capabilities.SetCapability("tags", new string[] { "sample" });
             }
             Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new AndroidDriver(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
             driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
         }
 
@@ -58,11 +58,11 @@ namespace Appium.Samples
         [Test]
         public void ConnectionTest()
         {
-            ((AndroidDriver)driver).ConnectionType = ConnectionType.AirplaneMode;
-            Assert.AreEqual(ConnectionType.AirplaneMode, ((AndroidDriver)driver).ConnectionType);
+            ((AndroidDriver<IWebElement>)driver).ConnectionType = ConnectionType.AirplaneMode;
+            Assert.AreEqual(ConnectionType.AirplaneMode, ((AndroidDriver<IWebElement>)driver).ConnectionType);
 
-            ((AndroidDriver)driver).ConnectionType = ConnectionType.WifiOnly;
-            Assert.AreEqual(ConnectionType.WifiOnly, ((AndroidDriver)driver).ConnectionType);
+            ((AndroidDriver<IWebElement>)driver).ConnectionType = ConnectionType.WifiOnly;
+            Assert.AreEqual(ConnectionType.WifiOnly, ((AndroidDriver<IWebElement>)driver).ConnectionType);
         }
     }
 }

--- a/samples/AndroidLocalServerTest.cs
+++ b/samples/AndroidLocalServerTest.cs
@@ -14,7 +14,7 @@ namespace Appium.Samples
 	[TestFixture ()]
 	public class AndroidLocalServerTest
 	{
-		private AppiumDriver driver;
+		private AppiumDriver<IWebElement> driver;
 		private bool allPassed = true;
 		LocalServer server = new LocalServer (3001);
 
@@ -31,7 +31,7 @@ namespace Appium.Samples
 				capabilities.SetCapability("tags", new string[]{"sample"});
 			}
 			Uri serverUri = Env.isSauce () ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new AndroidDriver(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
+            driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
 			driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
 		}
 

--- a/samples/AndroidOrientationTest.cs
+++ b/samples/AndroidOrientationTest.cs
@@ -30,7 +30,7 @@ namespace Appium.Samples
                 capabilities.SetCapability("tags", new string[] { "sample" });
             }
             Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new AndroidDriver(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
             driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
         }
 

--- a/samples/AndroidSimpleTest.cs
+++ b/samples/AndroidSimpleTest.cs
@@ -14,7 +14,7 @@ namespace Appium.Samples
 	[TestFixture ()]
 	public class AndroidSimpleTest
 	{
-		private AppiumDriver driver;
+		private AndroidDriver<AndroidElement> driver;
 		private bool allPassed = true;
 
 		[TestFixtureSetUp]
@@ -29,7 +29,7 @@ namespace Appium.Samples
 				capabilities.SetCapability("tags", new string[]{"sample"});
 			}
 			Uri serverUri = Env.isSauce () ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new AndroidDriver(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
+            driver = new AndroidDriver<AndroidElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
 			driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
 		}
 
@@ -54,13 +54,24 @@ namespace Appium.Samples
 		[Test ()]
 		public void FindElementTestCase ()
 		{
-			driver.FindElementByAccessibilityId ("Graphics").Click ();
+            By byAccessibilityId = new ByAccessibilityId("Graphics");
+            Assert.AreNotEqual(driver.FindElement(byAccessibilityId).Text, null);
+            Assert.GreaterOrEqual(driver.FindElements(byAccessibilityId).Count, 1);
+			
+            driver.FindElementByAccessibilityId ("Graphics").Click ();
 			Assert.IsNotNull (driver.FindElementByAccessibilityId ("Arcs"));
 			driver.Navigate ().Back ();
-			Assert.IsNotNull (driver.FindElementByName ("App"));
-			var els = ((AndroidDriver) driver).FindElementsByAndroidUIAutomator ("new UiSelector().clickable(true)");
-            Assert.GreaterOrEqual(els.Count, 12);
-            els = ((AndroidDriver)driver).FindElementsByAndroidUIAutomator("new UiSelector().enabled(true)");
+
+            Assert.IsNotNull(driver.FindElementByName("App"));
+            
+            Assert.IsNotNull(driver.FindElement(new ByAndroidUIAutomator("new UiSelector().clickable(true)")).Text);
+			var els = driver.FindElementsByAndroidUIAutomator ("new UiSelector().clickable(true)");
+            Assert.GreaterOrEqual(els.Count, 12); 
+
+            var els2 = driver.FindElements(new ByAndroidUIAutomator("new UiSelector().enabled(true)"));
+            Assert.GreaterOrEqual(els2.Count, 20);
+
+            els = driver.FindElementsByAndroidUIAutomator("new UiSelector().enabled(true)");
 			Assert.GreaterOrEqual (els.Count, 20);
 			Assert.IsNotNull (driver.FindElementByXPath ("//android.widget.TextView[@text='API Demos']"));
 		}

--- a/samples/AndroidWebviewTest.cs
+++ b/samples/AndroidWebviewTest.cs
@@ -8,13 +8,14 @@ using OpenQA.Selenium;
 using System.Threading;
 using System.Drawing;
 using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.Interfaces;
 
 namespace Appium.Samples
 {
 	[TestFixture ()]
 	public class AndroidWebviewTest
 	{
-		private AppiumDriver driver;
+		private IWebDriver driver;
 		private bool allPassed = true;
 
 		[TestFixtureSetUp]
@@ -29,7 +30,7 @@ namespace Appium.Samples
 				capabilities.SetCapability("tags", new string[]{"sample"});
 			}
 			Uri serverUri = Env.isSauce () ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new AndroidDriver(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
+            driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
 			driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
 		}
 
@@ -54,11 +55,11 @@ namespace Appium.Samples
 		[Test ()]
 		public void FindElementTestCase ()
 		{
-			driver.FindElementByName ("buttonStartWebviewCD").Click ();
+			driver.FindElement(By.Name("buttonStartWebviewCD")).Click ();
 			Thread.Sleep (5000);
 			if (!Env.isSauce ()) {
 				// Contexts don't work in android 4.3.3
-				var contexts = driver.Contexts;
+				var contexts = ((IContextAware) driver).Contexts;
 				string webviewContext = null;
 				for (int i = 0; i < contexts.Count; i++) {
 					Console.WriteLine (contexts [i]);
@@ -67,8 +68,8 @@ namespace Appium.Samples
 					}
 				}
 				Assert.IsNotNull (webviewContext);
-				driver.Context = webviewContext;
-				var el = driver.FindElementById ("name_input");
+                ((IContextAware) driver).Context = webviewContext;
+				var el = driver.FindElement(By.Id ("name_input"));
                 el.Click();
 				el.Clear ();
 				el.SendKeys ("Appium User");

--- a/samples/IosActionsTest.cs
+++ b/samples/IosActionsTest.cs
@@ -16,7 +16,7 @@ namespace Appium.Samples
 	[TestFixture ()]
 	public class IosActionsTest
 	{
-		private AppiumDriver driver;
+		private AppiumDriver<IWebElement> driver;
 		private bool allPassed = true;
 
 		[SetUp]
@@ -29,7 +29,7 @@ namespace Appium.Samples
 				capabilities.SetCapability("tags", new string[]{"sample"});
 			}
 			Uri serverUri = Env.isSauce () ? AppiumServers.sauceURI : AppiumServers.localURI;
-			driver = new IOSDriver(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
+			driver = new IOSDriver<IWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
 			driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
 		}
 

--- a/samples/IosComplexTest.cs
+++ b/samples/IosComplexTest.cs
@@ -18,7 +18,7 @@ namespace Appium.Samples
 	[TestFixture ()]
 	public class IosComplexTest
 	{
-		private AppiumDriver driver;
+		private AppiumDriver<IWebElement> driver;
 		private bool allPassed = true;
 
 		[SetUp]
@@ -31,7 +31,7 @@ namespace Appium.Samples
 				capabilities.SetCapability("tags", new string[]{"sample"});
 			}
 			Uri serverUri = Env.isSauce () ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new IOSDriver(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
+            driver = new IOSDriver<IWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
 			driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
 		}
 
@@ -198,9 +198,9 @@ namespace Appium.Samples
             e.Click();
             driver.HideKeyboard();
             e.Click();
-            ((IOSDriver) driver).HideKeyboard("Done");
+            ((IOSDriver<IWebElement>) driver).HideKeyboard("Done");
             e.Click();
-            ((IOSDriver)driver).HideKeyboard("Done", HideKeyboardStrategy.Tap_outside);
+            ((IOSDriver<IWebElement>) driver).HideKeyboard("Done", HideKeyboardStrategy.Tap_outside);
         }
 
 	}

--- a/samples/IosLocalServerTest.cs
+++ b/samples/IosLocalServerTest.cs
@@ -16,7 +16,7 @@ namespace Appium.Samples
 	[TestFixture ()]
 	public class IosLocalServerTest
 	{
-		private AppiumDriver driver;
+		private AppiumDriver<IWebElement> driver;
 		private bool allPassed = true;
 		LocalServer server = new LocalServer (3000);
 
@@ -31,7 +31,7 @@ namespace Appium.Samples
 				capabilities.SetCapability("tags", new string[]{"sample"});
 			}
 			Uri serverUri = Env.isSauce () ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new IOSDriver(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
+            driver = new IOSDriver<IWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
 			driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
 		}
 

--- a/samples/IosOrientationTest.cs
+++ b/samples/IosOrientationTest.cs
@@ -26,7 +26,7 @@ namespace Appium.Samples
 				capabilities.SetCapability("tags", new string[]{"sample"});
 			}
 			Uri serverUri = Env.isSauce () ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new IOSDriver(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
+            driver = new IOSDriver<IWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
 			driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
 		}
 

--- a/samples/IosSimpleTest.cs
+++ b/samples/IosSimpleTest.cs
@@ -14,7 +14,7 @@ namespace Appium.Samples
 	[TestFixture ()]
 	public class IosSimpleTest
 	{
-		private AppiumDriver driver;
+		private IOSDriver<IOSElement> driver;
 		private bool allPassed = true;
 
 		private Random rnd = new Random();
@@ -29,7 +29,7 @@ namespace Appium.Samples
 				capabilities.SetCapability("tags", new string[]{"sample"});
 			}
 			Uri serverUri = Env.isSauce () ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new IOSDriver(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
+            driver = new IOSDriver<IOSElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
 			driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
 		}
 
@@ -74,7 +74,8 @@ namespace Appium.Samples
 			// compute and check the sum
 			driver.FindElementByAccessibilityId ("ComputeSumButton").Click ();
 			Thread.Sleep (1000);
-			IWebElement sumEl = ((IOSDriver) driver).FindElementByIosUIAutomation (".elements().withName(\"Answer\")");
+
+			IWebElement sumEl = driver.FindElementByIosUIAutomation (".elements().withName(\"Answer\")");
 			int sumOut = Convert.ToInt32 (sumEl.Text);
 			Assert.AreEqual (sumIn, sumOut);
 		}

--- a/samples/IosWebviewTest.cs
+++ b/samples/IosWebviewTest.cs
@@ -16,7 +16,7 @@ namespace Appium.Samples
 	[TestFixture ()]
 	public class IosWebviewTest
 	{
-		private AppiumDriver driver;
+		private AppiumDriver<IWebElement> driver;
 		private bool allPassed = true;
 
 		[TestFixtureSetUp]
@@ -29,7 +29,7 @@ namespace Appium.Samples
 				capabilities.SetCapability("tags", new string[]{"sample"});
 			}
 			Uri serverUri = Env.isSauce () ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new IOSDriver(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
+            driver = new IOSDriver<IWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
 			driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
 		}
 

--- a/samples/helpers/Actions.cs
+++ b/samples/helpers/Actions.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.MultiTouch;
 using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
 
 namespace Appium.Samples.Helpers
 {
 	public class Actions
 	{
-		public static ITouchAction Swipe(AppiumDriver driver, int startX, int startY, int endX, int endY, 
+		public static ITouchAction Swipe(IPerformsTouchActions driver, int startX, int startY, int endX, int endY, 
 				int duration) {
 			ITouchAction touchAction = new TouchAction(driver) 
 				.Press (startX, startY)

--- a/samples/helpers/Filters.cs
+++ b/samples/helpers/Filters.cs
@@ -5,43 +5,47 @@ using System.Collections;
 
 namespace Appium.Samples.Helpers
 {
-	public class Filters
-	{
-		public static IWebElement FirstWithName(IList<IWebElement> els, string name)
-		{
-			for (int i = 0; i < els.Count; i++) 
-			{
-				if (els [i].GetAttribute ("name") == name) {
-					return els[i];
-				}
-			}
-			return null;
-		}
+    public class Filters
+    {
+        public static IWebElement FirstWithName<W>(IList<W> els, string name) where W : IWebElement
+        {
+            for (int i = 0; i < els.Count; i++)
+            {
+                if (els[i].GetAttribute("name") == name)
+                {
+                    return (W)els[i];
+                }
+            }
+            return null;
+        }
 
-		public static IList<IWebElement> FilterWithName(IList<IWebElement> els, string name)
-		{
-			var res = new List<IWebElement> ();
-			for (int i = 0; i < els.Count; i++) 
-			{
-				if (els [i].GetAttribute ("name") == name) {
-					res.Add(els [i]);
-				}
-			}
-			return res;
-		}
+        public static IList<IWebElement> FilterWithName<W>(IList<W> els, string name) where W : IWebElement
+        {
+            var res = new List<IWebElement>();
+            for (int i = 0; i < els.Count; i++)
+            {
+                if (els[i].GetAttribute("name") == name)
+                {
+                    res.Add(els[i]);
+                }
+            }
+            return res;
 
-		public static IList<IWebElement> FilterDisplayed(IList<IWebElement> els)
-		{
-			var res = new List<IWebElement> ();
-			for (int i = 0; i < els.Count; i++) 
-			{
-				IWebElement el = els [i];
-				if (els [i].Displayed ) {
-					res.Add(els [i]);
-				}
-			}
-			return res;
-		}
+        }
 
-	}
+        public static IList<IWebElement> FilterDisplayed<W>(IList<W> els) where W : IWebElement
+        {
+            var res = new List<IWebElement>();
+            for (int i = 0; i < els.Count; i++)
+            {
+                IWebElement el = els[i];
+                if (els[i].Displayed)
+                {
+                    res.Add(els[i]);
+                }
+            }
+            return res;
+        }
+
+    }
 }

--- a/test/specs/MJsonMethodTest.cs
+++ b/test/specs/MJsonMethodTest.cs
@@ -8,273 +8,269 @@ using OpenQA.Selenium.Appium.Android;
 
 namespace OpenQA.Selenium.Appium.Test.Specs
 {
-	[TestFixture ()]
-	public class MJsonMethodTest
-	{	
-		public FakeAppium server;
+    [TestFixture()]
+    public class MJsonMethodTest
+    {
+        public FakeAppium server;
         public readonly Uri defaultUri = new Uri("http://127.0.0.1:4733/wd/hub");
         public readonly DesiredCapabilities capabilities = new DesiredCapabilities();
 
-		[TestFixtureSetUp]
-		public void RunBeforeAll(){
-			server = new FakeAppium (4733);			 
-			server.Start ();
-			server.respondToInit ();
-			server.clear ();	
-		}
+        [TestFixtureSetUp]
+        public void RunBeforeAll()
+        {
+            server = new FakeAppium(4733);
+            server.Start();
+            server.respondToInit();
+            server.clear();
+        }
 
-		[TestFixtureTearDown]
-		public void RunAfterAll(){
-			server.Stop ();
-		}
-			
-		[TearDown]
-		public void RunAfterEach()
-		{
-			server.clear ();
-		}
+        [TestFixtureTearDown]
+        public void RunAfterAll()
+        {
+            server.Stop();
+        }
 
-		[Test]
-		public void ShakeDeviceTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/device/shake", null);
-			driver.ShakeDevice ();
-		}
+        [TearDown]
+        public void RunAfterEach()
+        {
+            server.clear();
+        }
 
-		[Test]
-		public void LockDeviceTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/device/lock", null);
-			driver.LockDevice (3);
-		}
+        [Test]
+        public void ShakeDeviceTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/device/shake", null);
+            driver.ShakeDevice();
+        }
+
+        [Test]
+        public void LockDeviceTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/device/lock", null);
+            driver.LockDevice(3);
+        }
 
 
-		[Test]
-		public void SetContextTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/context", null);
-			driver.Context = "1234";
-		}
+        [Test]
+        public void SetContextTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/context", null);
+            driver.Context = "1234";
+        }
 
-		[Test]
-		public void GetContextTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("GET", "/context", "1234");
-			Assert.AreEqual( driver.Context, "1234");
-		}
+        [Test]
+        public void GetContextTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("GET", "/context", "1234");
+            Assert.AreEqual(driver.Context, "1234");
+        }
 
-		[Test]
-		public void GetContextsTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("GET", "/contexts", new string[] {"ab", "cde", "123"});
-			Assert.AreEqual( driver.Contexts, new string[] {"ab", "cde", "123"});
-		}
+        [Test]
+        public void GetContextsTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("GET", "/contexts", new string[] { "ab", "cde", "123" });
+            Assert.AreEqual(driver.Contexts, new string[] { "ab", "cde", "123" });
+        }
 
-		[Test]
-		public void KeyEventTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/device/keyevent", null);
-			driver.KeyEvent(5);
-		}
+        [Test]
+        public void KeyEventTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/device/keyevent", null);
+            driver.KeyEvent(5);
+        }
 
-		[Test]
-		public void RotateTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/device/rotate", null);
-			Dictionary<string, int> parameters = new Dictionary<string, int> {{"x", 114}, 
-				{"y", 198}, {"duration", 5}, {"radius", 3}, {"rotation", 220}, {"touchCount", 2}};
-			driver.Rotate (parameters);
-		}
+        [Test]
+        public void RotateTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/device/rotate", null);
+            Dictionary<string, int> parameters = new Dictionary<string, int> {{"x", 114},  				{"y", 198}, {"duration", 5}, {"radius", 3}, {"rotation", 220}, {"touchCount", 2}};
+            driver.Rotate(parameters);
+        }
 
-		[Test]
-		public void ElementRotateTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			AppiumWebElement element = (AppiumWebElement) driver.FindElementByIosUIAutomation (".elements()");
-			server.clear ();
-			server.respondTo ("POST", "/appium/device/rotate", null);
-			Dictionary<string, int> parameters = new Dictionary<string, int> {{"x", 114}, 
-				{"y", 198}, {"duration", 5}, {"radius", 3}, {"rotation", 220}, {"touchCount", 2}};
-			element.Rotate (parameters);
-		}
+        [Test]
+        public void ElementRotateTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            AppiumWebElement element = (AppiumWebElement)driver.FindElementByIosUIAutomation(".elements()");
+            server.clear();
+            server.respondTo("POST", "/appium/device/rotate", null);
+            Dictionary<string, int> parameters = new Dictionary<string, int> {{"x", 114},  				{"y", 198}, {"duration", 5}, {"radius", 3}, {"rotation", 220}, {"touchCount", 2}};
+            element.Rotate(parameters);
+        }
 
-		[Test]
-		public void GetCurrentActivityTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("GET", "/appium/device/current_activity", ".activities.PeopleActivity");
-			string activity = driver.CurrentActivity;
-			Assert.AreEqual (activity, ".activities.PeopleActivity");
-		}
+        [Test]
+        public void GetCurrentActivityTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("GET", "/appium/device/current_activity", ".activities.PeopleActivity");
+            string activity = driver.CurrentActivity;
+            Assert.AreEqual(activity, ".activities.PeopleActivity");
+        }
 
-		[Test]
-		public void InstallAppTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/device/install_app", null);
-			driver.InstallApp ("/home/me/apps/superApp");
-		}
+        [Test]
+        public void InstallAppTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/device/install_app", null);
+            driver.InstallApp("/home/me/apps/superApp");
+        }
 
-		[Test]
-		public void RemoveAppTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/device/remove_app", null);
-			driver.RemoveApp ("rubbish");
-		}
+        [Test]
+        public void RemoveAppTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/device/remove_app", null);
+            driver.RemoveApp("rubbish");
+        }
 
-		[Test]
-		public void IsAppInstalledTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/device/app_installed", true);
-			driver.IsAppInstalled ("github");
-		}
+        [Test]
+        public void IsAppInstalledTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/device/app_installed", true);
+            driver.IsAppInstalled("github");
+        }
 
-		[Test]
-		public void PushFileTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/device/push_file", null);
-			driver.PushFile ("/pictures/me.jpg", "abde433qsawe3242");
-		}
+        [Test]
+        public void PushFileTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/device/push_file", null);
+            driver.PushFile("/pictures/me.jpg", "abde433qsawe3242");
+        }
 
-		[Test]
-		public void PullFileTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			var data = "wqewdsf232wewqqw443";
-			server.respondTo ("POST", "/appium/device/pull_file", data);
-			byte[] result = driver.PullFile ("/pictures/me.jpg");
-			Assert.AreEqual (result, Convert.FromBase64String(data));
-		}
+        [Test]
+        public void PullFileTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            var data = "wqewdsf232wewqqw443";
+            server.respondTo("POST", "/appium/device/pull_file", data);
+            byte[] result = driver.PullFile("/pictures/me.jpg");
+            Assert.AreEqual(result, Convert.FromBase64String(data));
+        }
 
-		[Test]
-		public void ToggleLocationServicesTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/device/toggle_location_services", null);
-			driver.ToggleLocationServices ();
-		}
+        [Test]
+        public void ToggleLocationServicesTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/device/toggle_location_services", null);
+            driver.ToggleLocationServices();
+        }
 
-		[Test]
-		public void LaunchAppTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/app/launch", null);
-			driver.LaunchApp ();
-		}
+        [Test]
+        public void LaunchAppTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/app/launch", null);
+            driver.LaunchApp();
+        }
 
-		[Test]
-		public void CloseAppTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/app/close", null);
-			driver.CloseApp ();
-		}
+        [Test]
+        public void CloseAppTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/app/close", null);
+            driver.CloseApp();
+        }
 
-		[Test]
-		public void ResetAppTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/app/reset", null);
-			driver.ResetApp ();
-		}
+        [Test]
+        public void ResetAppTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/app/reset", null);
+            driver.ResetApp();
+        }
 
-		[Test]
-		public void BackgroundAppTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/appium/app/background", null);
-			driver.BackgroundApp (5);
-		}
+        [Test]
+        public void BackgroundAppTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/appium/app/background", null);
+            driver.BackgroundApp(5);
+        }
 
-		[Test]
-		public void EndTestCoverageTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			var data = "21343n2312j3jw";
-			server.respondTo ("POST", "/appium/app/end_test_coverage", data);
-			var result = driver.EndTestCoverage ("android.intent.action.BOOT_COMPLETED", "/random/path");
-			Assert.AreEqual (result, data);
-		}
+        [Test]
+        public void EndTestCoverageTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            var data = "21343n2312j3jw";
+            server.respondTo("POST", "/appium/app/end_test_coverage", data);
+            var result = driver.EndTestCoverage("android.intent.action.BOOT_COMPLETED", "/random/path");
+            Assert.AreEqual(result, data);
+        }
 
-		[Test]
-		public void GetAppStringsTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			var data = "21343n2312j3jw";
-			server.respondTo ("POST", "/appium/app/strings", data);
-			var result = driver.GetAppStrings ();
-			Assert.AreEqual (result, data);
-		}
+        [Test]
+        public void GetAppStringsTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            var data = "21343n2312j3jw";
+            server.respondTo("POST", "/appium/app/strings", data);
+            var result = driver.GetAppStrings();
+            Assert.AreEqual(result, data);
+        }
 
-		[Test]
-		public void SetImmediateValueTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			AppiumWebElement element = (AppiumWebElement) driver.FindElementByIosUIAutomation (".elements()");
-			server.clear ();
-			server.respondTo ("POST", "/appium/element/5/value", null);
-			element.SetImmediateValue ("123");
-		}
+        [Test]
+        public void SetImmediateValueTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            AppiumWebElement element = (AppiumWebElement)driver.FindElementByIosUIAutomation(".elements()");
+            server.clear();
+            server.respondTo("POST", "/appium/element/5/value", null);
+            element.SetImmediateValue("123");
+        }
 
-		[Test]
-		public void HideKeyboardTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			{
-				server.clear ();
-				RequestProcessor re = server.respondTo ("POST", "/appium/device/hide_keyboard", null);
-				driver.HideKeyboard (key: "Done");
-				Assert.AreEqual (re.inputData, "{\"keyName\":\"Done\"}");
-			}
-			{
-				server.clear ();
-				RequestProcessor re = server.respondTo ("POST", "/appium/device/hide_keyboard", null);
-				driver.HideKeyboard ("pressKey", "Done");
-				Assert.AreEqual (re.inputData, "{\"strategy\":\"pressKey\",\"keyName\":\"Done\"}");
-			}
-			{
-				server.clear ();
-				RequestProcessor re = server.respondTo ("POST", "/appium/device/hide_keyboard", null);
-				driver.HideKeyboard ("tapOutside");
-				Assert.AreEqual (re.inputData, "{\"strategy\":\"tapOutside\"}");
-			}
-		}
+        [Test]
+        public void HideKeyboardTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            {
+                server.clear();
+                RequestProcessor re = server.respondTo("POST", "/appium/device/hide_keyboard", null);
+                driver.HideKeyboard(key: "Done");
+                Assert.AreEqual(re.inputData, "{\"keyName\":\"Done\"}");
+            }
+            {
+                server.clear();
+                RequestProcessor re = server.respondTo("POST", "/appium/device/hide_keyboard", null);
+                driver.HideKeyboard("pressKey", "Done");
+                Assert.AreEqual(re.inputData, "{\"strategy\":\"pressKey\",\"keyName\":\"Done\"}");
+            }
+            {
+                server.clear();
+                RequestProcessor re = server.respondTo("POST", "/appium/device/hide_keyboard", null);
+                driver.HideKeyboard("tapOutside");
+                Assert.AreEqual(re.inputData, "{\"strategy\":\"tapOutside\"}");
+            }
+        }
 
-		[Test]
-		public void SettingsTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			{
-				var data = "{\"setting\": true}";
-				Dictionary<String, Object> simpleDict = new Dictionary<string, object> ();
-				simpleDict.Add ("setting", true);
-				server.respondTo ("GET", "/appium/settings", data);
-				var result = driver.GetSettings ();
-				Assert.AreEqual (result, simpleDict);
-			}
-			{
-				RequestProcessor re = server.respondTo ("POST", "/appium/settings", null);
-				driver.IgnoreUnimportantViews (true);
-				Assert.AreEqual (re.inputData, "{\"settings\":{\"ignoreUnimportantViews\":true}}");
-			}
-		}
+        [Test]
+        public void SettingsTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            {
+                var data = "{\"setting\": true}";
+                Dictionary<String, Object> simpleDict = new Dictionary<string, object>();
+                simpleDict.Add("setting", true);
+                server.respondTo("GET", "/appium/settings", data);
+                var result = driver.GetSettings();
+                Assert.AreEqual(result, simpleDict);
+            }
+            {
+                RequestProcessor re = server.respondTo("POST", "/appium/settings", null);
+                driver.IgnoreUnimportantViews(true);
+                Assert.AreEqual(re.inputData, "{\"settings\":{\"ignoreUnimportantViews\":true}}");
+            }
+        }
 
-	}
+    }
 }
 

--- a/test/specs/SelectorTest.cs
+++ b/test/specs/SelectorTest.cs
@@ -8,278 +8,260 @@ using OpenQA.Selenium.Appium.Android;
 
 namespace OpenQA.Selenium.Appium.Test.Specs
 {
-	[TestFixture ()]
-	public class ByIosUIAutomationTest
-	{	
-		public FakeAppium server;
+    [TestFixture()]
+    public class ByIosUIAutomationTest
+    {
+        public FakeAppium server;
         public readonly Uri defaultUri = new Uri("http://127.0.0.1:4743/wd/hub");
         public readonly DesiredCapabilities capabilities = new DesiredCapabilities();
 
-		[TestFixtureSetUp]
-		public void RunBeforeAll(){
-			server = new FakeAppium (4743);			 
-			server.Start ();
-			server.respondToInit ();
-			server.clear ();
-		}
+        [TestFixtureSetUp]
+        public void RunBeforeAll()
+        {
+            server = new FakeAppium(4743);
+            server.Start();
+            server.respondToInit();
+            server.clear();
+        }
 
-		[TestFixtureTearDown]
-		public void RunAfterAll(){
-			server.Stop ();
-		}
-			
-		[TearDown]
-		public void RunAfterEach()
-		{
-			server.clear ();
-		}
+        [TestFixtureTearDown]
+        public void RunAfterAll()
+        {
+            server.Stop();
+        }
 
-		[Test]
-		public void FindElementByIosUIAutomationTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			IWebElement element = driver.FindElementByIosUIAutomation (".elements()");
-			server.clear ();
-			server.respondTo ("GET", "/element/5/attribute/id", "1234");
-			element.GetAttribute ("id");
-		}
-			
-		[Test]
-		public void FindElementsByIosUIAutomationTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			List<object> results = new List<object>();
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "4"}});
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "6"}});
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "8"}});
-			server.respondTo ("POST", "/elements", results);
-			ICollection<IWebElement> elements = driver.FindElementsByIosUIAutomation (".elements()");
-			Assert.AreEqual (elements.Count, 3); 
-		}
+        [TearDown]
+        public void RunAfterEach()
+        {
+            server.clear();
+        }
 
-		[Test]
-		public void ByIosUIAutomationTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			driver.FindElement(new ByIosUIAutomation(".elements()"));
-			(new ByIosUIAutomation(".elements()")).FindElement(driver);
-			server.clear ();
-			List<object> results = new List<object>();
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "4"}});
-			server.respondTo ("POST", "/elements", results);
-			driver.FindElements(new ByIosUIAutomation(".elements()"));
-			(new ByIosUIAutomation(".elements()")).FindElements(driver);
-		}
+        [Test]
+        public void FindElementByIosUIAutomationTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            IWebElement element = driver.FindElementByIosUIAutomation(".elements()");
+            server.clear();
+            server.respondTo("GET", "/element/5/attribute/id", "1234");
+            element.GetAttribute("id");
+        }
 
-		[Test]
-		public void FromElementTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			IOSElement element = (IOSElement) driver.FindElementByIosUIAutomation (".elements()");
-			server.clear ();
-			server.respondTo ("POST", "/element/5/element", new Dictionary<string, object>  {
-				{"ELEMENT", '6'}
-			});				
-			element.FindElementByIosUIAutomation (".elements()");
-			server.clear ();
-			List<object> results = new List<object>();
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "4"}});
-			server.respondTo ("POST", "/element/5/elements", results);
-			element.FindElementsByIosUIAutomation (".elements()");
-		}
+        [Test]
+        public void FindElementsByIosUIAutomationTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            List<object> results = new List<object>();
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "4" } });
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "6" } });
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "8" } });
+            server.respondTo("POST", "/elements", results);
+            ICollection<IWebElement> elements = driver.FindElementsByIosUIAutomation(".elements()");
+            Assert.AreEqual(elements.Count, 3);
+        }
 
-	}
+        [Test]
+        public void ByIosUIAutomationTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            driver.FindElement(new ByIosUIAutomation(".elements()"));
+            (new ByIosUIAutomation(".elements()")).FindElement(driver);
+            server.clear();
+            List<object> results = new List<object>();
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "4" } });
+            server.respondTo("POST", "/elements", results);
+            driver.FindElements(new ByIosUIAutomation(".elements()"));
+            (new ByIosUIAutomation(".elements()")).FindElements(driver);
+        }
 
-	[TestFixture ()]
-	public class ByAndroidUIAutomatorTest
-	{	
-		public FakeAppium server;
+        [Test]
+        public void FromElementTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            IOSElement element = (IOSElement)driver.FindElementByIosUIAutomation(".elements()");
+            server.clear();
+            server.respondTo("POST", "/element/5/element", new Dictionary<string, object>  { 				{"ELEMENT", '6'} 			});
+            element.FindElementByIosUIAutomation(".elements()");
+            server.clear();
+            List<object> results = new List<object>();
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "4" } });
+            server.respondTo("POST", "/element/5/elements", results);
+            element.FindElementsByIosUIAutomation(".elements()");
+        }
+
+    }
+
+    [TestFixture()]
+    public class ByAndroidUIAutomatorTest
+    {
+        public FakeAppium server;
         public readonly Uri defaultUri = new Uri("http://127.0.0.1:4744/wd/hub");
         public readonly DesiredCapabilities capabilities = new DesiredCapabilities();
 
-		[TestFixtureSetUp]
-		public void RunBeforeAll(){
-			server = new FakeAppium (4744);			 
-			server.Start ();
+        [TestFixtureSetUp]
+        public void RunBeforeAll()
+        {
+            server = new FakeAppium(4744);
+            server.Start();
             server.respondToInit();
-			server.clear ();
-		}
+            server.clear();
+        }
 
-		[TestFixtureTearDown]
-		public void RunAfterAll(){
-			server.Stop ();
-		}
+        [TestFixtureTearDown]
+        public void RunAfterAll()
+        {
+            server.Stop();
+        }
 
-		[TearDown]
-		public void RunAfterEach()
-		{
-			server.clear ();
-		}
+        [TearDown]
+        public void RunAfterEach()
+        {
+            server.clear();
+        }
 
-		[Test]
-		public void FindElementByAndroidUIAutomatorTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			IWebElement element = driver.FindElementByAndroidUIAutomator (".elements()");
-			server.clear ();
-			server.respondTo ("GET", "/element/5/attribute/id", "1234");
-			element.GetAttribute ("id");
-		}
+        [Test]
+        public void FindElementByAndroidUIAutomatorTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            IWebElement element = driver.FindElementByAndroidUIAutomator(".elements()");
+            server.clear();
+            server.respondTo("GET", "/element/5/attribute/id", "1234");
+            element.GetAttribute("id");
+        }
 
-		[Test]
-		public void FindElementsByAndroidUIAutomatorTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			List<object> results = new List<object>();
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "4"}});
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "6"}});
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "8"}});
-			server.respondTo ("POST", "/elements", results);
-			ICollection<IWebElement> elements = driver.FindElementsByAndroidUIAutomator (".elements()");
-			Assert.AreEqual (elements.Count, 3); 
-		}
+        [Test]
+        public void FindElementsByAndroidUIAutomatorTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            List<object> results = new List<object>();
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "4" } });
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "6" } });
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "8" } });
+            server.respondTo("POST", "/elements", results);
+            ICollection<IWebElement> elements = driver.FindElementsByAndroidUIAutomator(".elements()");
+            Assert.AreEqual(elements.Count, 3);
+        }
 
-		[Test]
-		public void ByAndroidUIAutomatorTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			driver.FindElement(new ByAndroidUIAutomator(".elements()"));
-			(new ByAndroidUIAutomator(".elements()")).FindElement(driver);
-			server.clear ();
-			List<object> results = new List<object>();
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "4"}});
-			server.respondTo ("POST", "/elements", results);
-			driver.FindElements(new ByAndroidUIAutomator(".elements()"));
-			(new ByAndroidUIAutomator(".elements()")).FindElements(driver);
-		}
+        [Test]
+        public void ByAndroidUIAutomatorTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            driver.FindElement(new ByAndroidUIAutomator(".elements()"));
+            (new ByAndroidUIAutomator(".elements()")).FindElement(driver);
+            server.clear();
+            List<object> results = new List<object>();
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "4" } });
+            server.respondTo("POST", "/elements", results);
+            driver.FindElements(new ByAndroidUIAutomator(".elements()"));
+            (new ByAndroidUIAutomator(".elements()")).FindElements(driver);
+        }
 
-		[Test]
-		public void FromElementTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			AndroidElement element = (AndroidElement) driver.FindElementByAndroidUIAutomator (".elements()");
-			server.clear ();
-			server.respondTo ("POST", "/element/5/element", new Dictionary<string, object>  {
-				{"ELEMENT", '6'}
-			});				
-			element.FindElementByAndroidUIAutomator (".elements()");
-			server.clear ();
-			List<object> results = new List<object>();
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "4"}});
-			server.respondTo ("POST", "/element/5/elements", results);
-			element.FindElementsByAndroidUIAutomator (".elements()");
-		}
+        [Test]
+        public void FromElementTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            AndroidElement element = (AndroidElement)driver.FindElementByAndroidUIAutomator(".elements()");
+            server.clear();
+            server.respondTo("POST", "/element/5/element", new Dictionary<string, object>  { 				{"ELEMENT", '6'} 			});
+            element.FindElementByAndroidUIAutomator(".elements()");
+            server.clear();
+            List<object> results = new List<object>();
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "4" } });
+            server.respondTo("POST", "/element/5/elements", results);
+            element.FindElementsByAndroidUIAutomator(".elements()");
+        }
 
-	}
-		
-	[TestFixture ()]
-	public class ByAccessibilityIdTest
-	{	
-		public FakeAppium server;
+    }
+
+    [TestFixture()]
+    public class ByAccessibilityIdTest
+    {
+        public FakeAppium server;
         public readonly Uri defaultUri = new Uri("http://127.0.0.1:4745/wd/hub");
         public readonly DesiredCapabilities capabilities = new DesiredCapabilities();
 
-		[TestFixtureSetUp]
-		public void RunBeforeAll(){
-			server = new FakeAppium (4745);			 
-			server.Start ();
-			server.respondToInit ();
-			server.clear ();
-		}
+        [TestFixtureSetUp]
+        public void RunBeforeAll()
+        {
+            server = new FakeAppium(4745);
+            server.Start();
+            server.respondToInit();
+            server.clear();
+        }
 
-		[TestFixtureTearDown]
-		public void RunAfterAll(){
-			server.Stop ();
-		}
+        [TestFixtureTearDown]
+        public void RunAfterAll()
+        {
+            server.Stop();
+        }
 
-		[TearDown]
-		public void RunAfterEach()
-		{
-			server.clear ();
-		}
+        [TearDown]
+        public void RunAfterEach()
+        {
+            server.clear();
+        }
 
-		[Test]
-		public void FindElementByAccessibilityIdTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			IWebElement element = driver.FindElementByAccessibilityId (".elements()");
-			server.clear ();
-			server.respondTo ("GET", "/element/5/attribute/id", "1234");
-			element.GetAttribute ("id");
-		}
+        [Test]
+        public void FindElementByAccessibilityIdTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            IWebElement element = driver.FindElementByAccessibilityId(".elements()");
+            server.clear();
+            server.respondTo("GET", "/element/5/attribute/id", "1234");
+            element.GetAttribute("id");
+        }
 
-		[Test]
-		public void FindElementsByAccessibilityIdTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			List<object> results = new List<object>();
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "4"}});
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "6"}});
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "8"}});
-			server.respondTo ("POST", "/elements", results);
-			ICollection<IWebElement> elements = driver.FindElementsByAccessibilityId (".elements()");
-			Assert.AreEqual (elements.Count, 3); 
-		}
+        [Test]
+        public void FindElementsByAccessibilityIdTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            List<object> results = new List<object>();
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "4" } });
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "6" } });
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "8" } });
+            server.respondTo("POST", "/elements", results);
+            ICollection<IWebElement> elements = driver.FindElementsByAccessibilityId(".elements()");
+            Assert.AreEqual(elements.Count, 3);
+        }
 
-		[Test]
-		public void ByAccessibilityIdTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			driver.FindElement(new ByAccessibilityId(".elements()"));
-			(new ByAccessibilityId(".elements()")).FindElement(driver);
-			server.clear ();
-			List<object> results = new List<object>();
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "4"}});
-			server.respondTo ("POST", "/elements", results);
-			driver.FindElements(new ByAccessibilityId(".elements()"));
-			(new ByAccessibilityId(".elements()")).FindElements(driver);
-		}
+        [Test]
+        public void ByAccessibilityIdTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            driver.FindElement(new ByAccessibilityId(".elements()"));
+            (new ByAccessibilityId(".elements()")).FindElement(driver);
+            server.clear();
+            List<object> results = new List<object>();
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "4" } });
+            server.respondTo("POST", "/elements", results);
+            driver.FindElements(new ByAccessibilityId(".elements()"));
+            (new ByAccessibilityId(".elements()")).FindElements(driver);
+        }
 
-		[Test]
-		public void FromElementTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			AppiumWebElement element = (AppiumWebElement) driver.FindElementByAccessibilityId (".elements()");
-			server.clear ();
-			server.respondTo ("POST", "/element/5/element", new Dictionary<string, object>  {
-				{"ELEMENT", '6'}
-			});				
-			element.FindElementByAccessibilityId (".elements()");
-			server.clear ();
-			List<object> results = new List<object>();
-			results.Add (new Dictionary<string, object> {{"ELEMENT", "4"}});
-			server.respondTo ("POST", "/element/5/elements", results);
-			element.FindElementsByAccessibilityId (".elements()");
-		}
+        [Test]
+        public void FromElementTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            AppiumWebElement element = (AppiumWebElement)driver.FindElementByAccessibilityId(".elements()");
+            server.clear();
+            server.respondTo("POST", "/element/5/element", new Dictionary<string, object>  { 				{"ELEMENT", '6'} 			});
+            element.FindElementByAccessibilityId(".elements()");
+            server.clear();
+            List<object> results = new List<object>();
+            results.Add(new Dictionary<string, object> { { "ELEMENT", "4" } });
+            server.respondTo("POST", "/element/5/elements", results);
+            element.FindElementsByAccessibilityId(".elements()");
+        }
 
 
-	}
+    }
 }
 

--- a/test/specs/SessionTest.cs
+++ b/test/specs/SessionTest.cs
@@ -6,89 +6,93 @@ using OpenQA.Selenium.Appium.Android;
 
 namespace OpenQA.Selenium.Appium.Test.Specs
 {
-	[TestFixture]
-	public class InitSessionTest
-	{	
-		public FakeAppium server;
+    [TestFixture]
+    public class InitSessionTest
+    {
+        public FakeAppium server;
         public readonly Uri defaultUri = new Uri("http://127.0.0.1:4733/wd/hub");
         public readonly DesiredCapabilities capabilities = new DesiredCapabilities();
 
-		[TestFixtureSetUp]
-		public void RunBeforeAll(){
-			server = new FakeAppium (4723);			 
-			server.Start ();
-		}
+        [TestFixtureSetUp]
+        public void RunBeforeAll()
+        {
+            server = new FakeAppium(4723);
+            server.Start();
+        }
 
-		[TestFixtureTearDown]
-		public void RunAfterAll(){
-			server.Stop ();
-		}
+        [TestFixtureTearDown]
+        public void RunAfterAll()
+        {
+            server.Stop();
+        }
 
-		[TearDown]
-		public void RunAfterEach()
-		{
-			server.clear ();
-		}
+        [TearDown]
+        public void RunAfterEach()
+        {
+            server.clear();
+        }
 
-		[Test]
-		public void InitSessionTestCase ()
-		{
-			server.respondToInit ();
-			DesiredCapabilities capabilities = new DesiredCapabilities();
-			new AndroidDriver (capabilities);
-		}
-	}
+        [Test]
+        public void InitSessionTestCase()
+        {
+            server.respondToInit();
+            DesiredCapabilities capabilities = new DesiredCapabilities();
+            new AndroidDriver<IWebElement>(capabilities);
+        }
+    }
 
-	[TestFixture]
-	public class EndSessionTest
-	{	
-		public FakeAppium server;
+    [TestFixture]
+    public class EndSessionTest
+    {
+        public FakeAppium server;
         public readonly Uri defaultUri = new Uri("http://127.0.0.1:4724/wd/hub");
         public readonly DesiredCapabilities capabilities = new DesiredCapabilities();
 
-		[TestFixtureSetUp]
-		public void RunBeforeAll(){
-			server = new FakeAppium (4724);			 
-			server.Start ();
-		}
+        [TestFixtureSetUp]
+        public void RunBeforeAll()
+        {
+            server = new FakeAppium(4724);
+            server.Start();
+        }
 
-		[TestFixtureTearDown]
-		public void RunAfterAll(){
-			server.Stop ();
-		}
-			
-		[SetUp]
-		public void RunBeforeEach()
-		{
-			server.respondToInit ();
-			DesiredCapabilities capabilities = new DesiredCapabilities();
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.clear ();
-		}
+        [TestFixtureTearDown]
+        public void RunAfterAll()
+        {
+            server.Stop();
+        }
+
+        [SetUp]
+        public void RunBeforeEach()
+        {
+            server.respondToInit();
+            DesiredCapabilities capabilities = new DesiredCapabilities();
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.clear();
+        }
 
 
-		[TearDown]
-		public void RunAfterEach()
-		{
-			server.clear ();
-		}
+        [TearDown]
+        public void RunAfterEach()
+        {
+            server.clear();
+        }
 
-		[Test]
-		public void CloseTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("DELETE", "/window", null);
-			driver.Close ();
-		}
-			
-		[Test]
-		public void QuitTestCase ()
-		{
-            AndroidDriver driver = new AndroidDriver(defaultUri, capabilities);
-			server.respondTo ("DELETE", "/", null);
-			driver.Quit ();
-		}
+        [Test]
+        public void CloseTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("DELETE", "/window", null);
+            driver.Close();
+        }
 
-	}
+        [Test]
+        public void QuitTestCase()
+        {
+            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
+            server.respondTo("DELETE", "/", null);
+            driver.Quit();
+        }
+
+    }
 }
 

--- a/test/specs/TouchTest.cs
+++ b/test/specs/TouchTest.cs
@@ -9,241 +9,241 @@ using OpenQA.Selenium.Appium.iOS;
 
 namespace OpenQA.Selenium.Appium.Test.Specs
 {
-	[TestFixture ()]
-	public class TouchTest
-	{	
-		public FakeAppium server;
+    [TestFixture()]
+    public class TouchTest
+    {
+        public FakeAppium server;
         public readonly Uri defaultUri = new Uri("http://127.0.0.1:4753/wd/hub");
         public readonly DesiredCapabilities capabilities = new DesiredCapabilities();
 
-		[TestFixtureSetUp]
-		public void RunBeforeAll(){
-			server = new FakeAppium (4753);			 
-			server.Start ();
-			server.respondToInit ();
-			server.clear ();	
-		}
+        [TestFixtureSetUp]
+        public void RunBeforeAll()
+        {
+            server = new FakeAppium(4753);
+            server.Start();
+            server.respondToInit();
+            server.clear();
+        }
 
-		[TestFixtureTearDown]
-		public void RunAfterAll(){
-			server.Stop ();
-		}
-			
-		[TearDown]
-		public void RunAfterEach()
-		{
-			server.clear ();
-		}
+        [TestFixtureTearDown]
+        public void RunAfterAll()
+        {
+            server.Stop();
+        }
 
-		private RequestProcessor setupTouchAction() {
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			return server.respondTo ("POST", "/touch/perform", null);
-		}
+        [TearDown]
+        public void RunAfterEach()
+        {
+            server.clear();
+        }
 
-		[Test]
-		public void LongPressTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			RequestProcessor re = setupTouchAction ();
-			IWebElement element = driver.FindElementByIosUIAutomation (".elements()");
+        private RequestProcessor setupTouchAction()
+        {
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            return server.respondTo("POST", "/touch/perform", null);
+        }
 
-			ITouchAction a;
+        [Test]
+        public void LongPressTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            RequestProcessor re = setupTouchAction();
+            IWebElement element = driver.FindElementByIosUIAutomation(".elements()");
 
-			a = new TouchAction (driver)
-				.LongPress (element, 50, 75);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"longpress\",\"options\":{\"element\":\"5\",\"x\":50,\"y\":75}}]}");
+            ITouchAction a;
 
-			a = new TouchAction (driver)
-				.LongPress (element, 0.5, 75);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"longpress\",\"options\":{\"element\":\"5\",\"x\":0.5,\"y\":75}}]}");
+            a = new TouchAction(driver)
+                .LongPress(element, 50, 75);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"longpress\",\"options\":{\"element\":\"5\",\"x\":50,\"y\":75}}]}");
 
-			a = new TouchAction (driver)
-				.LongPress (0.5, 75);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"longpress\",\"options\":{\"x\":0.5,\"y\":75}}]}");
+            a = new TouchAction(driver)
+                .LongPress(element, 0.5, 75);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"longpress\",\"options\":{\"element\":\"5\",\"x\":0.5,\"y\":75}}]}");
 
-			a = new TouchAction (driver)
-				.LongPress (element);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"longpress\",\"options\":{\"element\":\"5\"}}]}");
-		}
+            a = new TouchAction(driver)
+                .LongPress(0.5, 75);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"longpress\",\"options\":{\"x\":0.5,\"y\":75}}]}");
 
-		[Test]
-		public void MoveToTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			RequestProcessor re = setupTouchAction ();
-			IWebElement element = driver.FindElementByIosUIAutomation (".elements()");
+            a = new TouchAction(driver)
+                .LongPress(element);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"longpress\",\"options\":{\"element\":\"5\"}}]}");
+        }
 
-			ITouchAction a;
+        [Test]
+        public void MoveToTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            RequestProcessor re = setupTouchAction();
+            IWebElement element = driver.FindElementByIosUIAutomation(".elements()");
 
-			a = new TouchAction (driver)
-				.MoveTo (element, 50, 75);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"moveTo\",\"options\":{\"element\":\"5\",\"x\":50,\"y\":75}}]}");
+            ITouchAction a;
 
-			a = new TouchAction (driver)
-				.MoveTo (element, 0.5, 75);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"moveTo\",\"options\":{\"element\":\"5\",\"x\":0.5,\"y\":75}}]}");
+            a = new TouchAction(driver)
+                .MoveTo(element, 50, 75);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"moveTo\",\"options\":{\"element\":\"5\",\"x\":50,\"y\":75}}]}");
 
-			a = new TouchAction (driver)
-				.MoveTo (0.5, 75);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"moveTo\",\"options\":{\"x\":0.5,\"y\":75}}]}");
+            a = new TouchAction(driver)
+                .MoveTo(element, 0.5, 75);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"moveTo\",\"options\":{\"element\":\"5\",\"x\":0.5,\"y\":75}}]}");
 
-			a = new TouchAction (driver)
-				.MoveTo (element);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"moveTo\",\"options\":{\"element\":\"5\"}}]}");
-		}
+            a = new TouchAction(driver)
+                .MoveTo(0.5, 75);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"moveTo\",\"options\":{\"x\":0.5,\"y\":75}}]}");
 
-		[Test]
-		public void PressTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			RequestProcessor re = setupTouchAction ();
-			IWebElement element = driver.FindElementByIosUIAutomation (".elements()");
+            a = new TouchAction(driver)
+                .MoveTo(element);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"moveTo\",\"options\":{\"element\":\"5\"}}]}");
+        }
 
-			ITouchAction a;
+        [Test]
+        public void PressTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            RequestProcessor re = setupTouchAction();
+            IWebElement element = driver.FindElementByIosUIAutomation(".elements()");
 
-			a = new TouchAction (driver)
-				.Press (element, 50, 75);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"press\",\"options\":{\"element\":\"5\",\"x\":50,\"y\":75}}]}");
+            ITouchAction a;
 
-			a = new TouchAction (driver)
-				.Press (element, 0.5, 75);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"press\",\"options\":{\"element\":\"5\",\"x\":0.5,\"y\":75}}]}");
+            a = new TouchAction(driver)
+                .Press(element, 50, 75);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"press\",\"options\":{\"element\":\"5\",\"x\":50,\"y\":75}}]}");
 
-			a = new TouchAction (driver)
-				.Press (0.5, 75);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"press\",\"options\":{\"x\":0.5,\"y\":75}}]}");
+            a = new TouchAction(driver)
+                .Press(element, 0.5, 75);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"press\",\"options\":{\"element\":\"5\",\"x\":0.5,\"y\":75}}]}");
 
-			a = new TouchAction (driver)
-				.Press (element);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"press\",\"options\":{\"element\":\"5\"}}]}");
-		}
+            a = new TouchAction(driver)
+                .Press(0.5, 75);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"press\",\"options\":{\"x\":0.5,\"y\":75}}]}");
 
-		[Test]
-		public void ReleaseTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			RequestProcessor re = setupTouchAction ();
-			ITouchAction a;
+            a = new TouchAction(driver)
+                .Press(element);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"press\",\"options\":{\"element\":\"5\"}}]}");
+        }
 
-			a = new TouchAction (driver)
-				.Release ();
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"release\"}]}");
-		}
+        [Test]
+        public void ReleaseTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            RequestProcessor re = setupTouchAction();
+            ITouchAction a;
 
-		[Test]
-		public void TapTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			RequestProcessor re = setupTouchAction ();
-			IWebElement element = driver.FindElementByIosUIAutomation (".elements()");
+            a = new TouchAction(driver)
+                .Release();
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"release\"}]}");
+        }
 
-			ITouchAction a;
+        [Test]
+        public void TapTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            RequestProcessor re = setupTouchAction();
+            IWebElement element = driver.FindElementByIosUIAutomation(".elements()");
 
-			a = new TouchAction (driver)
-				.Tap (element, 50, 75);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"element\":\"5\",\"x\":50,\"y\":75}}]}");
+            ITouchAction a;
 
-			a = new TouchAction (driver)
-				.Tap (element, 50, 75, 10);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"element\":\"5\",\"x\":50,\"y\":75,\"count\":10}}]}");
+            a = new TouchAction(driver)
+                .Tap(element, 50, 75);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"element\":\"5\",\"x\":50,\"y\":75}}]}");
 
-			a = new TouchAction (driver)
-				.Tap (element, 0.5, 75);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"element\":\"5\",\"x\":0.5,\"y\":75}}]}");
+            a = new TouchAction(driver)
+                .Tap(element, 50, 75, 10);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"element\":\"5\",\"x\":50,\"y\":75,\"count\":10}}]}");
 
-			a = new TouchAction (driver)
-				.Tap (0.5, 75);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"x\":0.5,\"y\":75}}]}");
+            a = new TouchAction(driver)
+                .Tap(element, 0.5, 75);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"element\":\"5\",\"x\":0.5,\"y\":75}}]}");
 
-			a = new TouchAction (driver)
-				.Tap (0.5, 75, 10);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"x\":0.5,\"y\":75,\"count\":10}}]}");
+            a = new TouchAction(driver)
+                .Tap(0.5, 75);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"x\":0.5,\"y\":75}}]}");
 
-			a = new TouchAction (driver)
-				.Tap (element);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"element\":\"5\"}}]}");
+            a = new TouchAction(driver)
+                .Tap(0.5, 75, 10);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"x\":0.5,\"y\":75,\"count\":10}}]}");
 
-			a = new TouchAction (driver)
-				.Tap (element, count: 10);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"element\":\"5\",\"count\":10}}]}");
-				
-		}
+            a = new TouchAction(driver)
+                .Tap(element);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"element\":\"5\"}}]}");
 
-		[Test]
-		public void WaitTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			RequestProcessor re = setupTouchAction ();
-			ITouchAction a;
+            a = new TouchAction(driver)
+                .Tap(element, count: 10);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"tap\",\"options\":{\"element\":\"5\",\"count\":10}}]}");
 
-			a = new TouchAction (driver)
-				.Wait (1000);
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"wait\",\"options\":{\"ms\":1000}}]}");
+        }
 
-			a = new TouchAction (driver)
-				.Wait ();
-			a.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[{\"action\":\"wait\"}]}");
-		}
+        [Test]
+        public void WaitTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            RequestProcessor re = setupTouchAction();
+            ITouchAction a;
 
-		private RequestProcessor setupMultiAction() {
-			server.respondTo ("POST", "/element", new Dictionary<string, object>  {
-				{"ELEMENT", '5'}
-			});
-			return server.respondTo ("POST", "/touch/multi/perform", null);
-		}
+            a = new TouchAction(driver)
+                .Wait(1000);
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"wait\",\"options\":{\"ms\":1000}}]}");
 
-		[Test]
-		public void MultiActionTestCase ()
-		{
-            IOSDriver driver = new IOSDriver(defaultUri, capabilities);
-			RequestProcessor re = setupMultiAction ();
-			IWebElement element = driver.FindElementByIosUIAutomation (".elements()");
+            a = new TouchAction(driver)
+                .Wait();
+            a.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[{\"action\":\"wait\"}]}");
+        }
 
-			MultiAction m = new MultiAction(driver);
-			m.Perform ();
-			Assert.AreEqual (re.inputData, "");
+        private RequestProcessor setupMultiAction()
+        {
+            server.respondTo("POST", "/element", new Dictionary<string, object>  { 				{"ELEMENT", '5'} 			});
+            return server.respondTo("POST", "/touch/multi/perform", null);
+        }
 
-			TouchAction a1 = new TouchAction ();
-			a1
-				.Press (element, 100, 100)
-				.Wait (1000)
-				.Release ();
-			m.Add (a1);
-			m.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[[{\"action\":\"press\",\"options\":{\"element\":\"5\",\"x\":100,\"y\":100}},{\"action\":\"wait\",\"options\":{\"ms\":1000}},{\"action\":\"release\"}]]}");
+        [Test]
+        public void MultiActionTestCase()
+        {
+            IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
+            RequestProcessor re = setupMultiAction();
+            IWebElement element = driver.FindElementByIosUIAutomation(".elements()");
 
-			TouchAction a2 = new TouchAction ();
-			a2
-				.Tap (100, 100)
-				.MoveTo (element);
-			m.Add (a2);
-			m.Perform ();
-			Assert.AreEqual (re.inputData, "{\"actions\":[[{\"action\":\"press\",\"options\":{\"element\":\"5\",\"x\":100,\"y\":100}},{\"action\":\"wait\",\"options\":{\"ms\":1000}},{\"action\":\"release\"}],[{\"action\":\"tap\",\"options\":{\"x\":100,\"y\":100}},{\"action\":\"moveTo\",\"options\":{\"element\":\"5\"}}]]}");
-		}
-	}
+            MultiAction m = new MultiAction(driver);
+            m.Perform();
+            Assert.AreEqual(re.inputData, "");
+
+            TouchAction a1 = new TouchAction();
+            a1
+                .Press(element, 100, 100)
+                .Wait(1000)
+                .Release();
+            m.Add(a1);
+            m.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[[{\"action\":\"press\",\"options\":{\"element\":\"5\",\"x\":100,\"y\":100}},{\"action\":\"wait\",\"options\":{\"ms\":1000}},{\"action\":\"release\"}]]}");
+
+            TouchAction a2 = new TouchAction();
+            a2
+                .Tap(100, 100)
+                .MoveTo(element);
+            m.Add(a2);
+            m.Perform();
+            Assert.AreEqual(re.inputData, "{\"actions\":[[{\"action\":\"press\",\"options\":{\"element\":\"5\",\"x\":100,\"y\":100}},{\"action\":\"wait\",\"options\":{\"ms\":1000}},{\"action\":\"release\"}],[{\"action\":\"tap\",\"options\":{\"x\":100,\"y\":100}},{\"action\":\"moveTo\",\"options\":{\"element\":\"5\"}}]]}");
+        }
+    }
 }
 


### PR DESCRIPTION
Hi guys! I want to propose changes that are similar as https://github.com/appium/java-client/pull/182 (java client, it is still waiting for the merging or rejection).

Major change:
AppiumDriver and its subclasses are generic now. This feature will allow to user the choice of IWebElement type those instances should be found and returned.

```c#
AppiumDriver<IWebElement> driver;
//some actions

IWebElement e = driver.FindElement(By.Id("id"));
List<IWebElement> l = driver.FindElements(By.id("id"));
```

User can choose the desired type. IWebElement, RemoteWebElement, AppiumWebElement or subclasses are allowed. So when they will choose something that differs from IWebElement then:

```c#
AppiumDriver<AppiumWebElement> driver;
//some actions

AppiumWebElement e = driver.FindElement(By.Id("id"));
IList<AppiumWebElement> l = driver.FindElements(By.Id("id"));

AppiumWebElement e1. = e.FindElement(By.Id("id2"));
IList<AppiumWebElement> l1 = e.findElements(By.Id("id2"));
```
AppiumWebElement and subclasses are not generic.  But their finders already return AppiumWebElement.

@Astro03 @Jonahss @bootstraponline What do you think about changes like that in C#?
I would like to merge them but release them later. There is scope of changes that I am going to implement and release as 2.0.0.0 version. 