### PR TITLE
#64 fix

### DIFF
--- a/appium-dotnet-driver/Appium/AppiumWebElement.cs
+++ b/appium-dotnet-driver/Appium/AppiumWebElement.cs
@@ -40,11 +40,8 @@ namespace OpenQA.Selenium.Appium
     /// }
     /// </code>
     /// </example>
-    public abstract class AppiumWebElement : RemoteWebElement, IFindByAccessibilityId<AppiumWebElement>, IGenericSearchContext<AppiumWebElement>,
-        IGenericFindsByClassName<AppiumWebElement>,
-        IGenericFindsById<AppiumWebElement>, IGenericFindsByCssSelector<AppiumWebElement>, IGenericFindsByLinkText<AppiumWebElement>,
-        IGenericFindsByName<AppiumWebElement>,
-        IGenericFindsByPartialLinkText<AppiumWebElement>, IGenericFindsByTagName<AppiumWebElement>, IGenericFindsByXPath<AppiumWebElement>
+    public abstract class AppiumWebElement : RemoteWebElement, 
+        IMobileElement<AppiumWebElement>
     {
         /// <summary>
         /// Initializes a new instance of the AppiumWebElement class.

--- a/appium-dotnet-driver/Appium/Enums/AutomationName.cs
+++ b/appium-dotnet-driver/Appium/Enums/AutomationName.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.Enums
+{
+    public sealed class AutomationName
+    {
+        public static readonly string Appium = "Appium";
+        public static readonly string Selendroid = "Selendroid";
+    }
+}

--- a/appium-dotnet-driver/Appium/Interfaces/IMobileElement.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/IMobileElement.cs
@@ -1,0 +1,22 @@
+﻿using Appium.Interfaces.Generic.SearchContext;
+using OpenQA.Selenium.Appium.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.Interfaces
+{
+    /// <summary>
+    /// This interface extends IWebElement and defines specific behavior
+    /// for mobile.
+    /// </summary>
+    public interface IMobileElement<W> : IFindByAccessibilityId<W>, IGenericSearchContext<W>,
+        IGenericFindsByClassName<W>,
+        IGenericFindsById<W>, IGenericFindsByCssSelector<W>, IGenericFindsByLinkText<W>,
+        IGenericFindsByName<W>,
+        IGenericFindsByPartialLinkText<W>, IGenericFindsByTagName<W>, IGenericFindsByXPath<W>, IWebElement 
+        where W: IWebElement
+    {
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/AppiumPageObjectMemberDecorator.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/AppiumPageObjectMemberDecorator.cs
@@ -1,0 +1,211 @@
+﻿using Castle.DynamicProxy;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.Enums;
+using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.PageFactory.Interceptors;
+using OpenQA.Selenium.Appium.PageObjects.Attributes;
+using OpenQA.Selenium.Appium.PageObjects.Interceptors;
+using OpenQA.Selenium.Internal;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects
+{
+    public class AppiumPageObjectMemberDecorator : IPageObjectMemberDecorator
+    {
+        private static readonly TimeSpan defaultTimeSpan = new TimeSpan(0, 0, 1);
+        private readonly TimeSpan timeForWaitingForElements;
+
+        private static List<Type> listAvailableElementTypes;
+
+
+
+        private static List<Type> ListAvailableElementTypes
+        {
+            get
+            {
+                if (listAvailableElementTypes == null)
+                {
+                    listAvailableElementTypes = new List<Type>();
+                    listAvailableElementTypes.Add(typeof(IWebElement));
+                    listAvailableElementTypes.Add(typeof(RemoteWebElement));
+                    listAvailableElementTypes.Add(typeof(AppiumWebElement));
+                    listAvailableElementTypes.Add(typeof(AndroidElement));
+                    listAvailableElementTypes.Add(typeof(IOSElement));
+                }
+
+                return listAvailableElementTypes;
+            }
+        }
+
+
+        private static bool MatchGenerics(Type generalType, List<Type> possibleParameters, Type targetType)
+        {
+            foreach (var type in possibleParameters)
+            {
+                Type fullType = generalType.MakeGenericType(type);
+                if (fullType.Equals(targetType))
+                    return true;
+            }
+
+            return false;
+        }
+
+
+        private static string GetPlatform(ISearchContext context)
+        {
+            IWebDriver driver = WebDriverUnpackUtility.UnpackWebdriver(context);
+
+            if (driver == null)
+                return null;
+
+            Type driverType = driver.GetType();
+
+            if (MatchGenerics(typeof(AndroidDriver<>), ListAvailableElementTypes, driverType))
+                return MobilePlatform.Android;
+
+            if (MatchGenerics(typeof(IOSDriver<>), ListAvailableElementTypes, driverType))
+                return MobilePlatform.IOS;
+
+            if (typeof(IHasCapabilities).IsAssignableFrom(driverType))
+            {
+                IHasCapabilities hasCapabilities = (IHasCapabilities) driver;
+                object platform = hasCapabilities.
+                    Capabilities.GetCapability(MobileCapabilityType.PlatformName);
+
+                if (platform == null || String.IsNullOrEmpty(Convert.ToString(platform)))
+                    platform = hasCapabilities.Capabilities.GetCapability(CapabilityType.Platform);
+
+                string convertedPlatform = Convert.ToString(platform);
+                if (platform != null && !String.IsNullOrEmpty(convertedPlatform))
+                    return convertedPlatform;
+            }
+            return null;
+        }
+
+
+        private static string GetAutomation(ISearchContext context)
+        {
+           IWebDriver driver = WebDriverUnpackUtility.
+                UnpackWebdriver(context);
+
+            if (driver == null)
+                return null;
+
+            if (typeof(IHasCapabilities).IsAssignableFrom(driver.GetType())) {
+
+                IHasCapabilities hasCapabilities = (IHasCapabilities) driver;
+                object automation = hasCapabilities.
+                    Capabilities.GetCapability(MobileCapabilityType.AutomationName);
+
+                if (automation == null || String.IsNullOrEmpty(Convert.ToString(automation)))
+                    automation = hasCapabilities.Capabilities.GetCapability(CapabilityType.BrowserName);
+
+                string convertedAutomation = Convert.ToString(automation);
+                if (automation != null && !String.IsNullOrEmpty(convertedAutomation))
+                    return convertedAutomation;                
+            }
+            return null;
+        }
+
+        public AppiumPageObjectMemberDecorator()
+            :this(defaultTimeSpan)
+        {}
+
+        public AppiumPageObjectMemberDecorator(TimeSpan timeForWaitingForElements)
+        {
+            this.timeForWaitingForElements = timeForWaitingForElements;
+        }
+
+
+        private static Type GetTypeOfASingleElement(Type targetType, MemberInfo member)
+        {
+            if (typeof(IWebElement).Equals(targetType))
+                return targetType;
+            else
+                if (MatchGenerics(typeof(IMobileElement<>), ListAvailableElementTypes, targetType))
+                    return targetType;
+
+            return null;
+        }
+
+        private TimeSpan GetTimeWaitingForElements(MemberInfo member)
+        {
+            WithTimeSpanAttribute customTimeSpan = (WithTimeSpanAttribute) Attribute.
+                GetCustomAttribute(member, typeof(WithTimeSpanAttribute), true);
+            if (customTimeSpan != null)
+                try
+                {
+                    return new TimeSpan(0, customTimeSpan.Hours, customTimeSpan.Minutes, 
+                        customTimeSpan.Seconds, customTimeSpan.Milliseconds);
+                }
+                catch (Exception e) 
+                {
+                    throw new Exception("Exception was thrown while it was tryig to get time of the waiting for elements. Please check the "+
+                        member.MemberType.ToString() + " " + member.Name + ".", e);
+                }
+
+            return timeForWaitingForElements;               
+        }
+
+
+        public object Decorate(MemberInfo member, IElementLocator locator)
+        {
+            FieldInfo field = member as FieldInfo;
+            PropertyInfo property = member as PropertyInfo;
+
+            Type targetType = null;
+            if (field != null)
+            {
+                targetType = field.FieldType;
+            }
+
+            bool hasPropertySet = false;
+            if (property != null)
+            {
+                hasPropertySet = property.CanWrite;
+                targetType = property.PropertyType;
+            }
+
+            if (field == null & (property == null || !hasPropertySet))
+                return null;
+
+            if (field != null && (field.IsStatic || field.IsInitOnly))
+                return null;
+
+            Type aSingleElementType = GetTypeOfASingleElement(targetType, member);
+
+            Type aListOfElementsType = null;
+            if (MatchGenerics(typeof(IList<>), ListAvailableElementTypes, targetType))
+                aListOfElementsType = targetType;
+
+            if (aSingleElementType == null & aListOfElementsType == null)
+                return null;
+
+            ISearchContext context = locator.SearchContext;
+            string platform = GetPlatform(context);
+            string automation = GetAutomation(context);
+            
+            IEnumerable<By> bys = ByFactory.CreateBys(platform, automation, member);
+
+            ProxyGenerator generator = new ProxyGenerator();
+            TimeSpan span = GetTimeWaitingForElements(member);
+            bool shouldCache = (Attribute.
+                GetCustomAttribute(member, typeof(CacheLookupAttribute), true) != null);
+
+            if (aSingleElementType != null)
+                return generator.CreateInterfaceProxyWithoutTarget(aSingleElementType, new Type[] { typeof(IWrapsDriver), typeof(IWrapsElement) },
+                    ProxyGenerationOptions.Default, new ElementInterceptor(bys, locator, span, shouldCache));
+
+            return generator.CreateInterfaceProxyWithoutTarget(aListOfElementsType, ProxyGenerationOptions.Default, 
+                    new ElementListInterceptor(bys, locator, span, shouldCache));
+        }
+
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/AppiumPageObjectMemberDecorator.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/AppiumPageObjectMemberDecorator.cs
@@ -20,7 +20,7 @@ namespace OpenQA.Selenium.Appium.PageObjects
     public class AppiumPageObjectMemberDecorator : IPageObjectMemberDecorator
     {
         private static readonly TimeSpan defaultTimeSpan = new TimeSpan(0, 0, 1);
-        private readonly TimeSpan timeForWaitingForElements;
+        private readonly TimeOutDuration timeForWaitingForElements;
 
         private static List<Type> listAvailableElementTypes;
 
@@ -115,10 +115,10 @@ namespace OpenQA.Selenium.Appium.PageObjects
         }
 
         public AppiumPageObjectMemberDecorator()
-            :this(defaultTimeSpan)
+            :this(new TimeOutDuration(defaultTimeSpan))
         {}
 
-        public AppiumPageObjectMemberDecorator(TimeSpan timeForWaitingForElements)
+        public AppiumPageObjectMemberDecorator(TimeOutDuration timeForWaitingForElements)
         {
             this.timeForWaitingForElements = timeForWaitingForElements;
         }
@@ -135,15 +135,15 @@ namespace OpenQA.Selenium.Appium.PageObjects
             return null;
         }
 
-        private TimeSpan GetTimeWaitingForElements(MemberInfo member)
+        private TimeOutDuration GetTimeWaitingForElements(MemberInfo member)
         {
             WithTimeSpanAttribute customTimeSpan = (WithTimeSpanAttribute) Attribute.
                 GetCustomAttribute(member, typeof(WithTimeSpanAttribute), true);
             if (customTimeSpan != null)
                 try
                 {
-                    return new TimeSpan(0, customTimeSpan.Hours, customTimeSpan.Minutes, 
-                        customTimeSpan.Seconds, customTimeSpan.Milliseconds);
+                    return new TimeOutDuration(new TimeSpan(0, customTimeSpan.Hours, customTimeSpan.Minutes, 
+                        customTimeSpan.Seconds, customTimeSpan.Milliseconds));
                 }
                 catch (Exception e) 
                 {
@@ -195,7 +195,7 @@ namespace OpenQA.Selenium.Appium.PageObjects
             IEnumerable<By> bys = ByFactory.CreateBys(platform, automation, member);
 
             ProxyGenerator generator = new ProxyGenerator();
-            TimeSpan span = GetTimeWaitingForElements(member);
+            TimeOutDuration span = GetTimeWaitingForElements(member);
             bool shouldCache = (Attribute.
                 GetCustomAttribute(member, typeof(CacheLookupAttribute), true) != null);
 

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/Abstract/FindsByMobileAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/Abstract/FindsByMobileAttribute.cs
@@ -128,7 +128,6 @@ namespace OpenQA.Selenium.Appium.PageObjects.Attributes.Abstract
                 throw new ArgumentException("Object to compare must be a FindsByAttribute", "obj");
             }
 
-            // TODO(JimEvans): Construct an algorithm to sort on more than just Priority.
             if (this.Priority != other.Priority)
             {
                 return this.Priority - other.Priority;

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/Abstract/FindsByMobileAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/Abstract/FindsByMobileAttribute.cs
@@ -1,0 +1,262 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects.Attributes.Abstract
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = true)]
+    public abstract class FindsByMobileAttribute: Attribute, IComparable
+    {
+        protected List<By> byList = new List<By>();
+
+        private void ValidateByDefinition()
+        {
+            if (byList.Count == 0)
+            {
+                throw new IllegalLocatorException("The desired locator strategy is not defines");
+            }
+
+            if (byList.Count > 1)
+            {
+                throw new IllegalLocatorException("There should be defined only one locator strategy. Few strategies are being defined " +
+                "right now: " + byList.ToString());
+            }
+        }
+
+        internal By By
+        {
+            get
+            {
+                ValidateByDefinition();
+                return byList[0];
+            }
+            
+        }
+
+        /// <summary>
+        /// Determines if two <see cref="FindsByAttribute"/> instances are equal.
+        /// </summary>
+        /// <param name="one">One instance to compare.</param>
+        /// <param name="two">The other instance to compare.</param>
+        /// <returns><see langword="true"/> if the two instances are equal; otherwise, <see langword="false"/>.</returns>
+        public static bool operator ==(FindsByMobileAttribute one, FindsByMobileAttribute two)
+        {
+            // If both are null, or both are same instance, return true.
+            if (object.ReferenceEquals(one, two))
+            {
+                return true;
+            }
+
+            // If one is null, but not both, return false.
+            if (((object)one == null) || ((object)two == null))
+            {
+                return false;
+            }
+
+            return one.Equals(two);
+        }
+
+        /// <summary>
+        /// Determines if two <see cref="FindsByAttribute"/> instances are unequal.
+        /// </summary>s
+        /// <param name="one">One instance to compare.</param>
+        /// <param name="two">The other instance to compare.</param>
+        /// <returns><see langword="true"/> if the two instances are not equal; otherwise, <see langword="false"/>.</returns>
+        public static bool operator !=(FindsByMobileAttribute one, FindsByMobileAttribute two)
+        {
+            return !(one == two);
+        }
+
+        /// <summary>
+        /// Determines if one <see cref="FindsByAttribute"/> instance is greater than another.
+        /// </summary>
+        /// <param name="one">One instance to compare.</param>
+        /// <param name="two">The other instance to compare.</param>
+        /// <returns><see langword="true"/> if the first instance is greater than the second; otherwise, <see langword="false"/>.</returns>
+        public static bool operator >(FindsByMobileAttribute one, FindsByMobileAttribute two)
+        {
+            if (one == null)
+            {
+                throw new ArgumentNullException("one", "Object to compare cannot be null");
+            }
+
+            return one.CompareTo(two) > 0;
+        }
+
+        /// <summary>
+        /// Determines if one <see cref="FindsByAttribute"/> instance is less than another.
+        /// </summary>
+        /// <param name="one">One instance to compare.</param>
+        /// <param name="two">The other instance to compare.</param>
+        /// <returns><see langword="true"/> if the first instance is less than the second; otherwise, <see langword="false"/>.</returns>
+        public static bool operator <(FindsByMobileAttribute one, FindsByMobileAttribute two)
+        {
+            if (one == null)
+            {
+                throw new ArgumentNullException("one", "Object to compare cannot be null");
+            }
+
+            return one.CompareTo(two) < 0;
+        }
+
+        /// <summary>
+        /// Compares the current instance with another object of the same type and returns an 
+        /// integer that indicates whether the current instance precedes, follows, or occurs 
+        /// in the same position in the sort order as the other object.
+        /// </summary>
+        /// <param name="obj">An object to compare with this instance.</param>
+        /// <returns>A value that indicates the relative order of the objects being compared. The return value has these meanings:
+        /// <list type="table">
+        /// <listheader>Value</listheader><listheader>Meaning</listheader>
+        /// <item><description>Less than zero</description><description>This instance precedes <paramref name="obj"/> in the sort order.</description></item>
+        /// <item><description>Zero</description><description>This instance occurs in the same position in the sort order as <paramref name="obj"/>.</description></item>
+        /// <item><description>Greater than zero</description><description>This instance follows <paramref name="obj"/> in the sort order. </description></item>
+        /// </list>
+        /// </returns>
+        public int CompareTo(object obj)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException("obj", "Object to compare cannot be null");
+            }
+
+            FindsByMobileAttribute other = obj as FindsByMobileAttribute;
+            if (other == null)
+            {
+                throw new ArgumentException("Object to compare must be a FindsByAttribute", "obj");
+            }
+
+            // TODO(JimEvans): Construct an algorithm to sort on more than just Priority.
+            if (this.Priority != other.Priority)
+            {
+                return this.Priority - other.Priority;
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object">Object</see> is equal 
+        /// to the current <see cref="System.Object">Object</see>.
+        /// </summary>
+        /// <param name="obj">The <see cref="System.Object">Object</see> to compare with the 
+        /// current <see cref="System.Object">Object</see>.</param>
+        /// <returns><see langword="true"/> if the specified <see cref="System.Object">Object</see>
+        /// is equal to the current <see cref="System.Object">Object</see>; otherwise,
+        /// <see langword="false"/>.</returns>
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+
+            FindsByMobileAttribute other = obj as FindsByMobileAttribute;
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (other.Priority != this.Priority)
+            {
+                return false;
+            }
+
+            return other.By.Equals(this.By);
+        }
+
+        /// <summary>
+        /// Serves as a hash function for a particular type.
+        /// </summary>
+        /// <returns>A hash code for the current <see cref="System.Object">Object</see>.</returns>
+        public override int GetHashCode()
+        {
+            return this.By.GetHashCode();
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating where this attribute should be evaluated relative to other instances
+        /// of this attribute decorating the same class member.
+        /// </summary>
+        [DefaultValue(0)]
+        public int Priority { get; set; }
+
+        /// <summary>
+        /// Sets the target element id
+        /// </summary>
+        public String ID
+        {
+            set
+            {
+                byList.Add(By.Id(value));
+            }
+            get
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Sets the target element class name
+        /// </summary>
+        public String ClassName
+        {
+            set
+            {
+                byList.Add(By.ClassName(value));
+            }
+            get
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Sets the target element tag name
+        /// </summary>
+        public String TagName
+        {
+            set
+            {
+                byList.Add(By.TagName(value));
+            }
+            get
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Sets the target element name
+        /// </summary>
+        public String Name
+        {
+            set
+            {
+                byList.Add(By.Name(value));
+            }
+            get
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Sets the target element xpath
+        /// </summary>
+        public String XPath
+        {
+            set
+            {
+                byList.Add(By.XPath(value));
+            }
+            get
+            {
+                return null;
+            }
+        }
+
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/Abstract/FindsByUIAutomatorsAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/Abstract/FindsByUIAutomatorsAttribute.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects.Attributes.Abstract
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = true)]
+    public class FindsByUIAutomatorsAttribute: FindsByMobileAttribute
+    {
+        /// <summary>
+        /// Sets the target accessibility
+        /// </summary>
+        public String Accessibility
+        {
+            set
+            {
+                byList.Add(new ByAccessibilityId(value));
+            }
+            get
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/Abstract/FindsByUIAutomatorsAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/Abstract/FindsByUIAutomatorsAttribute.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace OpenQA.Selenium.Appium.PageObjects.Attributes.Abstract
 {
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = true)]
-    public class FindsByUIAutomatorsAttribute: FindsByMobileAttribute
+    public abstract class FindsByUIAutomatorsAttribute : FindsByMobileAttribute
     {
         /// <summary>
         /// Sets the target accessibility

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/FindsByAndroidUIAutomatorAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/FindsByAndroidUIAutomatorAttribute.cs
@@ -1,0 +1,27 @@
+﻿using OpenQA.Selenium.Appium.PageObjects.Attributes.Abstract;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = true)]
+    public class FindsByAndroidUIAutomatorAttribute : FindsByUIAutomatorsAttribute
+    {
+        /// <summary>
+        /// Sets the target UI automator locator
+        /// </summary>
+        public String AndroidUIAutomator
+        {
+            set
+            {
+                byList.Add(new ByAndroidUIAutomator(value));
+            }
+            get
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/FindsByIOSUIAutomationAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/FindsByIOSUIAutomationAttribute.cs
@@ -1,0 +1,27 @@
+﻿using OpenQA.Selenium.Appium.PageObjects.Attributes.Abstract;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = true)]
+    public class FindsByIOSUIAutomationAttribute : FindsByUIAutomatorsAttribute
+    {
+        /// <summary>
+        /// Sets the target UI automation locator
+        /// </summary>
+        public String IosUIAutomation
+        {
+            set
+            {
+                byList.Add(new ByIosUIAutomation(value));
+            }
+            get
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/FindsBySelendroidAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/FindsBySelendroidAttribute.cs
@@ -1,0 +1,44 @@
+﻿using OpenQA.Selenium.Appium.PageObjects.Attributes.Abstract;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = true)]
+    public class FindsBySelendroidAttribute: FindsByMobileAttribute
+    {
+        /// <summary>
+        /// Sets the target element link text.
+        /// This locator is supported by Selendroid
+        /// </summary>
+        public String LinkText
+        {
+            set
+            {
+                byList.Add(By.LinkText(value));
+            }
+            get
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Sets the target element partial link text
+        /// This locator is supported by Selendroid
+        /// </summary>
+        public String PartialLinkText
+        {
+            set
+            {
+                byList.Add(By.PartialLinkText(value));
+            }
+            get
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/MobileFindsByAllAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/MobileFindsByAllAttribute.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects.Attributes
+{
+    /// <summary>
+    /// Marks elements to indicate that found elements should match the criteria of
+    /// all <see cref="FindsByAndroidUIAutomatorAttribute"/> or <see cref="FindsByIOSUIAutomationAttribute"/>
+    /// or <see cref="FindsBySelendroidAttribute"/> on the field or property.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When used with a set of <see cref="MobileFindsByAllAttribute"/>, all criteria must be
+    /// matched to be returned. The criteria are used in sequence according to the
+    /// Priority property. Note that the behavior when setting multiple
+    /// <see cref="FindsByAndroidUIAutomatorAttribute"/> or 
+    /// <see cref="FindsByIOSUIAutomationAttribute"/> or <see cref="FindsBySelendroidAttribute"/> Priority properties to the same value, or not
+    /// specifying a Priority value, is undefined.
+    /// </para>
+    /// <para>
+    /// <code>
+    /// // Will find the element with the class "SomeClass" that also has an ID
+    /// // attribute matching "elementId".
+    /// [MobileFindsByAll(Android = true)]
+    /// [FindsByAndroidUIAutomator(Class = "SomeClass", Priority = 0)]
+    /// [FindsByAndroidUIAutomator(Id = "elementId", Priority = 1)]
+    /// public IWebElement thisElement;
+    /// </code>
+    /// </para>
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = false)]
+    public class MobileFindsByAllAttribute : Attribute
+    {
+        /// <summary>
+        /// If this property is "true" then target elements should match the criteria of
+        /// all <see cref="FindsByAndroidUIAutomatorAttribute"/>  on the field or property.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool Android { get; set; }
+
+        /// <summary>
+        /// If this property is "true" then target elements should match the criteria of
+        /// all <see cref="FindsByIOSUIAutomationAttribute"/>  on the field or property.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool IOS { get; set; }
+
+        /// <summary>
+        /// If this property is "true" then target elements should match the criteria of
+        /// all <see cref="FindsBySelendroidAttribute"/>  on the field or property.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool Selendroid { get; set; }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/MobileFindsBySequenceAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/MobileFindsBySequenceAttribute.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects.Attributes
+{
+    /// <summary>
+    /// Marks elements to indicate that each <see cref="FindsByAndroidUIAutomatorAttribute"/> or 
+    /// <see cref="FindsByIOSUIAutomationAttribute"/> or <see cref="FindsBySelendroidAttribute"/> on the field or
+    /// property should be used in sequence to find the appropriate element.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When used with a set of <see cref="FindsByAndroidUIAutomatorAttribute"/> or 
+    /// <see cref="FindsByIOSUIAutomationAttribute"/> or <see cref="FindsBySelendroidAttribute"/>, the criteria are used
+    /// in sequence according to the Priority property to find child elements. Note that
+    /// the behavior when setting multiple <see cref="FindsByAttribute"/> Priority
+    /// properties to the same value, or not specifying a Priority value, is undefined.
+    /// </para>
+    /// <para>
+    /// <code>
+    /// // Will find the element with the ID attribute matching "elementId", then will find
+    /// // a child element with the ID attribute matching "childElementId".
+    /// [MobileFindsBySequence(Android = true)]
+    /// [FindsByAndroidUIAutomator(Id = "elementId", Priority = 0)]
+    /// [FindsByAndroidUIAutomator(Id = "childElementId", Priority = 1)]
+    /// public IWebElement targetElement;
+    /// </code>
+    /// </para>
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = false)]
+    public class MobileFindsBySequenceAttribute : Attribute
+    {
+        /// <summary>
+        /// If this property is "true" then each <see cref="FindsByAndroidUIAutomatorAttribute"/>  on the field or
+        /// property will be used in sequence to find the appropriate element.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool Android { get; set; }
+
+        /// <summary>
+        /// If this property is "true" then each <see cref="FindsByIOSUIAutomationAttribute"/>  on the field or
+        /// property will be used in sequence to find the appropriate element.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool IOS { get; set; }
+
+        /// <summary>
+        /// If this property is "true" then each <see cref="FindsBySelendroidAttribute"/>  on the field or
+        /// property will be used in sequence to find the appropriate element.
+        /// </summary>
+        [DefaultValue(false)]
+        public bool Selendroid { get; set; }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/WithTimeSpanAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/WithTimeSpanAttribute.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property | AttributeTargets.Class, AllowMultiple = false)]
+    public class WithTimeSpanAttribute : Attribute
+    {
+        [DefaultValue(0)]
+        public int Hours { get; set; }
+
+        [DefaultValue(0)]
+        public int Minutes { get; set; }
+
+        public int Seconds { get; set; }
+
+        [DefaultValue(0)]
+        public int Milliseconds { get; set; }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/ByFactory.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/ByFactory.cs
@@ -1,0 +1,178 @@
+﻿using OpenQA.Selenium.Appium.Enums;
+using OpenQA.Selenium.Appium.PageObjects.Attributes;
+using OpenQA.Selenium.Appium.PageObjects.Attributes.Abstract;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects
+{
+    internal class ByFactory
+    {
+
+
+        private static By From(FindsByAttribute attribute)
+        {
+            var how = attribute.How;
+            var usingValue = attribute.Using;
+            switch (how)
+            {
+                case How.Id:
+                    return By.Id(usingValue);
+                case How.Name:
+                    return By.Name(usingValue);
+                case How.TagName:
+                    return By.TagName(usingValue);
+                case How.ClassName:
+                    return By.ClassName(usingValue);
+                case How.CssSelector:
+                    return By.CssSelector(usingValue);
+                case How.LinkText:
+                    return By.LinkText(usingValue);
+                case How.PartialLinkText:
+                    return By.PartialLinkText(usingValue);
+                case How.XPath:
+                    return By.XPath(usingValue);
+                case How.Custom:
+                    if (attribute.CustomFinderType == null)
+                    {
+                        throw new ArgumentException("Cannot use How.Custom without supplying a custom finder type");
+                    }
+
+                    if (!attribute.CustomFinderType.IsSubclassOf(typeof(By)))
+                    {
+                        throw new ArgumentException("Custom finder type must be a descendent of the By class");
+                    }
+
+                    ConstructorInfo ctor = attribute.CustomFinderType.GetConstructor(new Type[] { typeof(string) });
+                    if (ctor == null)
+                    {
+                        throw new ArgumentException("Custom finder type must expose a public constructor with a string argument");
+                    }
+
+                    By finder = ctor.Invoke(new object[] { usingValue }) as By;
+                    return finder;
+            }
+
+            throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Did not know how to construct How from how {0}, using {1}", how, usingValue));
+        }
+
+        private static ReadOnlyCollection<By> CreateDefaultLocatorList(MemberInfo member, bool useSequence, bool useAll)
+        {
+            List<By> bys = new List<By>();
+            var attributes = Attribute.GetCustomAttributes(member, typeof(FindsByAttribute), true);
+
+            if (attributes.Length == 0)
+            {
+                bys.Add(new ByIdOrName(member.Name));
+                return bys.AsReadOnly();
+            }
+
+            Array.Sort(attributes);
+            foreach (var attribute in attributes)
+            {
+                var castedAttribute = (FindsByAttribute) attribute;
+                bys.Add(From(castedAttribute));
+            }
+
+            return GetListOfComplexBys(useSequence, useAll, bys).AsReadOnly();
+        }
+
+        private static List<By> GetListOfComplexBys(bool useSequence, bool useAll, List<By> bys)
+        {
+            if (useSequence)
+            {
+                ByChained chained = new ByChained(bys.ToArray());
+                bys.Clear();
+                bys.Add(chained);
+            }
+
+            if (useAll)
+            {
+                ByAll all = new ByAll(bys.ToArray());
+                bys.Clear();
+                bys.Add(all);
+            }
+
+            return bys;
+        }
+
+        private static ReadOnlyCollection<By> CreateNativeContextLocatorList(MemberInfo member, bool useSequence, bool useAll, string platform, string automation)
+        {
+            if (platform == null)
+                return null;
+
+            string upperPlatform = platform.ToUpper();
+            string upperAutomation = null;
+
+            if (automation != null)
+                upperAutomation = automation.ToUpper();
+
+            if (!upperPlatform.Equals(MobilePlatform.Android.ToUpper()) & ! upperPlatform.Equals(MobilePlatform.IOS.ToUpper()))
+                return null;
+
+            Attribute[] attributes = null;
+            if (upperPlatform.Equals(MobilePlatform.Android.ToUpper()) & (upperAutomation != null && 
+                upperAutomation.Equals(AutomationName.Selendroid.ToUpper()))){
+                attributes = Attribute.GetCustomAttributes(member, typeof(FindsBySelendroidAttribute), true);
+            }
+                
+
+
+            if (upperPlatform.Equals(MobilePlatform.Android.ToUpper()) & (upperAutomation == null || !
+                upperAutomation.Equals(AutomationName.Selendroid.ToUpper())))
+                attributes = Attribute.GetCustomAttributes(member, typeof(FindsByAndroidUIAutomatorAttribute), true);
+
+            if (upperPlatform.Equals(MobilePlatform.IOS.ToUpper()))
+                attributes = Attribute.GetCustomAttributes(member, typeof(FindsByIOSUIAutomationAttribute), true);
+
+            if (attributes == null || attributes.Length == 0)
+                return null;
+
+            List<By> bys = new List<By>();
+
+            Array.Sort(attributes);
+            foreach (var attribute in attributes)
+            {
+                var castedAttribute = (FindsByMobileAttribute) attribute;
+                bys.Add( castedAttribute.By);
+            }
+
+            return GetListOfComplexBys(useSequence, useAll, bys).AsReadOnly();
+
+        }
+
+
+        internal static IEnumerable<By> CreateBys(string platform, string automation, MemberInfo member)
+        {
+            bool useSequence = (Attribute.GetCustomAttribute(member, typeof(FindsBySequenceAttribute), true) != null);
+            bool useAll = (Attribute.GetCustomAttribute(member, typeof(FindsByAllAttribute), true) != null);
+
+            if (useSequence && useAll)
+            {
+                throw new ArgumentException("Cannot specify FindsBySequence and FindsByAll on the same member");
+            }
+
+            IEnumerable<By> defaultBys = CreateDefaultLocatorList(member, useSequence, useAll);
+            IEnumerable<By> nativeBys = CreateNativeContextLocatorList(member, useSequence, useAll, platform, automation);
+
+            if (nativeBys == null)
+                nativeBys = defaultBys;
+
+            Dictionary<ContentTypes, IEnumerable<By>> map = new Dictionary<ContentTypes, IEnumerable<By>>();
+            map.Add(ContentTypes.HTML, new List<By>(defaultBys).AsReadOnly());
+            map.Add(ContentTypes.NATIVE, new List<By>(nativeBys).AsReadOnly());
+            ContentMappedBy by = new ContentMappedBy(map);
+            List<By> bys = new List<By>();
+            bys.Add(by);
+
+            return bys.AsReadOnly();
+        }
+
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/ByFactory.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/ByFactory.cs
@@ -19,48 +19,10 @@ namespace OpenQA.Selenium.Appium.PageObjects
     {
         private static By From(FindsByAttribute attribute)
         {
-            var how = attribute.How;
-            var usingValue = attribute.Using;
-            switch (how)
-            {
-                case How.Id:
-                    return By.Id(usingValue);
-                case How.Name:
-                    return By.Name(usingValue);
-                case How.TagName:
-                    return By.TagName(usingValue);
-                case How.ClassName:
-                    return By.ClassName(usingValue);
-                case How.CssSelector:
-                    return By.CssSelector(usingValue);
-                case How.LinkText:
-                    return By.LinkText(usingValue);
-                case How.PartialLinkText:
-                    return By.PartialLinkText(usingValue);
-                case How.XPath:
-                    return By.XPath(usingValue);
-                case How.Custom:
-                    if (attribute.CustomFinderType == null)
-                    {
-                        throw new ArgumentException("Cannot use How.Custom without supplying a custom finder type");
-                    }
-
-                    if (!attribute.CustomFinderType.IsSubclassOf(typeof(By)))
-                    {
-                        throw new ArgumentException("Custom finder type must be a descendent of the By class");
-                    }
-
-                    ConstructorInfo ctor = attribute.CustomFinderType.GetConstructor(new Type[] { typeof(string) });
-                    if (ctor == null)
-                    {
-                        throw new ArgumentException("Custom finder type must expose a public constructor with a string argument");
-                    }
-
-                    By finder = ctor.Invoke(new object[] { usingValue }) as By;
-                    return finder;
-            }
-
-            throw new ArgumentException(string.Format(CultureInfo.InvariantCulture, "Did not know how to construct How from how {0}, using {1}", how, usingValue));
+            Assembly assembly = Assembly.LoadFrom("WebDriver.Support.dll");
+            Type seleniumByFactory = assembly.GetType("OpenQA.Selenium.Support.PageObjects.ByFactory");
+            MethodInfo m = seleniumByFactory.GetMethod("From", new Type[] { typeof(FindsByAttribute) });
+            return (By) m.Invoke(seleniumByFactory, new object[] { attribute });
         }
 
         private static ReadOnlyCollection<By> CreateDefaultLocatorList(MemberInfo member)

--- a/appium-dotnet-driver/Appium/PageObjects/ByFactory.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/ByFactory.cs
@@ -159,14 +159,19 @@ namespace OpenQA.Selenium.Appium.PageObjects
             }
 
             IEnumerable<By> defaultBys = CreateDefaultLocatorList(member, useSequence, useAll);
+            ReadOnlyCollection<By> defaultByList = new List<By>(defaultBys).AsReadOnly();
+
             IEnumerable<By> nativeBys = CreateNativeContextLocatorList(member, useSequence, useAll, platform, automation);
+            IList<By> nativeByList = null;
 
             if (nativeBys == null)
-                nativeBys = defaultBys;
+                nativeByList = defaultByList;
+            else
+                nativeByList = new List<By>(nativeBys).AsReadOnly();
 
             Dictionary<ContentTypes, IEnumerable<By>> map = new Dictionary<ContentTypes, IEnumerable<By>>();
-            map.Add(ContentTypes.HTML, new List<By>(defaultBys).AsReadOnly());
-            map.Add(ContentTypes.NATIVE, new List<By>(nativeBys).AsReadOnly());
+            map.Add(ContentTypes.HTML, defaultByList);
+            map.Add(ContentTypes.NATIVE, nativeByList);
             ContentMappedBy by = new ContentMappedBy(map);
             List<By> bys = new List<By>();
             bys.Add(by);

--- a/appium-dotnet-driver/Appium/PageObjects/ByFactory.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/ByFactory.cs
@@ -15,7 +15,7 @@ using System.Text;
 
 namespace OpenQA.Selenium.Appium.PageObjects
 {
-    internal class ByFactory
+    public class ByFactory
     {
         private static By From(FindsByAttribute attribute)
         {
@@ -185,7 +185,7 @@ namespace OpenQA.Selenium.Appium.PageObjects
         }
 
 
-        internal static IEnumerable<By> CreateBys(ISearchContext context, MemberInfo member)
+        public static IEnumerable<By> CreateBys(ISearchContext context, MemberInfo member)
         {
             string platform = GetPlatform(context);
             string automation = GetAutomation(context);

--- a/appium-dotnet-driver/Appium/PageObjects/ContentMappedBy.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/ContentMappedBy.cs
@@ -1,0 +1,63 @@
+﻿using OpenQA.Selenium.Appium.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects
+{
+    internal class ContentMappedBy: By
+    {
+        private readonly Dictionary<ContentTypes, IEnumerable<By>> map;
+        private readonly static String NATIVE_APP_PATTERN = "NATIVE_APP";
+
+        internal ContentMappedBy(Dictionary<ContentTypes, IEnumerable<By>> map)
+        {
+            this.map = map;
+        }
+
+        private IEnumerable<By> GetReturnRelevantBys(ISearchContext context)
+        {
+		    IWebDriver driver = WebDriverUnpackUtility.UnpackWebdriver(context);
+		    if (!typeof(IContextAware).IsAssignableFrom(driver.GetType())) //it is desktop browser 
+			    return map[ContentTypes.HTML];
+
+		    IContextAware contextAware = driver as IContextAware;
+		    String currentContext = contextAware.Context;
+		    if (currentContext.Contains(NATIVE_APP_PATTERN))
+			    return map[ContentTypes.NATIVE];
+
+		    return map[ContentTypes.HTML];
+	    }
+
+
+        public override ReadOnlyCollection<IWebElement> FindElements(ISearchContext context)
+        {
+            List<IWebElement> result = new List<IWebElement>();
+            IEnumerable<By> bys = GetReturnRelevantBys(context);
+
+            foreach (var by in bys)
+            {
+                ReadOnlyCollection<IWebElement> list = context.FindElements(by);
+                result.AddRange(list);
+            }
+
+            return result.AsReadOnly();
+        }
+
+        
+        public override string ToString()
+        {
+            IEnumerable<By> defaultBy = map[ContentTypes.HTML];
+            IEnumerable<By> nativeBy = map[ContentTypes.NATIVE];
+
+            if (defaultBy.Equals(nativeBy))
+                return defaultBy.ToString();
+
+            return "Locator map: " + "\n" +
+                    "- native content: \"" + nativeBy.ToString() + "\" \n" +
+                    "- html content: \"" + defaultBy.ToString() + "\"";
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/ContentMappedBy.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/ContentMappedBy.cs
@@ -46,6 +46,15 @@ namespace OpenQA.Selenium.Appium.PageObjects
             return result.AsReadOnly();
         }
 
+        private static string ReturnByString(IEnumerable<By> bys)
+        {
+            String result = "";
+            foreach (var by in bys)
+            {
+                result = result + by.ToString() + "; ";
+            }
+            return result;
+        }
         
         public override string ToString()
         {
@@ -53,11 +62,11 @@ namespace OpenQA.Selenium.Appium.PageObjects
             IEnumerable<By> nativeBy = map[ContentTypes.NATIVE];
 
             if (defaultBy.Equals(nativeBy))
-                return defaultBy.ToString();
+                return ReturnByString(defaultBy);
 
             return "Locator map: " + "\n" +
-                    "- native content: \"" + nativeBy.ToString() + "\" \n" +
-                    "- html content: \"" + defaultBy.ToString() + "\"";
+                    "- native content: \"" + ReturnByString(nativeBy) + "\" \n" +
+                    "- html content: \"" + ReturnByString(defaultBy) + "\"";
         }
     }
 }

--- a/appium-dotnet-driver/Appium/PageObjects/ContentTypes.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/ContentTypes.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects
+{
+    internal enum ContentTypes
+    {
+        HTML = 0,
+        NATIVE = 1
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/GenericsUtility.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/GenericsUtility.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects
+{
+    internal class GenericsUtility
+    {
+        public static bool MatchGenerics(Type generalType, List<Type> possibleParameters, Type targetType)
+        {
+            foreach (var type in possibleParameters)
+            {
+                Type fullType = generalType.MakeGenericType(type);
+                if (fullType.Equals(targetType))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public static object CraeteInstanceOfSomeGeneric(Type generalType, Type genericParameter, 
+            Type[] argTypes, object[] argValues)
+        {
+            Type generic = generalType.MakeGenericType(genericParameter);
+            return generic.GetConstructor(argTypes).Invoke(argValues);
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementInterceptor.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementInterceptor.cs
@@ -1,0 +1,67 @@
+﻿using Castle.DynamicProxy;
+using OpenQA.Selenium.Internal;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects.Interceptors
+{
+    internal class ElementInterceptor: SearchingInterceptor
+    {
+        private readonly IWebDriver driver;
+
+        public ElementInterceptor(IEnumerable<By> bys, IElementLocator locator, TimeSpan waitingTimeSpan, bool shouldCache)
+            :base(bys, locator, waitingTimeSpan, shouldCache)
+        {
+            driver = WebDriverUnpackUtility.UnpackWebdriver(locator.SearchContext);
+        }
+
+        internal override object getTarget(IInvocation ignored)
+        {
+            if (cached != null)
+                return cached;
+
+            ITimeouts timeOuts = WebDriverUnpackUtility.UnpackWebdriver(locator.SearchContext).Manage().Timeouts();
+            try
+            {
+                timeOuts.ImplicitlyWait(zeroTimeSpan);
+                var result = waitingForElementList.Until(ReturnWaitingFunction(locator, bys))[0];
+                if (shouldCache && cached == null)
+                    cached = result;
+                return result;
+            }
+            catch (WebDriverTimeoutException e)
+            {
+                throw new NoSuchElementException("Can't locate an element by this strategies: " + bys.ToString());
+            }
+            finally
+            {
+                timeOuts.ImplicitlyWait(waitingTimeSpan);
+            }
+        }
+
+        public override void Intercept(IInvocation invocation)
+        {
+
+            MethodInfo m = invocation.Method;
+            if (typeof(IWrapsDriver).IsAssignableFrom(m.DeclaringType))
+            {
+                invocation.ReturnValue = driver;
+                return;
+            }
+            
+            if (typeof(IWrapsElement).IsAssignableFrom(m.DeclaringType))
+            {
+                var e = (IWebElement) getTarget(invocation);
+                invocation.ReturnValue = e;
+                return;
+            }
+
+            base.Intercept(invocation);
+           
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementInterceptor.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementInterceptor.cs
@@ -13,7 +13,7 @@ namespace OpenQA.Selenium.Appium.PageObjects.Interceptors
     {
         private readonly IWebDriver driver;
 
-        public ElementInterceptor(IEnumerable<By> bys, IElementLocator locator, TimeSpan waitingTimeSpan, bool shouldCache)
+        public ElementInterceptor(IEnumerable<By> bys, IElementLocator locator, TimeOutDuration waitingTimeSpan, bool shouldCache)
             :base(bys, locator, waitingTimeSpan, shouldCache)
         {
             driver = WebDriverUnpackUtility.UnpackWebdriver(locator.SearchContext);
@@ -28,6 +28,7 @@ namespace OpenQA.Selenium.Appium.PageObjects.Interceptors
             try
             {
                 timeOuts.ImplicitlyWait(zeroTimeSpan);
+                waitingForElementList.Timeout = waitingTimeSpan.WaitingDuration;
                 var result = waitingForElementList.Until(ReturnWaitingFunction(locator, bys))[0];
                 if (shouldCache && cached == null)
                     cached = result;
@@ -35,11 +36,14 @@ namespace OpenQA.Selenium.Appium.PageObjects.Interceptors
             }
             catch (WebDriverTimeoutException e)
             {
-                throw new NoSuchElementException("Can't locate an element by this strategies: " + bys.ToString());
+                String bysString = "";
+                foreach (var by in bys)
+                    bysString = bysString + by.ToString() + " ";
+                throw new NoSuchElementException("Couldn't locate an element by these strategies: " + bysString);
             }
             finally
             {
-                timeOuts.ImplicitlyWait(waitingTimeSpan);
+                timeOuts.ImplicitlyWait(waitingTimeSpan.WaitingDuration);
             }
         }
 

--- a/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementListInterceptor.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementListInterceptor.cs
@@ -13,7 +13,7 @@ namespace OpenQA.Selenium.Appium.PageFactory.Interceptors
 {
     class ElementListInterceptor : SearchingInterceptor
     {
-        public ElementListInterceptor(IEnumerable<By> bys, IElementLocator locator, TimeSpan waitingTimeSpan, bool shouldCache)
+        public ElementListInterceptor(IEnumerable<By> bys, IElementLocator locator, TimeOutDuration waitingTimeSpan, bool shouldCache)
             :base(bys, locator, waitingTimeSpan, shouldCache)
         {}
 
@@ -45,6 +45,7 @@ namespace OpenQA.Selenium.Appium.PageFactory.Interceptors
             try
             {
                 timeOuts.ImplicitlyWait(zeroTimeSpan);
+                waitingForElementList.Timeout = waitingTimeSpan.WaitingDuration;                    
                 ReadOnlyCollection<IWebElement> found = waitingForElementList.Until(ReturnWaitingFunction(locator, bys));
                 result = convert(found, genericParameter);
             }
@@ -52,7 +53,7 @@ namespace OpenQA.Selenium.Appium.PageFactory.Interceptors
             {}
             finally
             {
-                timeOuts.ImplicitlyWait(waitingTimeSpan);
+                timeOuts.ImplicitlyWait(waitingTimeSpan.WaitingDuration);
             }
 
             if (shouldCache && cached == null)

--- a/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementListInterceptor.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementListInterceptor.cs
@@ -9,7 +9,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 
-namespace OpenQA.Selenium.Appium.PageFactory.Interceptors
+namespace OpenQA.Selenium.Appium.PageObjects.Interceptors
 {
     class ElementListInterceptor : SearchingInterceptor
     {
@@ -20,7 +20,8 @@ namespace OpenQA.Selenium.Appium.PageFactory.Interceptors
         private IList convert(ReadOnlyCollection<IWebElement> original, Type genericParameter)
         {
             Type generic = typeof(List<>).MakeGenericType(genericParameter);
-            object result = generic.GetConstructor(new Type[] { }).Invoke(new object[] { });
+            object result = GenericsUtility.CraeteInstanceOfSomeGeneric(typeof(List<>), genericParameter, new Type[] { }, 
+                new object[] { });
             IList list = result as IList;
 
             foreach (var elem in original)
@@ -37,9 +38,8 @@ namespace OpenQA.Selenium.Appium.PageFactory.Interceptors
                 return cached;
 
             Type genericParameter = invocation.Method.DeclaringType.GetGenericArguments()[0];
-            IList result = typeof(List<>).MakeGenericType(genericParameter).
-                GetConstructor(new Type[] { }).Invoke(new object[] { }) as IList;
-
+            IList result = GenericsUtility.CraeteInstanceOfSomeGeneric(typeof(List<>), genericParameter, new Type[] { },
+                new object[] { }) as IList;
 
             ITimeouts timeOuts = WebDriverUnpackUtility.UnpackWebdriver(locator.SearchContext).Manage().Timeouts();
             try

--- a/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementListInterceptor.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementListInterceptor.cs
@@ -1,0 +1,64 @@
+﻿using Castle.DynamicProxy;
+using OpenQA.Selenium.Appium.PageObjects;
+using OpenQA.Selenium.Appium.PageObjects.Interceptors;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageFactory.Interceptors
+{
+    class ElementListInterceptor : SearchingInterceptor
+    {
+        public ElementListInterceptor(IEnumerable<By> bys, IElementLocator locator, TimeSpan waitingTimeSpan, bool shouldCache)
+            :base(bys, locator, waitingTimeSpan, shouldCache)
+        {}
+
+        private IList convert(ReadOnlyCollection<IWebElement> original, Type genericParameter)
+        {
+            Type generic = typeof(List<>).MakeGenericType(genericParameter);
+            object result = generic.GetConstructor(new Type[] { }).Invoke(new object[] { });
+            IList list = result as IList;
+
+            foreach (var elem in original)
+            {
+                list.Add(elem);
+            }
+
+            return list;
+        }
+
+        internal override object getTarget(IInvocation invocation)
+        {
+            if (cached != null)
+                return cached;
+
+            Type genericParameter = invocation.Method.DeclaringType.GetGenericArguments()[0];
+            IList result = typeof(List<>).MakeGenericType(genericParameter).
+                GetConstructor(new Type[] { }).Invoke(new object[] { }) as IList;
+
+
+            ITimeouts timeOuts = WebDriverUnpackUtility.UnpackWebdriver(locator.SearchContext).Manage().Timeouts();
+            try
+            {
+                timeOuts.ImplicitlyWait(zeroTimeSpan);
+                ReadOnlyCollection<IWebElement> found = waitingForElementList.Until(ReturnWaitingFunction(locator, bys));
+                result = convert(found, genericParameter);
+            }
+            catch (WebDriverTimeoutException ignored)
+            {}
+            finally
+            {
+                timeOuts.ImplicitlyWait(waitingTimeSpan);
+            }
+
+            if (shouldCache && cached == null)
+                cached = result;
+
+            return result;
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/Interceptors/SearchingInterceptor.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Interceptors/SearchingInterceptor.cs
@@ -53,20 +53,26 @@ namespace OpenQA.Selenium.Appium.PageObjects.Interceptors
         {
             return (IElementLocator) => {
                 List<IWebElement> result = new List<IWebElement>();
-                try
-                {
-                    result.AddRange(locator.LocateElements(bys));
-                }
-                catch (NoSuchElementException e)
-                {
-                    return null;
-                }
-                catch (Exception e)
-                {
-                    if (!IsInvalidSelectorRootCause(e))
-                        throw e;
-                }
 
+                foreach (var by in bys) {
+                    try
+                    {
+                        List<By> listOfSingleBy = new List<By>();
+                        listOfSingleBy.Add(by);
+                        result.AddRange(locator.LocateElements(listOfSingleBy));
+                    }
+                    catch (NoSuchElementException e)
+                    {
+                        continue;
+                    }
+                    catch (Exception e)
+                    {
+                        if (!IsInvalidSelectorRootCause(e))
+                            throw e;
+                        continue;
+                    }
+
+                }
                 if (result.Count > 0)
                     return result.AsReadOnly();
 

--- a/appium-dotnet-driver/Appium/PageObjects/Interceptors/SearchingInterceptor.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Interceptors/SearchingInterceptor.cs
@@ -13,14 +13,14 @@ namespace OpenQA.Selenium.Appium.PageObjects.Interceptors
     internal abstract class SearchingInterceptor: IInterceptor
     {
         protected readonly IElementLocator locator;
-        protected readonly TimeSpan waitingTimeSpan;
+        protected readonly TimeOutDuration waitingTimeSpan;
         protected readonly IEnumerable<By> bys;
         protected readonly DefaultWait<IElementLocator> waitingForElementList;
         protected static readonly TimeSpan zeroTimeSpan = new TimeSpan(0, 0, 0, 0, 0);
         protected readonly bool shouldCache;
         protected object cached;
 
-        public SearchingInterceptor(IEnumerable<By> bys, IElementLocator locator, TimeSpan waitingTimeSpan, bool shouldCache)
+        public SearchingInterceptor(IEnumerable<By> bys, IElementLocator locator, TimeOutDuration waitingTimeSpan, bool shouldCache)
         {
             this.locator = locator;
             this.waitingTimeSpan = waitingTimeSpan;
@@ -57,11 +57,16 @@ namespace OpenQA.Selenium.Appium.PageObjects.Interceptors
                 {
                     result.AddRange(locator.LocateElements(bys));
                 }
+                catch (NoSuchElementException e)
+                {
+                    return null;
+                }
                 catch (Exception e)
                 {
                     if (!IsInvalidSelectorRootCause(e))
                         throw e;
                 }
+
                 if (result.Count > 0)
                     return result.AsReadOnly();
 

--- a/appium-dotnet-driver/Appium/PageObjects/Interceptors/SearchingInterceptor.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Interceptors/SearchingInterceptor.cs
@@ -1,0 +1,80 @@
+﻿using Castle.DynamicProxy;
+using OpenQA.Selenium.Support.PageObjects;
+using OpenQA.Selenium.Support.UI;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects.Interceptors
+{
+    internal abstract class SearchingInterceptor: IInterceptor
+    {
+        protected readonly IElementLocator locator;
+        protected readonly TimeSpan waitingTimeSpan;
+        protected readonly IEnumerable<By> bys;
+        protected readonly DefaultWait<IElementLocator> waitingForElementList;
+        protected static readonly TimeSpan zeroTimeSpan = new TimeSpan(0, 0, 0, 0, 0);
+        protected readonly bool shouldCache;
+        protected object cached;
+
+        public SearchingInterceptor(IEnumerable<By> bys, IElementLocator locator, TimeSpan waitingTimeSpan, bool shouldCache)
+        {
+            this.locator = locator;
+            this.waitingTimeSpan = waitingTimeSpan;
+            this.shouldCache = shouldCache;
+            this.bys = bys;
+            waitingForElementList = new DefaultWait<IElementLocator>(locator);
+            waitingForElementList.IgnoreExceptionTypes(new Type[] { typeof(StaleElementReferenceException)});
+            
+        }
+
+        internal abstract object getTarget(IInvocation invocation);
+
+        private static bool IsInvalidSelectorRootCause(Exception e)
+        {
+            String invalid_selector_pattern = "Invalid locator strategy:";
+            if (e == null)
+                return false;
+
+            string message = e.Message;
+
+            if (!String.IsNullOrWhiteSpace(message) && message.Contains(invalid_selector_pattern))
+                return true;
+
+            return IsInvalidSelectorRootCause(e.InnerException);
+        }
+
+
+        internal static Func<IElementLocator, ReadOnlyCollection<IWebElement>> ReturnWaitingFunction(IElementLocator locator, 
+            IEnumerable<By> bys)
+        {
+            return (IElementLocator) => {
+                List<IWebElement> result = new List<IWebElement>();
+                try
+                {
+                    result.AddRange(locator.LocateElements(bys));
+                }
+                catch (Exception e)
+                {
+                    if (!IsInvalidSelectorRootCause(e))
+                        throw e;
+                }
+                if (result.Count > 0)
+                    return result.AsReadOnly();
+
+                return null;
+            };
+        }
+
+        public virtual void Intercept(IInvocation invocation)
+        {
+            MethodInfo method = invocation.Method;
+            object[] args = invocation.Arguments;
+            object result = method.Invoke(getTarget(invocation), args);
+            invocation.ReturnValue = result;
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/TimeOutDuration.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/TimeOutDuration.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects
+{
+    /// <summary>
+    /// This class stores the time of the waiting for elements.
+    /// It also allows to change this duration in runtime.
+    /// </summary>
+    public class TimeOutDuration
+    {
+        
+        public TimeOutDuration(TimeSpan span)
+        {
+            WaitingDuration = span;
+        }
+
+        public TimeSpan WaitingDuration
+        {
+            set; get;
+        }
+    }
+}

--- a/appium-dotnet-driver/Appium/PageObjects/WebDriverUnpackUtility.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/WebDriverUnpackUtility.cs
@@ -1,0 +1,35 @@
+﻿using OpenQA.Selenium.Internal;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace OpenQA.Selenium.Appium.PageObjects
+{
+    internal class WebDriverUnpackUtility
+    {
+        /// <summary>
+        /// This method returns a wrapped IWebDriver instance 
+        /// </summary>
+        /// <returns></returns>
+        internal static IWebDriver UnpackWebdriver(ISearchContext context)
+        {
+            IWebDriver driver = context as IWebDriver;
+            if (driver != null)
+                return driver;
+
+            // Search context it is not only Webdriver. Webelement is search context
+            // too.
+            // RemoteWebElement and AppiumWebElement implement IWrapsDriver
+            if ((context as IWrapsDriver) != null)
+                return UnpackWebdriver(((IWrapsDriver) context)
+                    .WrappedDriver);
+
+            if ((context as  IWrapsElement) != null)
+                return UnpackWebdriver(((IWrapsElement) context)
+					.WrappedElement);
+
+            return null;
+        }
+    }
+}

--- a/appium-dotnet-driver/appium-dotnet-driver.csproj
+++ b/appium-dotnet-driver/appium-dotnet-driver.csproj
@@ -86,10 +86,13 @@
     <Compile Include="Appium\PageObjects\Attributes\FindsBySelendroidAttribute.cs" />
     <Compile Include="Appium\PageObjects\Attributes\FindsByAndroidUIAutomatorAttribute.cs" />
     <Compile Include="Appium\PageObjects\Attributes\Abstract\FindsByUIAutomatorsAttribute.cs" />
+    <Compile Include="Appium\PageObjects\Attributes\MobileFindsByAllAttribute.cs" />
+    <Compile Include="Appium\PageObjects\Attributes\MobileFindsBySequenceAttribute.cs" />
     <Compile Include="Appium\PageObjects\Attributes\WithTimeSpanAttribute.cs" />
     <Compile Include="Appium\PageObjects\ByFactory.cs" />
     <Compile Include="Appium\PageObjects\ContentMappedBy.cs" />
     <Compile Include="Appium\PageObjects\ContentTypes.cs" />
+    <Compile Include="Appium\PageObjects\GenericsUtility.cs" />
     <Compile Include="Appium\PageObjects\Interceptors\ElementInterceptor.cs" />
     <Compile Include="Appium\PageObjects\Interceptors\ElementListInterceptor.cs" />
     <Compile Include="Appium\PageObjects\Interceptors\SearchingInterceptor.cs" />

--- a/appium-dotnet-driver/appium-dotnet-driver.csproj
+++ b/appium-dotnet-driver/appium-dotnet-driver.csproj
@@ -28,6 +28,9 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core">
+      <HintPath>$(SolutionDir)\packages\Castle.Core.3.3.3\lib\net40-client\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.6.0.8\lib\net40\Newtonsoft.Json.dll</HintPath>
@@ -39,7 +42,7 @@
       <HintPath>$(SolutionDir)\packages\Selenium.WebDriver.2.46.0\lib\net40\WebDriver.dll</HintPath>
     </Reference>
     <Reference Include="WebDriver.Support">
-      <HintPath>..\packages\Selenium.Support.2.46.0\lib\net40\WebDriver.Support.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Selenium.Support.2.46.0\lib\net40\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -51,6 +54,7 @@
     <Compile Include="Appium\Android\Interfaces\IHasNetworkConnection.cs" />
     <Compile Include="Appium\Android\Interfaces\IPushesFiles.cs" />
     <Compile Include="Appium\Android\Interfaces\IStartsActivity.cs" />
+    <Compile Include="Appium\Enums\AutomationName.cs" />
     <Compile Include="Appium\Enums\MobilePlatform.cs" />
     <Compile Include="Appium\Enums\MobileBrowserType.cs" />
     <Compile Include="Appium\Enums\MobileCapabilityType.cs" />
@@ -68,6 +72,7 @@
     <Compile Include="Appium\Interfaces\IDeviceActionShortcuts.cs" />
     <Compile Include="Appium\Interfaces\IInteractsWithApps.cs" />
     <Compile Include="Appium\Interfaces\IInteractsWithFiles.cs" />
+    <Compile Include="Appium\Interfaces\IMobileElement.cs" />
     <Compile Include="Appium\Interfaces\IPerformsTouchActions.cs" />
     <Compile Include="Appium\iOS\Enums\HideKeyboardStrategy.cs" />
     <Compile Include="Appium\iOS\Enums\IOSKeyCode.cs" />
@@ -75,6 +80,20 @@
     <Compile Include="Appium\iOS\IOSDriver.cs" />
     <Compile Include="Appium\iOS\IOSElement.cs" />
     <Compile Include="Appium\CollectionConverterUnility.cs" />
+    <Compile Include="Appium\PageObjects\AppiumPageObjectMemberDecorator.cs" />
+    <Compile Include="Appium\PageObjects\Attributes\FindsByIOSUIAutomationAttribute.cs" />
+    <Compile Include="Appium\PageObjects\Attributes\Abstract\FindsByMobileAttribute.cs" />
+    <Compile Include="Appium\PageObjects\Attributes\FindsBySelendroidAttribute.cs" />
+    <Compile Include="Appium\PageObjects\Attributes\FindsByAndroidUIAutomatorAttribute.cs" />
+    <Compile Include="Appium\PageObjects\Attributes\Abstract\FindsByUIAutomatorsAttribute.cs" />
+    <Compile Include="Appium\PageObjects\Attributes\WithTimeSpanAttribute.cs" />
+    <Compile Include="Appium\PageObjects\ByFactory.cs" />
+    <Compile Include="Appium\PageObjects\ContentMappedBy.cs" />
+    <Compile Include="Appium\PageObjects\ContentTypes.cs" />
+    <Compile Include="Appium\PageObjects\Interceptors\ElementInterceptor.cs" />
+    <Compile Include="Appium\PageObjects\Interceptors\ElementListInterceptor.cs" />
+    <Compile Include="Appium\PageObjects\Interceptors\SearchingInterceptor.cs" />
+    <Compile Include="Appium\PageObjects\WebDriverUnpackUtility.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Appium\AppiumDriver.cs" />
     <Compile Include="Appium\AppiumDriverCommand.cs" />
@@ -96,6 +115,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/appium-dotnet-driver/appium-dotnet-driver.csproj
+++ b/appium-dotnet-driver/appium-dotnet-driver.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Appium\PageObjects\Interceptors\ElementInterceptor.cs" />
     <Compile Include="Appium\PageObjects\Interceptors\ElementListInterceptor.cs" />
     <Compile Include="Appium\PageObjects\Interceptors\SearchingInterceptor.cs" />
+    <Compile Include="Appium\PageObjects\TimeOutDuration.cs" />
     <Compile Include="Appium\PageObjects\WebDriverUnpackUtility.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Appium\AppiumDriver.cs" />

--- a/appium-dotnet-driver/packages.config
+++ b/appium-dotnet-driver/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="3.3.3" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net40" />
   <package id="Selenium.Support" version="2.46.0" targetFramework="net40" />
   <package id="Selenium.WebDriver" version="2.46.0" targetFramework="net40" />

--- a/samples/PageObjectTests/Android/AndroidNativeAppAttributesTest.cs
+++ b/samples/PageObjectTests/Android/AndroidNativeAppAttributesTest.cs
@@ -83,7 +83,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckElementsFoundUsingMultipleLocators()
         {
-            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]
@@ -95,7 +96,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckElementsFoundUsingMultipleLocatorssProperty()
         {
-            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]
@@ -107,7 +109,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckElementsFoundByChainedSearch()
         {
-            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]
@@ -119,7 +122,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckFoundByChainedSearchElementsProperty()
         {
-            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]

--- a/samples/PageObjectTests/Android/AndroidNativeAppAttributesTest.cs
+++ b/samples/PageObjectTests/Android/AndroidNativeAppAttributesTest.cs
@@ -1,0 +1,151 @@
+﻿using Appium.Samples.Helpers;
+using Appium.Samples.PageObjects;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.PageObjects;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjectTests.Android
+{
+    [TestFixture()]
+    public class AndroidNativeAppAttributesTest
+    {
+        private AndroidDriver<AppiumWebElement> driver;
+        private bool allPassed = true;
+        private AndroidPageObjectChecksAppributesForNativeAndroidApp pageObject;
+
+        [SetUp]
+        public void BeforeAll()
+        {
+            DesiredCapabilities capabilities = Env.isSauce() ?
+                Caps.getAndroid18Caps(Apps.get("androidApiDemos")) :
+                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
+            if (Env.isSauce())
+            {
+                capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+                capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+                capabilities.SetCapability("name", "android - complex");
+                capabilities.SetCapability("tags", new string[] { "sample" });
+            }
+            Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
+            driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            TimeSpan timeSpan = new TimeSpan(0, 0, 0, 5, 0);
+            pageObject = new AndroidPageObjectChecksAppributesForNativeAndroidApp();
+            PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
+        }
+
+        [TearDown]
+        public void AfterEach()
+        {
+            allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);
+            if (Env.isSauce())
+                ((IJavaScriptExecutor)driver).ExecuteScript("sauce:job-result=" + (allPassed ? "passed" : "failed"));
+            driver.Quit();
+        }
+
+        [Test()]
+        public void CheckMobileElement()
+        {
+            Assert.NotNull(pageObject.GetMobileElementText());
+        }
+
+        [Test()]
+        public void CheckMobileElements()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMobileElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckMobileElementProperty()
+        {
+            Assert.NotNull(pageObject.GetMobileElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckMobileElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMobileElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundUsingMultipleLocators()
+        {
+            Assert.NotNull(pageObject.GetMultipleFindByElementText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundUsingMultipleLocators()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundUsingMultipleLocatorsProperty()
+        {
+            Assert.NotNull(pageObject.GetMultipleFindByElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundUsingMultipleLocatorssProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundByChainedSearch()
+        {
+            Assert.NotNull(pageObject.GetFoundByChainedSearchElementText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundByChainedSearch()
+        {
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckFoundByChainedSearchElementProperty()
+        {
+            Assert.NotNull(pageObject.GetFoundByChainedSearchElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckFoundByChainedSearchElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAll()
+        {
+            Assert.NotNull(pageObject.GetMatchedToAllLocatorsElementText());
+        }
+
+        [Test()]
+        public void CheckElementsMatchedToAll()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMatchedToAllLocatorsElementSize(), 1);
+            Assert.LessOrEqual(pageObject.GetMatchedToAllLocatorsElementSize(), 13);
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAllProperty()
+        {
+            Assert.NotNull(pageObject.GetMatchedToAllLocatorsElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAllElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMatchedToAllLocatorsElementPropertySize(), 1);
+            Assert.LessOrEqual(pageObject.GetMatchedToAllLocatorsElementPropertySize(), 13);
+        }
+    }
+}

--- a/samples/PageObjectTests/Android/AndroidNativeAppAttributesTest.cs
+++ b/samples/PageObjectTests/Android/AndroidNativeAppAttributesTest.cs
@@ -21,7 +21,7 @@ namespace Appium.Samples.PageObjectTests.Android
         private bool allPassed = true;
         private AndroidPageObjectChecksAttributesForNativeAndroidApp pageObject;
 
-        [SetUp]
+        [TestFixtureSetUp]
         public void BeforeAll()
         {
             DesiredCapabilities capabilities = Env.isSauce() ?
@@ -36,12 +36,12 @@ namespace Appium.Samples.PageObjectTests.Android
             }
             Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
             driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
-            TimeSpan timeSpan = new TimeSpan(0, 0, 0, 5, 0);
+            TimeOutDuration timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));
             pageObject = new AndroidPageObjectChecksAttributesForNativeAndroidApp();
             PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
         }
 
-        [TearDown]
+        [TestFixtureTearDown]
         public void AfterEach()
         {
             allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);

--- a/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix1.cs
+++ b/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix1.cs
@@ -1,0 +1,151 @@
+﻿using Appium.Samples.Helpers;
+using Appium.Samples.PageObjects;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.PageObjects;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjectTests.Android
+{
+    [TestFixture()]
+    public class AndroidTestThatChecksAttributeMix1
+    {
+        private AndroidDriver<AppiumWebElement> driver;
+        private bool allPassed = true;
+        private AndroidPageObjectChecksAttributeMixOnNativeApp1 pageObject;
+
+        [SetUp]
+        public void BeforeAll()
+        {
+            DesiredCapabilities capabilities = Env.isSauce() ?
+                Caps.getAndroid18Caps(Apps.get("androidApiDemos")) :
+                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
+            if (Env.isSauce())
+            {
+                capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+                capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+                capabilities.SetCapability("name", "android - complex");
+                capabilities.SetCapability("tags", new string[] { "sample" });
+            }
+            Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
+            driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            TimeSpan timeSpan = new TimeSpan(0, 0, 0, 5, 0);
+            pageObject = new AndroidPageObjectChecksAttributeMixOnNativeApp1();
+            PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
+        }
+
+        [TearDown]
+        public void AfterEach()
+        {
+            allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);
+            if (Env.isSauce())
+                ((IJavaScriptExecutor)driver).ExecuteScript("sauce:job-result=" + (allPassed ? "passed" : "failed"));
+            driver.Quit();
+        }
+
+        [Test()]
+        public void CheckMobileElement()
+        {
+            Assert.NotNull(pageObject.GetMobileElementText());
+        }
+
+        [Test()]
+        public void CheckMobileElements()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMobileElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckMobileElementProperty()
+        {
+            Assert.NotNull(pageObject.GetMobileElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckMobileElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMobileElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundUsingMultipleLocators()
+        {
+            Assert.NotNull(pageObject.GetMultipleFindByElementText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundUsingMultipleLocators()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundUsingMultipleLocatorsProperty()
+        {
+            Assert.NotNull(pageObject.GetMultipleFindByElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundUsingMultipleLocatorssProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundByChainedSearch()
+        {
+            Assert.NotNull(pageObject.GetFoundByChainedSearchElementText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundByChainedSearch()
+        {
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckFoundByChainedSearchElementProperty()
+        {
+            Assert.NotNull(pageObject.GetFoundByChainedSearchElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckFoundByChainedSearchElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAll()
+        {
+            Assert.NotNull(pageObject.GetMatchedToAllLocatorsElementText());
+        }
+
+        [Test()]
+        public void CheckElementsMatchedToAll()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMatchedToAllLocatorsElementSize(), 1);
+            Assert.LessOrEqual(pageObject.GetMatchedToAllLocatorsElementSize(), 13);
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAllProperty()
+        {
+            Assert.NotNull(pageObject.GetMatchedToAllLocatorsElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAllElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMatchedToAllLocatorsElementPropertySize(), 1);
+            Assert.LessOrEqual(pageObject.GetMatchedToAllLocatorsElementPropertySize(), 13);
+        }
+    }
+}

--- a/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix1.cs
+++ b/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix1.cs
@@ -83,7 +83,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckElementsFoundUsingMultipleLocators()
         {
-            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]
@@ -95,7 +96,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckElementsFoundUsingMultipleLocatorssProperty()
         {
-            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]
@@ -107,7 +109,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckElementsFoundByChainedSearch()
         {
-            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]
@@ -119,7 +122,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckFoundByChainedSearchElementsProperty()
         {
-            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]

--- a/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix1.cs
+++ b/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix1.cs
@@ -21,7 +21,7 @@ namespace Appium.Samples.PageObjectTests.Android
         private bool allPassed = true;
         private AndroidPageObjectChecksAttributeMixOnNativeApp1 pageObject;
 
-        [SetUp]
+        [TestFixtureSetUp]
         public void BeforeAll()
         {
             DesiredCapabilities capabilities = Env.isSauce() ?
@@ -36,12 +36,12 @@ namespace Appium.Samples.PageObjectTests.Android
             }
             Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
             driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
-            TimeSpan timeSpan = new TimeSpan(0, 0, 0, 5, 0);
+            TimeOutDuration timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));
             pageObject = new AndroidPageObjectChecksAttributeMixOnNativeApp1();
             PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
         }
 
-        [TearDown]
+        [TestFixtureTearDown]
         public void AfterEach()
         {
             allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);

--- a/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix2.cs
+++ b/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix2.cs
@@ -83,7 +83,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckElementsFoundUsingMultipleLocators()
         {
-            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]
@@ -95,7 +96,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckElementsFoundUsingMultipleLocatorssProperty()
         {
-            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]
@@ -107,7 +109,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckElementsFoundByChainedSearch()
         {
-            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]
@@ -119,7 +122,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckFoundByChainedSearchElementsProperty()
         {
-            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]

--- a/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix2.cs
+++ b/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix2.cs
@@ -21,7 +21,7 @@ namespace Appium.Samples.PageObjectTests.Android
         private bool allPassed = true;
         private AndroidPageObjectChecksAttributeMixOnNativeApp2 pageObject;
 
-        [SetUp]
+        [TestFixtureSetUp]
         public void BeforeAll()
         {
             DesiredCapabilities capabilities = Env.isSauce() ?
@@ -36,12 +36,12 @@ namespace Appium.Samples.PageObjectTests.Android
             }
             Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
             driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
-            TimeSpan timeSpan = new TimeSpan(0, 0, 0, 5, 0);
+            TimeOutDuration timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));
             pageObject = new AndroidPageObjectChecksAttributeMixOnNativeApp2();
             PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
         }
 
-        [TearDown]
+        [TestFixtureTearDown]
         public void AfterEach()
         {
             allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);

--- a/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix2.cs
+++ b/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix2.cs
@@ -1,0 +1,151 @@
+﻿using Appium.Samples.Helpers;
+using Appium.Samples.PageObjects;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.PageObjects;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjectTests.Android
+{
+    [TestFixture()]
+    public class AndroidTestThatChecksAttributeMix2
+    {
+        private AndroidDriver<AppiumWebElement> driver;
+        private bool allPassed = true;
+        private AndroidPageObjectChecksAttributeMixOnNativeApp2 pageObject;
+
+        [SetUp]
+        public void BeforeAll()
+        {
+            DesiredCapabilities capabilities = Env.isSauce() ?
+                Caps.getAndroid18Caps(Apps.get("androidApiDemos")) :
+                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
+            if (Env.isSauce())
+            {
+                capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+                capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+                capabilities.SetCapability("name", "android - complex");
+                capabilities.SetCapability("tags", new string[] { "sample" });
+            }
+            Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
+            driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            TimeSpan timeSpan = new TimeSpan(0, 0, 0, 5, 0);
+            pageObject = new AndroidPageObjectChecksAttributeMixOnNativeApp2();
+            PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
+        }
+
+        [TearDown]
+        public void AfterEach()
+        {
+            allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);
+            if (Env.isSauce())
+                ((IJavaScriptExecutor)driver).ExecuteScript("sauce:job-result=" + (allPassed ? "passed" : "failed"));
+            driver.Quit();
+        }
+
+        [Test()]
+        public void CheckMobileElement()
+        {
+            Assert.NotNull(pageObject.GetMobileElementText());
+        }
+
+        [Test()]
+        public void CheckMobileElements()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMobileElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckMobileElementProperty()
+        {
+            Assert.NotNull(pageObject.GetMobileElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckMobileElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMobileElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundUsingMultipleLocators()
+        {
+            Assert.NotNull(pageObject.GetMultipleFindByElementText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundUsingMultipleLocators()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundUsingMultipleLocatorsProperty()
+        {
+            Assert.NotNull(pageObject.GetMultipleFindByElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundUsingMultipleLocatorssProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundByChainedSearch()
+        {
+            Assert.NotNull(pageObject.GetFoundByChainedSearchElementText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundByChainedSearch()
+        {
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckFoundByChainedSearchElementProperty()
+        {
+            Assert.NotNull(pageObject.GetFoundByChainedSearchElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckFoundByChainedSearchElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAll()
+        {
+            Assert.NotNull(pageObject.GetMatchedToAllLocatorsElementText());
+        }
+
+        [Test()]
+        public void CheckElementsMatchedToAll()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMatchedToAllLocatorsElementSize(), 1);
+            Assert.LessOrEqual(pageObject.GetMatchedToAllLocatorsElementSize(), 13);
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAllProperty()
+        {
+            Assert.NotNull(pageObject.GetMatchedToAllLocatorsElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAllElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMatchedToAllLocatorsElementPropertySize(), 1);
+            Assert.LessOrEqual(pageObject.GetMatchedToAllLocatorsElementPropertySize(), 13);
+        }
+    }
+}

--- a/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix3SelendroidMode.cs
+++ b/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix3SelendroidMode.cs
@@ -21,7 +21,7 @@ namespace Appium.Samples.PageObjectTests.Android
         private bool allPassed = true;
         private AndroidPageObjectChecksSelendroidModeOnNativeApp pageObject;
 
-        [SetUp]
+        [TestFixtureSetUp]
         public void BeforeAll()
         {
             DesiredCapabilities capabilities =
@@ -35,12 +35,12 @@ namespace Appium.Samples.PageObjectTests.Android
             }
             Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
             driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
-            TimeSpan timeSpan = new TimeSpan(0, 0, 0, 15, 0);
+            TimeOutDuration timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));
             pageObject = new AndroidPageObjectChecksSelendroidModeOnNativeApp();
             PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
         }
 
-        [TearDown]
+        [TestFixtureTearDown]
         public void AfterEach()
         {
             allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);

--- a/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix3SelendroidMode.cs
+++ b/samples/PageObjectTests/Android/AndroidTestThatChecksAttributeMix3SelendroidMode.cs
@@ -1,0 +1,150 @@
+﻿using Appium.Samples.Helpers;
+using Appium.Samples.PageObjects;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.PageObjects;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjectTests.Android
+{
+    [TestFixture()]
+    public class AndroidTestThatChecksAttributeMix3SelendroidMode
+    {
+        private AndroidDriver<AppiumWebElement> driver;
+        private bool allPassed = true;
+        private AndroidPageObjectChecksSelendroidModeOnNativeApp pageObject;
+
+        [SetUp]
+        public void BeforeAll()
+        {
+            DesiredCapabilities capabilities =
+                Caps.getSelendroid16Caps(Apps.get("selendroidTestApp"));
+            if (Env.isSauce())
+            {
+                capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+                capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+                capabilities.SetCapability("name", "android - complex");
+                capabilities.SetCapability("tags", new string[] { "sample" });
+            }
+            Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
+            driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            TimeSpan timeSpan = new TimeSpan(0, 0, 0, 15, 0);
+            pageObject = new AndroidPageObjectChecksSelendroidModeOnNativeApp();
+            PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
+        }
+
+        [TearDown]
+        public void AfterEach()
+        {
+            allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);
+            if (Env.isSauce())
+                ((IJavaScriptExecutor)driver).ExecuteScript("sauce:job-result=" + (allPassed ? "passed" : "failed"));
+            driver.Quit();
+        }
+
+         [Test()]
+        public void CheckMobileElement()
+        {
+            Assert.NotNull(pageObject.GetMobileElementText());
+        }
+
+        [Test()]
+        public void CheckMobileElements()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMobileElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckMobileElementProperty()
+        {
+            Assert.NotNull(pageObject.GetMobileElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckMobileElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMobileElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundUsingMultipleLocators()
+        {
+            Assert.NotNull(pageObject.GetMultipleFindByElementText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundUsingMultipleLocators()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundUsingMultipleLocatorsProperty()
+        {
+            Assert.NotNull(pageObject.GetMultipleFindByElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundUsingMultipleLocatorssProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundByChainedSearch()
+        {
+            Assert.NotNull(pageObject.GetFoundByChainedSearchElementText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundByChainedSearch()
+        {
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckFoundByChainedSearchElementProperty()
+        {
+            Assert.NotNull(pageObject.GetFoundByChainedSearchElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckFoundByChainedSearchElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAll()
+        {
+            Assert.NotNull(pageObject.GetMatchedToAllLocatorsElementText());
+        }
+
+        [Test()]
+        public void CheckElementsMatchedToAll()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMatchedToAllLocatorsElementSize(), 1);
+            Assert.LessOrEqual(pageObject.GetMatchedToAllLocatorsElementSize(), 2);
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAllProperty()
+        {
+            Assert.NotNull(pageObject.GetMatchedToAllLocatorsElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAllElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMatchedToAllLocatorsElementPropertySize(), 1);
+            Assert.LessOrEqual(pageObject.GetMatchedToAllLocatorsElementPropertySize(), 2);
+        }
+    }
+}

--- a/samples/PageObjectTests/Android/AndroidWebViewTest.cs
+++ b/samples/PageObjectTests/Android/AndroidWebViewTest.cs
@@ -1,0 +1,78 @@
+﻿using Appium.Samples.Helpers;
+using Appium.Samples.PageObjects;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.PageObjects;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+
+namespace Appium.Samples.PageObjectTests.Android
+{
+    public class AndroidWebViewTest
+    {
+        private AndroidDriver<AppiumWebElement> driver;
+        private bool allPassed = true;
+        private AndroidWebView pageObject;
+
+        [TestFixtureSetUp]
+        public void BeforeAll()
+        {
+            DesiredCapabilities capabilities = Env.isSauce() ?
+                Caps.getAndroid18Caps(Apps.get("selendroidTestApp")) :
+                Caps.getAndroid19Caps(Apps.get("selendroidTestApp"));
+            if (Env.isSauce())
+            {
+                capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+                capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+                capabilities.SetCapability("name", "android - webview");
+                capabilities.SetCapability("tags", new string[] { "sample" });
+            }
+            Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
+            driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            TimeOutDuration timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));
+            pageObject = new AndroidWebView();
+            PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
+            driver.StartActivity("io.selendroid.testapp", ".WebViewActivity");
+        }
+
+        [TestFixtureTearDown]
+        public void AfterEach()
+        {
+            allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);
+            if (Env.isSauce())
+                ((IJavaScriptExecutor)driver).ExecuteScript("sauce:job-result=" + (allPassed ? "passed" : "failed"));
+            driver.Quit();
+        }
+
+        [Test()]
+        public void WebViewTestCase()
+        {
+            Thread.Sleep(5000);
+            if (!Env.isSauce())
+            {
+                var contexts = driver.Contexts;
+                string webviewContext = null;
+                for (int i = 0; i < contexts.Count; i++)
+                {
+                    Console.WriteLine(contexts[i]);
+                    if (contexts[i].Contains("WEBVIEW"))
+                    {
+                        webviewContext = contexts[i];
+                    }
+                }
+                Assert.IsNotNull(webviewContext);
+                driver.Context = webviewContext;
+
+                pageObject.SendMeYourName();                
+            }
+        }
+
+    }
+}

--- a/samples/PageObjectTests/Android/SeleniumAttributesCompatipilityTest.cs
+++ b/samples/PageObjectTests/Android/SeleniumAttributesCompatipilityTest.cs
@@ -107,7 +107,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckElementsFoundUsingMultipleLocators()
         {
-            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]
@@ -119,7 +120,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckElementsFoundUsingMultipleLocatorssProperty()
         {
-            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]
@@ -131,7 +133,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckElementsFoundByChainedSearch()
         {
-            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]
@@ -143,7 +146,8 @@ namespace Appium.Samples.PageObjectTests.Android
         [Test()]
         public void CheckFoundByChainedSearchElementsProperty()
         {
-            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 1);
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 10);
+            Assert.LessOrEqual(pageObject.GetMultipleFindByElementSize(), 14);
         }
 
         [Test()]

--- a/samples/PageObjectTests/Android/SeleniumAttributesCompatipilityTest.cs
+++ b/samples/PageObjectTests/Android/SeleniumAttributesCompatipilityTest.cs
@@ -1,0 +1,175 @@
+﻿using Appium.Samples.Helpers;
+using Appium.Samples.PageObjects;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.PageObjects;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjectTests.Android
+{
+    [TestFixture()]
+    public class SeleniumAttributesCompatipilityTest
+    {
+        private AndroidDriver<AppiumWebElement> driver;
+        private bool allPassed = true;
+        private AndroidPageObjectChecksSeleniumFindsByCompatibility pageObject;
+
+        [SetUp]
+        public void BeforeAll()
+        {
+            DesiredCapabilities capabilities = Env.isSauce() ?
+                Caps.getAndroid18Caps(Apps.get("androidApiDemos")) :
+                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
+            if (Env.isSauce())
+            {
+                capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+                capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+                capabilities.SetCapability("name", "android - complex");
+                capabilities.SetCapability("tags", new string[] { "sample" });
+            }
+            Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
+            driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            TimeSpan timeSpan = new TimeSpan(0, 0, 0, 5, 0);
+            pageObject = new AndroidPageObjectChecksSeleniumFindsByCompatibility();
+            PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
+        }
+
+        [TearDown]
+        public void AfterEach()
+        {
+            allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);
+            if (Env.isSauce())
+                ((IJavaScriptExecutor)driver).ExecuteScript("sauce:job-result=" + (allPassed ? "passed" : "failed"));
+            driver.Quit();
+        }
+
+        [Test()]
+        public void CheckElement()
+        {
+            Assert.NotNull(pageObject.GetElementText());
+        }
+
+        [Test()]
+        public void CheckElements()
+        {
+            Assert.GreaterOrEqual(pageObject.GetElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementProperty()
+        {
+            Assert.NotNull(pageObject.GetElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckMobileElement()
+        {
+            Assert.NotNull(pageObject.GetMobileElementText());
+        }
+
+        [Test()]
+        public void CheckMobileElements()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMobileElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckMobileElementProperty()
+        {
+            Assert.NotNull(pageObject.GetMobileElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckMobileElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMobileElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundUsingMultipleLocators()
+        {
+            Assert.NotNull(pageObject.GetMultipleFindByElementText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundUsingMultipleLocators()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundUsingMultipleLocatorsProperty()
+        {
+            Assert.NotNull(pageObject.GetMultipleFindByElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundUsingMultipleLocatorssProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementFoundByChainedSearch()
+        {
+            Assert.NotNull(pageObject.GetFoundByChainedSearchElementText());
+        }
+
+        [Test()]
+        public void CheckElementsFoundByChainedSearch()
+        {
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 1);
+        }
+
+        [Test()]
+        public void CheckFoundByChainedSearchElementProperty()
+        {
+            Assert.NotNull(pageObject.GetFoundByChainedSearchElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckFoundByChainedSearchElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 1);
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAll()
+        {
+            Assert.NotNull(pageObject.GetMatchedToAllLocatorsElementText());
+        }
+
+        [Test()]
+        public void CheckElementsMatchedToAll()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMatchedToAllLocatorsElementSize(), 1);
+            Assert.LessOrEqual(pageObject.GetMatchedToAllLocatorsElementSize(), 13);
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAllProperty()
+        {
+            Assert.NotNull(pageObject.GetMatchedToAllLocatorsElementPropertyText());
+        }
+
+        [Test()]
+        public void CheckElementMatchedToAllElementsProperty()
+        {
+            Assert.GreaterOrEqual(pageObject.GetMatchedToAllLocatorsElementPropertySize(), 1);
+            Assert.LessOrEqual(pageObject.GetMatchedToAllLocatorsElementPropertySize(), 13);
+        }
+    }
+}

--- a/samples/PageObjectTests/Android/SeleniumAttributesCompatipilityTest.cs
+++ b/samples/PageObjectTests/Android/SeleniumAttributesCompatipilityTest.cs
@@ -21,7 +21,7 @@ namespace Appium.Samples.PageObjectTests.Android
         private bool allPassed = true;
         private AndroidPageObjectChecksSeleniumFindsByCompatibility pageObject;
 
-        [SetUp]
+        [TestFixtureSetUp]
         public void BeforeAll()
         {
             DesiredCapabilities capabilities = Env.isSauce() ?
@@ -36,12 +36,12 @@ namespace Appium.Samples.PageObjectTests.Android
             }
             Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
             driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
-            TimeSpan timeSpan = new TimeSpan(0, 0, 0, 5, 0);
+            TimeOutDuration timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));
             pageObject = new AndroidPageObjectChecksSeleniumFindsByCompatibility();
             PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
         }
 
-        [TearDown]
+        [TestFixtureTearDown]
         public void AfterEach()
         {
             allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);

--- a/samples/PageObjectTests/DesktopBrowserCompatibility/DesctopBrowserCompatibilityTest.cs
+++ b/samples/PageObjectTests/DesktopBrowserCompatibility/DesctopBrowserCompatibilityTest.cs
@@ -70,12 +70,28 @@ namespace Appium.Samples.PageObjectTests.DesktopBrowserCompatibility
             Assert.GreaterOrEqual(10, links.Links.Count);
             Assert.AreNotEqual(ires, null);
             Assert.AreNotEqual(((IWrapsElement) ires).WrappedElement, null);
+
+            //this checking notices that element is found once and cached
+            Assert.AreEqual(((IWrapsElement)ires).WrappedElement.GetHashCode(), ((IWrapsElement)ires).WrappedElement.GetHashCode());
+
+            //this checking notices that element are found once and cached
+            IList<IWebElement> cachedList = links.Links;
+            Assert.GreaterOrEqual(10, cachedList.Count);
+            Assert.AreEqual(links.Links.Count, cachedList.Count);
+
+            int i = 0;
+            foreach (var element in cachedList)
+            {
+                Assert.AreEqual(element.GetHashCode(), links.Links[i].GetHashCode());
+                i++;
+            }
         }
     }
 
 
     class FoundLinks
     {
+        [CacheLookup]
         [FindsBySequence]
         [FindsBy(How = How.ClassName, Using = "r", Priority = 1)]
         [FindsBy(How = How.TagName, Using = "a", Priority = 2)]

--- a/samples/PageObjectTests/DesktopBrowserCompatibility/DesctopBrowserCompatibilityTest.cs
+++ b/samples/PageObjectTests/DesktopBrowserCompatibility/DesctopBrowserCompatibilityTest.cs
@@ -1,0 +1,86 @@
+﻿using Appium.Samples.Helpers;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.PageObjects;
+using OpenQA.Selenium.Appium.PageObjects.Attributes;
+using OpenQA.Selenium.Firefox;
+using OpenQA.Selenium.Internal;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjectTests.DesktopBrowserCompatibility
+{
+    [TestFixture()]
+    public class DesctopBrowserCompatibilityTest
+    {
+        private IWebDriver driver;
+        private bool allPassed = true;
+        private FoundLinks links;
+
+        [FindsBy(How = How.Name, Using = "q")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/someId\")")]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        private IWebElement searchTextField;
+
+        [FindsByAndroidUIAutomator(ClassName = "someClass")]
+        [FindsByIOSUIAutomation(IosUIAutomation = "//selector[1]")]
+        [FindsBy(How = How.Name, Using = "btnG")]
+        private IWebElement searchButton;
+
+        [CacheLookup] //this element will be found once
+        private IWebElement ires; //Should be found by ID or Name equal "ires"
+
+        private IList<IWebElement> btnG; //these elements are found by name="btnG"
+
+        [TestFixtureSetUp]
+        public void BeforeAll()
+        {
+            TimeOutDuration timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));
+            driver = new FirefoxDriver();
+            driver.Url = "https://www.google.com";
+            AppiumPageObjectMemberDecorator decorator = new AppiumPageObjectMemberDecorator(timeSpan);
+            PageFactory.InitElements(driver, this, decorator);
+            links = new FoundLinks();
+            PageFactory.InitElements(ires, links, decorator);
+        }
+
+        [TestFixtureTearDown]
+        public void AfterAll()
+        {
+            try
+            {
+                if (Env.isSauce())
+                    ((IJavaScriptExecutor)driver).ExecuteScript("sauce:job-result=" + (allPassed ? "passed" : "failed"));
+            }
+            finally
+            {
+                driver.Quit();
+            }
+        }
+
+        [Test()]
+        public void GoogleSearching()
+        {
+            searchTextField.SendKeys("Hello Appium!");
+            Assert.GreaterOrEqual(1, btnG.Count);
+            searchButton.Click();
+            Assert.GreaterOrEqual(10, links.Links.Count);
+            Assert.AreNotEqual(ires, null);
+            Assert.AreNotEqual(((IWrapsElement) ires).WrappedElement, null);
+        }
+    }
+
+
+    class FoundLinks
+    {
+        [FindsBySequence]
+        [FindsBy(How = How.ClassName, Using = "r", Priority = 1)]
+        [FindsBy(How = How.TagName, Using = "a", Priority = 2)]
+        public IList<IWebElement> Links { set;  get; }
+
+        
+    }
+}

--- a/samples/PageObjectTests/IOS/IOSNativeAppAttributesTest.cs
+++ b/samples/PageObjectTests/IOS/IOSNativeAppAttributesTest.cs
@@ -21,7 +21,7 @@ namespace Appium.Samples.PageObjectTests.IOS
         private bool allPassed = true;
         private IOSPageObjectChecksAttributesForNativeIOSApp pageObject;
 
-        [SetUp]
+        [TestFixtureSetUp]
         public void BeforeAll()
         {
             DesiredCapabilities capabilities = Caps.getIos71Caps(Apps.get("iosTestApp"));
@@ -33,13 +33,13 @@ namespace Appium.Samples.PageObjectTests.IOS
                 capabilities.SetCapability("tags", new string[] { "sample" });
             }
             Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new IOSDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
-            TimeSpan timeSpan = new TimeSpan(0, 0, 0, 5, 0);
+            driver = new IOSDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            TimeOutDuration timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));
             pageObject = new IOSPageObjectChecksAttributesForNativeIOSApp();
             PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
         }
 
-        [TearDown]
+        [TestFixtureTearDown]
         public void AfterEach()
         {
             allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);

--- a/samples/PageObjectTests/IOS/IOSNativeAppAttributesTest.cs
+++ b/samples/PageObjectTests/IOS/IOSNativeAppAttributesTest.cs
@@ -3,7 +3,7 @@ using Appium.Samples.PageObjects;
 using NUnit.Framework;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
-using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.iOS;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Remote;
 using OpenQA.Selenium.Support.PageObjects;
@@ -12,32 +12,30 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace Appium.Samples.PageObjectTests.Android
+namespace Appium.Samples.PageObjectTests.IOS
 {
     [TestFixture()]
-    public class AndroidNativeAppAttributesTest
+    public class IOSNativeAppAttributesTest
     {
-        private AndroidDriver<AppiumWebElement> driver;
+        private IOSDriver<AppiumWebElement> driver;
         private bool allPassed = true;
-        private AndroidPageObjectChecksAttributesForNativeAndroidApp pageObject;
+        private IOSPageObjectChecksAttributesForNativeIOSApp pageObject;
 
         [SetUp]
         public void BeforeAll()
         {
-            DesiredCapabilities capabilities = Env.isSauce() ?
-                Caps.getAndroid18Caps(Apps.get("androidApiDemos")) :
-                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
+            DesiredCapabilities capabilities = Caps.getIos71Caps(Apps.get("iosTestApp"));
             if (Env.isSauce())
             {
                 capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
                 capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
-                capabilities.SetCapability("name", "android - complex");
+                capabilities.SetCapability("name", "ios - actions");
                 capabilities.SetCapability("tags", new string[] { "sample" });
             }
             Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            driver = new IOSDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
             TimeSpan timeSpan = new TimeSpan(0, 0, 0, 5, 0);
-            pageObject = new AndroidPageObjectChecksAttributesForNativeAndroidApp();
+            pageObject = new IOSPageObjectChecksAttributesForNativeIOSApp();
             PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
         }
 
@@ -96,30 +94,6 @@ namespace Appium.Samples.PageObjectTests.Android
         public void CheckElementsFoundUsingMultipleLocatorssProperty()
         {
             Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 1);
-        }
-
-        [Test()]
-        public void CheckElementFoundByChainedSearch()
-        {
-            Assert.NotNull(pageObject.GetFoundByChainedSearchElementText());
-        }
-
-        [Test()]
-        public void CheckElementsFoundByChainedSearch()
-        {
-            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 1);
-        }
-
-        [Test()]
-        public void CheckFoundByChainedSearchElementProperty()
-        {
-            Assert.NotNull(pageObject.GetFoundByChainedSearchElementPropertyText());
-        }
-
-        [Test()]
-        public void CheckFoundByChainedSearchElementsProperty()
-        {
-            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 1);
         }
 
         [Test()]

--- a/samples/PageObjectTests/IOS/IOSTestThatChecksAttributeMix.cs
+++ b/samples/PageObjectTests/IOS/IOSTestThatChecksAttributeMix.cs
@@ -3,7 +3,7 @@ using Appium.Samples.PageObjects;
 using NUnit.Framework;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
-using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.iOS;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Remote;
 using OpenQA.Selenium.Support.PageObjects;
@@ -12,32 +12,30 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-namespace Appium.Samples.PageObjectTests.Android
+namespace Appium.Samples.PageObjectTests.IOS
 {
     [TestFixture()]
-    public class AndroidNativeAppAttributesTest
+    public class IOSTestThatChecksAttributeMix
     {
-        private AndroidDriver<AppiumWebElement> driver;
+        private IOSDriver<AppiumWebElement> driver;
         private bool allPassed = true;
-        private AndroidPageObjectChecksAttributesForNativeAndroidApp pageObject;
+        private IOSPageObjectChecksAttributeMixOnNativeApp pageObject;
 
         [SetUp]
         public void BeforeAll()
         {
-            DesiredCapabilities capabilities = Env.isSauce() ?
-                Caps.getAndroid18Caps(Apps.get("androidApiDemos")) :
-                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
+            DesiredCapabilities capabilities = Caps.getIos71Caps(Apps.get("iosTestApp"));
             if (Env.isSauce())
             {
                 capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
                 capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
-                capabilities.SetCapability("name", "android - complex");
+                capabilities.SetCapability("name", "ios - actions");
                 capabilities.SetCapability("tags", new string[] { "sample" });
             }
             Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            driver = new IOSDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
             TimeSpan timeSpan = new TimeSpan(0, 0, 0, 5, 0);
-            pageObject = new AndroidPageObjectChecksAttributesForNativeAndroidApp();
+            pageObject = new IOSPageObjectChecksAttributeMixOnNativeApp();
             PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
         }
 
@@ -96,30 +94,6 @@ namespace Appium.Samples.PageObjectTests.Android
         public void CheckElementsFoundUsingMultipleLocatorssProperty()
         {
             Assert.GreaterOrEqual(pageObject.GetMultipleFindByElementPropertySize(), 1);
-        }
-
-        [Test()]
-        public void CheckElementFoundByChainedSearch()
-        {
-            Assert.NotNull(pageObject.GetFoundByChainedSearchElementText());
-        }
-
-        [Test()]
-        public void CheckElementsFoundByChainedSearch()
-        {
-            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementSize(), 1);
-        }
-
-        [Test()]
-        public void CheckFoundByChainedSearchElementProperty()
-        {
-            Assert.NotNull(pageObject.GetFoundByChainedSearchElementPropertyText());
-        }
-
-        [Test()]
-        public void CheckFoundByChainedSearchElementsProperty()
-        {
-            Assert.GreaterOrEqual(pageObject.GetFoundByChainedSearchElementPropertySize(), 1);
         }
 
         [Test()]

--- a/samples/PageObjectTests/IOS/IOSTestThatChecksAttributeMix.cs
+++ b/samples/PageObjectTests/IOS/IOSTestThatChecksAttributeMix.cs
@@ -21,7 +21,7 @@ namespace Appium.Samples.PageObjectTests.IOS
         private bool allPassed = true;
         private IOSPageObjectChecksAttributeMixOnNativeApp pageObject;
 
-        [SetUp]
+        [TestFixtureSetUp]
         public void BeforeAll()
         {
             DesiredCapabilities capabilities = Caps.getIos71Caps(Apps.get("iosTestApp"));
@@ -33,13 +33,13 @@ namespace Appium.Samples.PageObjectTests.IOS
                 capabilities.SetCapability("tags", new string[] { "sample" });
             }
             Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
-            driver = new IOSDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);	
-            TimeSpan timeSpan = new TimeSpan(0, 0, 0, 5, 0);
+            driver = new IOSDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            TimeOutDuration timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));
             pageObject = new IOSPageObjectChecksAttributeMixOnNativeApp();
             PageFactory.InitElements(driver, pageObject, new AppiumPageObjectMemberDecorator(timeSpan));
         }
 
-        [TearDown]
+        [TestFixtureTearDown]
         public void AfterEach()
         {
             allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);

--- a/samples/PageObjectTests/NegativeTests/NoSuchElementTestOnAndroid.cs
+++ b/samples/PageObjectTests/NegativeTests/NoSuchElementTestOnAndroid.cs
@@ -1,0 +1,106 @@
+﻿using Appium.Samples.Helpers;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.PageObjects;
+using OpenQA.Selenium.Appium.PageObjects.Attributes;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjectTests.NegativeTests
+{
+    public class NoSuchElementTestOnAndroid
+    {
+        private AndroidDriver<AppiumWebElement> driver;
+        private bool allPassed = true;
+
+        [FindsBy(How = How.ClassName, Using = "FakeHtmlClass")]
+        [FindsByIOSUIAutomation(Accessibility = "FakeAccebility")]
+        private IWebElement inconsistentElement1;
+
+        [FindsBy(How = How.ClassName, Using = "FakeHtmlClass")]
+        [FindsByIOSUIAutomation(Accessibility = "FakeAccebility")]
+        private IList<IWebElement> inconsistentElements1;
+
+        [FindsBy(How = How.CssSelector, Using = "fake.css")]
+        [FindsByIOSUIAutomation(Accessibility = "FakeAccebility")]
+        private IWebElement inconsistentElement2;
+
+        [FindsBy(How = How.CssSelector, Using = "fake.css")]
+        [FindsByIOSUIAutomation(Accessibility = "FakeAccebility")]
+        private IList<IWebElement> inconsistentElements2;
+
+        [TestFixtureSetUp]
+        public void BeforeAll()
+        {
+            DesiredCapabilities capabilities = Env.isSauce() ?
+                Caps.getAndroid18Caps(Apps.get("androidApiDemos")) :
+                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
+            if (Env.isSauce())
+            {
+                capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+                capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+                capabilities.SetCapability("name", "android - complex");
+                capabilities.SetCapability("tags", new string[] { "sample" });
+            }
+            Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.localURI;
+            driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            TimeOutDuration timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));
+            PageFactory.InitElements(driver, this, new AppiumPageObjectMemberDecorator(timeSpan));
+        }
+
+        [TestFixtureTearDown]
+        public void AfterEach()
+        {
+            allPassed = allPassed && (TestContext.CurrentContext.Result.State == TestState.Success);
+            if (Env.isSauce())
+                ((IJavaScriptExecutor)driver).ExecuteScript("sauce:job-result=" + (allPassed ? "passed" : "failed"));
+            driver.Quit();
+        }
+
+        [Test()]
+        public void WhenThereIsNoConsistentLocatorForCurrentPlatform_NoSuchElementExceptionShouldBeThrown()
+        {
+            try
+            {
+                string text = inconsistentElement1.Text;
+            }
+            catch (NoSuchElementException e)
+            {
+                //it is expected
+                return;
+            }
+        }
+
+        [Test()]
+        public void WhenThereIsNoConsistentLocatorForCurrentPlatform_EmptyListShouldBeFound()
+        {
+            Assert.AreEqual(0, inconsistentElements1.Count);
+        }
+
+        [Test()]
+        public void WhenDefaultLocatorIsInvalidForCurrentPlatform_NoSuchElementExceptionShouldBeThrown()
+        {
+            try
+            {
+                string text = inconsistentElement2.Text;
+            }
+            catch (NoSuchElementException e)
+            {
+                //it is expected
+                return;
+            }
+        }
+
+        [Test()]
+        public void WhenDefaultLocatorIsInvalidForCurrentPlatform_EmptyListShouldBeFound()
+        {
+            Assert.AreEqual(0, inconsistentElements2.Count);
+        }
+    }
+}

--- a/samples/PageObjectTests/TimeOutManagement/TimeOutManagementTest.cs
+++ b/samples/PageObjectTests/TimeOutManagement/TimeOutManagementTest.cs
@@ -1,0 +1,95 @@
+﻿using Appium.Samples.Helpers;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.PageObjects;
+using OpenQA.Selenium.Appium.PageObjects.Attributes;
+using OpenQA.Selenium.Firefox;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+
+
+namespace Appium.Samples.PageObjectTests.TimeOutManagement
+{
+    public class TimeOutManagementTest
+    {
+        private IWebDriver driver;
+        private bool allPassed = true;
+        private TimeOutDuration duration;
+
+        [FindsBy(How = How.ClassName, Using = "FakeClass", Priority = 1)]
+        [FindsBy(How = How.TagName, Using = "FakeTag", Priority = 2)]
+        private IList<IWebElement> stubElements;
+
+        [WithTimeSpan(Seconds = 15)]
+        [FindsBy(How = How.ClassName, Using = "FakeClass", Priority = 1)]
+        [FindsBy(How = How.TagName, Using = "FakeTag", Priority = 2)]
+        private IList<IWebElement> stubElements2;
+
+        private readonly TimeSpan accepableTimeDelta = new TimeSpan(0, 0, 2); //Another procceses/environment issues can interfere 
+        //the checking
+
+        [SetUp]
+        public void Before()
+        {   
+            if (driver == null)
+            {
+                driver = new FirefoxDriver();
+            }
+            duration = new TimeOutDuration(new TimeSpan(0, 0, 5));
+            PageFactory.InitElements(driver, this, new AppiumPageObjectMemberDecorator(duration));
+        }
+
+        [TestFixtureTearDown]
+        public void AfterAll()
+        {
+            try
+            {
+                if (Env.isSauce())
+                    ((IJavaScriptExecutor)driver).ExecuteScript("sauce:job-result=" + (allPassed ? "passed" : "failed"));
+            }
+            finally
+            {
+                driver.Quit();
+            }
+        }
+
+        private bool IsInTime(TimeSpan span, IList<IWebElement> list)
+        {
+            DateTime start = DateTime.Now;
+            TimeSpan checkingSpan = new TimeSpan(span.Hours, span.Seconds + accepableTimeDelta.Seconds, span.Milliseconds);
+            DateTime deadline = DateTime.Now.Add(checkingSpan);
+            var size = list.Count;
+            DateTime now = DateTime.Now;
+
+            return (now <= deadline & start.Add(span) <= now);
+        }
+
+
+
+        [Test()]
+        public void CheckAbilityToChangeWaitingTime()
+        {
+            Assert.AreEqual(true, IsInTime(new TimeSpan(0, 0, 5), stubElements));
+            TimeSpan newTime = new TimeSpan(0, 0, 0, 20, 500);
+            duration.WaitingDuration = newTime;
+            Assert.AreEqual(true, IsInTime(newTime, stubElements));
+            newTime = new TimeSpan(0, 0, 0, 2, 0);
+            duration.WaitingDuration = newTime;
+            Assert.AreEqual(true, IsInTime(newTime, stubElements));
+        }
+
+        [Test()]
+        public void CheckWaitingTimeIfMemberHasAttribute_WithTimeSpan()
+        {
+            TimeSpan fifteenSeconds = new TimeSpan(0, 0, 0, 15, 0); ;
+            Assert.AreEqual(true, IsInTime(new TimeSpan(0, 0, 5), stubElements));
+            Assert.AreEqual(true, IsInTime(fifteenSeconds, stubElements2));
+
+            TimeSpan newTime = new TimeSpan(0, 0, 0, 2, 0);
+            duration.WaitingDuration = newTime;
+            Assert.AreEqual(true, IsInTime(newTime, stubElements));
+            Assert.AreEqual(true, IsInTime(fifteenSeconds, stubElements2));
+        }
+    }
+}

--- a/samples/PageObjects/AndroidPageObjectChecksAppributesForNativeAndroidApp.cs
+++ b/samples/PageObjects/AndroidPageObjectChecksAppributesForNativeAndroidApp.cs
@@ -1,0 +1,285 @@
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium.Appium.PageObjects.Attributes;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjects
+{
+    public class AndroidPageObjectChecksAppributesForNativeAndroidApp
+    {
+        /////////////////////////////////////////////////////////////////
+        private object testMobileElementProperty;
+        private object testMobileElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IMobileElement<AndroidElement> testMobileElement;
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IList<AndroidElement> testMobileElements;
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IMobileElement<AndroidElement> TestMobileElement
+        {
+            set
+            {
+                testMobileElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) testMobileElementProperty;
+            }
+        }
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IList<AndroidElement> TestMobileElements
+        {
+            set
+            {
+                testMobileElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) testMobileElementsProperty;
+            }
+        }
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> testMultipleElement;
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> testMultipleElements;
+
+
+        /////////////////////////////////////////////////////////////////
+        private object testMultipleFindByElementProperty;
+        private object testMultipleFindByElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> TestMultipleFindByElementProperty
+        {
+            set
+            {
+                testMultipleFindByElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) testMultipleFindByElementProperty;
+            }
+        }
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> MultipleFindByElementsProperty
+        {
+            set
+            {
+                testMultipleFindByElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) testMultipleFindByElementsProperty;
+            }
+        }
+
+        [FindsBySequence]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> foundByChainedSearchElement;
+
+        [FindsBySequence]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> foundByChainedSearchElements;
+
+        /////////////////////////////////////////////////////////////////
+        private object foundByChainedSearchElementProperty;
+        private object foundByChainedSearchElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBySequence]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> TestFoundByChainedSearchElementProperty
+        {
+            set
+            {
+                foundByChainedSearchElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) foundByChainedSearchElementProperty;
+            }
+        }
+
+        [FindsBySequence]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> TestFoundByChainedSearchElementsProperty
+        {
+            set
+            {
+                foundByChainedSearchElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) foundByChainedSearchElementsProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IMobileElement<AndroidElement> matchedToAllLocatorsElement;
+
+        [FindsByAll]
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IList<AndroidElement> matchedToAllLocatorsElements;
+
+        /////////////////////////////////////////////////////////////////
+        private object matchedToAllLocatorsElementProperty;
+        private object matchedToAllLocatorsElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsByAll]
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IMobileElement<AndroidElement> TestMatchedToAllLocatorsElementProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) matchedToAllLocatorsElementProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IList<AndroidElement> TestMatchedToAllLocatorsElementsProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) matchedToAllLocatorsElementsProperty;
+            }
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMobileElementText()
+        {
+            return testMobileElement.Text;
+        }
+
+        public int GetMobileElementSize()
+        {
+            return testMobileElements.Count;
+        }
+
+        public string GetMobileElementPropertyText()
+        {
+            return TestMobileElement.Text;
+        }
+
+        public int GetMobileElementPropertySize()
+        {
+            return TestMobileElements.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMultipleFindByElementText()
+        {
+            return testMultipleElement.Text;
+        }
+
+        public int GetMultipleFindByElementSize()
+        {
+            return testMultipleElements.Count;
+        }
+
+        public string GetMultipleFindByElementPropertyText()
+        {
+            return TestMultipleFindByElementProperty.Text;
+        }
+
+        public int GetMultipleFindByElementPropertySize()
+        {
+            return MultipleFindByElementsProperty.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetFoundByChainedSearchElementText()
+        {
+            return foundByChainedSearchElement.Text;
+        }
+
+        public int GetFoundByChainedSearchElementSize()
+        {
+            return foundByChainedSearchElements.Count;
+        }
+
+        public string GetFoundByChainedSearchElementPropertyText()
+        {
+            return TestFoundByChainedSearchElementProperty.Text;
+        }
+
+        public int GetFoundByChainedSearchElementPropertySize()
+        {
+            return TestFoundByChainedSearchElementsProperty.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMatchedToAllLocatorsElementText()
+        {
+            return matchedToAllLocatorsElement.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementSize()
+        {
+            return matchedToAllLocatorsElements.Count;
+        }
+
+        public string GetMatchedToAllLocatorsElementPropertyText()
+        {
+            return TestMatchedToAllLocatorsElementProperty.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementPropertySize()
+        {
+            return TestMatchedToAllLocatorsElementsProperty.Count;
+        }
+
+    }
+}

--- a/samples/PageObjects/AndroidPageObjectChecksAttributeMixOnNativeApp1.cs
+++ b/samples/PageObjects/AndroidPageObjectChecksAttributeMixOnNativeApp1.cs
@@ -1,0 +1,337 @@
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium.Appium.PageObjects.Attributes;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjects
+{
+    public class AndroidPageObjectChecksAttributeMixOnNativeApp1
+    {
+        /////////////////////////////////////////////////////////////////
+        private object testMobileElementProperty;
+        private object testMobileElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IMobileElement<AndroidElement> testMobileElement;
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IList<AndroidElement> testMobileElements;
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IMobileElement<AndroidElement> TestMobileElement
+        {
+            set
+            {
+                testMobileElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) testMobileElementProperty;
+            }
+        }
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IList<AndroidElement> TestMobileElements
+        {
+            set
+            {
+                testMobileElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) testMobileElementsProperty;
+            }
+        }
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> testMultipleElement;
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> testMultipleElements;
+
+
+        /////////////////////////////////////////////////////////////////
+        private object testMultipleFindByElementProperty;
+        private object testMultipleFindByElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> TestMultipleFindByElementProperty
+        {
+            set
+            {
+                testMultipleFindByElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) testMultipleFindByElementProperty;
+            }
+        }
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> MultipleFindByElementsProperty
+        {
+            set
+            {
+                testMultipleFindByElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) testMultipleFindByElementsProperty;
+            }
+        }
+
+        [FindsBySequence]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> foundByChainedSearchElement;
+
+        [FindsBySequence]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> foundByChainedSearchElements;
+
+        /////////////////////////////////////////////////////////////////
+        private object foundByChainedSearchElementProperty;
+        private object foundByChainedSearchElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBySequence]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> TestFoundByChainedSearchElementProperty
+        {
+            set
+            {
+                foundByChainedSearchElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) foundByChainedSearchElementProperty;
+            }
+        }
+
+        [FindsBySequence]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> TestFoundByChainedSearchElementsProperty
+        {
+            set
+            {
+                foundByChainedSearchElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) foundByChainedSearchElementsProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IMobileElement<AndroidElement> matchedToAllLocatorsElement;
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IList<AndroidElement> matchedToAllLocatorsElements;
+
+        /////////////////////////////////////////////////////////////////
+        private object matchedToAllLocatorsElementProperty;
+        private object matchedToAllLocatorsElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IMobileElement<AndroidElement> TestMatchedToAllLocatorsElementProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) matchedToAllLocatorsElementProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IList<AndroidElement> TestMatchedToAllLocatorsElementsProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) matchedToAllLocatorsElementsProperty;
+            }
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMobileElementText()
+        {
+            return testMobileElement.Text;
+        }
+
+        public int GetMobileElementSize()
+        {
+            return testMobileElements.Count;
+        }
+
+        public string GetMobileElementPropertyText()
+        {
+            return TestMobileElement.Text;
+        }
+
+        public int GetMobileElementPropertySize()
+        {
+            return TestMobileElements.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMultipleFindByElementText()
+        {
+            return testMultipleElement.Text;
+        }
+
+        public int GetMultipleFindByElementSize()
+        {
+            return testMultipleElements.Count;
+        }
+
+        public string GetMultipleFindByElementPropertyText()
+        {
+            return TestMultipleFindByElementProperty.Text;
+        }
+
+        public int GetMultipleFindByElementPropertySize()
+        {
+            return MultipleFindByElementsProperty.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetFoundByChainedSearchElementText()
+        {
+            return foundByChainedSearchElement.Text;
+        }
+
+        public int GetFoundByChainedSearchElementSize()
+        {
+            return foundByChainedSearchElements.Count;
+        }
+
+        public string GetFoundByChainedSearchElementPropertyText()
+        {
+            return TestFoundByChainedSearchElementProperty.Text;
+        }
+
+        public int GetFoundByChainedSearchElementPropertySize()
+        {
+            return TestFoundByChainedSearchElementsProperty.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMatchedToAllLocatorsElementText()
+        {
+            return matchedToAllLocatorsElement.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementSize()
+        {
+            return matchedToAllLocatorsElements.Count;
+        }
+
+        public string GetMatchedToAllLocatorsElementPropertyText()
+        {
+            return TestMatchedToAllLocatorsElementProperty.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementPropertySize()
+        {
+            return TestMatchedToAllLocatorsElementsProperty.Count;
+        }
+
+    }
+}

--- a/samples/PageObjects/AndroidPageObjectChecksAttributeMixOnNativeApp1.cs
+++ b/samples/PageObjects/AndroidPageObjectChecksAttributeMixOnNativeApp1.cs
@@ -1,20 +1,13 @@
-﻿using OpenQA.Selenium;
-using OpenQA.Selenium.Appium.Android;
+﻿using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
 using OpenQA.Selenium.Support.PageObjects;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Appium.Samples.PageObjects
 {
     public class AndroidPageObjectChecksAttributeMixOnNativeApp1
     {
-        /////////////////////////////////////////////////////////////////
-        private object testMobileElementProperty;
-        private object testMobileElementsProperty;
         /////////////////////////////////////////////////////////////////
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid")]
@@ -29,28 +22,14 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
         private IMobileElement<AndroidElement> TestMobileElement
         {
-            set
-            {
-                testMobileElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) testMobileElementProperty;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid")]
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
         private IList<AndroidElement> TestMobileElements
         {
-            set
-            {
-                testMobileElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) testMobileElementsProperty;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
@@ -73,9 +52,6 @@ namespace Appium.Samples.PageObjects
 
 
         /////////////////////////////////////////////////////////////////
-        private object testMultipleFindByElementProperty;
-        private object testMultipleFindByElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
@@ -86,14 +62,7 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IMobileElement<AndroidElement> TestMultipleFindByElementProperty
         {
-            set
-            {
-                testMultipleFindByElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) testMultipleFindByElementProperty;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
@@ -105,17 +74,11 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IList<AndroidElement> MultipleFindByElementsProperty
         {
-            set
-            {
-                testMultipleFindByElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) testMultipleFindByElementsProperty;
-            }
+            set; get;
         }
 
         [FindsBySequence]
+        [MobileFindsBySequence(Android = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -126,6 +89,7 @@ namespace Appium.Samples.PageObjects
         private IMobileElement<AndroidElement> foundByChainedSearchElement;
 
         [FindsBySequence]
+        [MobileFindsBySequence(Android = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -136,11 +100,9 @@ namespace Appium.Samples.PageObjects
         private IList<AndroidElement> foundByChainedSearchElements;
 
         /////////////////////////////////////////////////////////////////
-        private object foundByChainedSearchElementProperty;
-        private object foundByChainedSearchElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
         [FindsBySequence]
+        [MobileFindsBySequence(Android = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -150,17 +112,11 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IMobileElement<AndroidElement> TestFoundByChainedSearchElementProperty
         {
-            set
-            {
-                foundByChainedSearchElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) foundByChainedSearchElementProperty;
-            }
+            set; get;
         }
 
         [FindsBySequence]
+        [MobileFindsBySequence(Android = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -170,17 +126,11 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IList<AndroidElement> TestFoundByChainedSearchElementsProperty
         {
-            set
-            {
-                foundByChainedSearchElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) foundByChainedSearchElementsProperty;
-            }
+            set; get;
         }
 
         [FindsByAll]
+        [MobileFindsByAll(Android = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -192,6 +142,7 @@ namespace Appium.Samples.PageObjects
         private IMobileElement<AndroidElement> matchedToAllLocatorsElement;
 
         [FindsByAll]
+        [MobileFindsByAll(Android = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -203,11 +154,8 @@ namespace Appium.Samples.PageObjects
         private IList<AndroidElement> matchedToAllLocatorsElements;
 
         /////////////////////////////////////////////////////////////////
-        private object matchedToAllLocatorsElementProperty;
-        private object matchedToAllLocatorsElementsProperty;
-        /////////////////////////////////////////////////////////////////
-
         [FindsByAll]
+        [MobileFindsByAll(Android = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -218,17 +166,11 @@ namespace Appium.Samples.PageObjects
         //The second selector will be commented till the problem is worked out
         private IMobileElement<AndroidElement> TestMatchedToAllLocatorsElementProperty
         {
-            set
-            {
-                matchedToAllLocatorsElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) matchedToAllLocatorsElementProperty;
-            }
+            set; get;
         }
 
         [FindsByAll]
+        [MobileFindsByAll(Android = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -239,14 +181,7 @@ namespace Appium.Samples.PageObjects
         //The second selector will be commented till the problem is worked out
         private IList<AndroidElement> TestMatchedToAllLocatorsElementsProperty
         {
-            set
-            {
-                matchedToAllLocatorsElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) matchedToAllLocatorsElementsProperty;
-            }
+            set; get;
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/samples/PageObjects/AndroidPageObjectChecksAttributeMixOnNativeApp2.cs
+++ b/samples/PageObjects/AndroidPageObjectChecksAttributeMixOnNativeApp2.cs
@@ -1,0 +1,389 @@
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium.Appium.PageObjects.Attributes;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjects
+{
+    public class AndroidPageObjectChecksAttributeMixOnNativeApp2
+    {
+        /////////////////////////////////////////////////////////////////
+        private object testMobileElementProperty;
+        private object testMobileElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IMobileElement<AndroidElement> testMobileElement;
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IList<AndroidElement> testMobileElements;
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IMobileElement<AndroidElement> TestMobileElement
+        {
+            set
+            {
+                testMobileElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) testMobileElementProperty;
+            }
+        }
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IList<AndroidElement> TestMobileElements
+        {
+            set
+            {
+                testMobileElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) testMobileElementsProperty;
+            }
+        }
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[1]", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[2]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> testMultipleElement;
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[1]", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[2]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> testMultipleElements;
+
+
+        /////////////////////////////////////////////////////////////////
+        private object testMultipleFindByElementProperty;
+        private object testMultipleFindByElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[1]", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[2]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> TestMultipleFindByElementProperty
+        {
+            set
+            {
+                testMultipleFindByElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) testMultipleFindByElementProperty;
+            }
+        }
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[1]", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[2]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> MultipleFindByElementsProperty
+        {
+            set
+            {
+                testMultipleFindByElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) testMultipleFindByElementsProperty;
+            }
+        }
+
+        [FindsBySequence]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[1]", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[2]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> foundByChainedSearchElement;
+
+        [FindsBySequence]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[1]", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[2]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> foundByChainedSearchElements;
+
+        /////////////////////////////////////////////////////////////////
+        private object foundByChainedSearchElementProperty;
+        private object foundByChainedSearchElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBySequence]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[1]", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[2]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> TestFoundByChainedSearchElementProperty
+        {
+            set
+            {
+                foundByChainedSearchElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) foundByChainedSearchElementProperty;
+            }
+        }
+
+        [FindsBySequence]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[1]", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[2]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> TestFoundByChainedSearchElementsProperty
+        {
+            set
+            {
+                foundByChainedSearchElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) foundByChainedSearchElementsProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[1]", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[2]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IMobileElement<AndroidElement> matchedToAllLocatorsElement;
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[1]", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[2]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IList<AndroidElement> matchedToAllLocatorsElements;
+
+        /////////////////////////////////////////////////////////////////
+        private object matchedToAllLocatorsElementProperty;
+        private object matchedToAllLocatorsElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[1]", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[2]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IMobileElement<AndroidElement> TestMatchedToAllLocatorsElementProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) matchedToAllLocatorsElementProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[1]", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[2]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IList<AndroidElement> TestMatchedToAllLocatorsElementsProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) matchedToAllLocatorsElementsProperty;
+            }
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMobileElementText()
+        {
+            return testMobileElement.Text;
+        }
+
+        public int GetMobileElementSize()
+        {
+            return testMobileElements.Count;
+        }
+
+        public string GetMobileElementPropertyText()
+        {
+            return TestMobileElement.Text;
+        }
+
+        public int GetMobileElementPropertySize()
+        {
+            return TestMobileElements.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMultipleFindByElementText()
+        {
+            return testMultipleElement.Text;
+        }
+
+        public int GetMultipleFindByElementSize()
+        {
+            return testMultipleElements.Count;
+        }
+
+        public string GetMultipleFindByElementPropertyText()
+        {
+            return TestMultipleFindByElementProperty.Text;
+        }
+
+        public int GetMultipleFindByElementPropertySize()
+        {
+            return MultipleFindByElementsProperty.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetFoundByChainedSearchElementText()
+        {
+            return foundByChainedSearchElement.Text;
+        }
+
+        public int GetFoundByChainedSearchElementSize()
+        {
+            return foundByChainedSearchElements.Count;
+        }
+
+        public string GetFoundByChainedSearchElementPropertyText()
+        {
+            return TestFoundByChainedSearchElementProperty.Text;
+        }
+
+        public int GetFoundByChainedSearchElementPropertySize()
+        {
+            return TestFoundByChainedSearchElementsProperty.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMatchedToAllLocatorsElementText()
+        {
+            return matchedToAllLocatorsElement.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementSize()
+        {
+            return matchedToAllLocatorsElements.Count;
+        }
+
+        public string GetMatchedToAllLocatorsElementPropertyText()
+        {
+            return TestMatchedToAllLocatorsElementProperty.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementPropertySize()
+        {
+            return TestMatchedToAllLocatorsElementsProperty.Count;
+        }
+
+    }
+}

--- a/samples/PageObjects/AndroidPageObjectChecksAttributeMixOnNativeApp2.cs
+++ b/samples/PageObjects/AndroidPageObjectChecksAttributeMixOnNativeApp2.cs
@@ -1,20 +1,13 @@
-﻿using OpenQA.Selenium;
-using OpenQA.Selenium.Appium.Android;
+﻿using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
 using OpenQA.Selenium.Support.PageObjects;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Appium.Samples.PageObjects
 {
     public class AndroidPageObjectChecksAttributeMixOnNativeApp2
     {
-        /////////////////////////////////////////////////////////////////
-        private object testMobileElementProperty;
-        private object testMobileElementsProperty;
         /////////////////////////////////////////////////////////////////
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
@@ -32,14 +25,7 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
         private IMobileElement<AndroidElement> TestMobileElement
         {
-            set
-            {
-                testMobileElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) testMobileElementProperty;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
@@ -47,14 +33,7 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
         private IList<AndroidElement> TestMobileElements
         {
-            set
-            {
-                testMobileElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) testMobileElementsProperty;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
@@ -85,9 +64,6 @@ namespace Appium.Samples.PageObjects
 
 
         /////////////////////////////////////////////////////////////////
-        private object testMultipleFindByElementProperty;
-        private object testMultipleFindByElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
@@ -102,14 +78,7 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IMobileElement<AndroidElement> TestMultipleFindByElementProperty
         {
-            set
-            {
-                testMultipleFindByElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) testMultipleFindByElementProperty;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
@@ -125,17 +94,11 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IList<AndroidElement> MultipleFindByElementsProperty
         {
-            set
-            {
-                testMultipleFindByElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) testMultipleFindByElementsProperty;
-            }
+            set; get;
         }
 
         [FindsBySequence]
+        [MobileFindsBySequence(Android = true, IOS = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -150,6 +113,7 @@ namespace Appium.Samples.PageObjects
         private IMobileElement<AndroidElement> foundByChainedSearchElement;
 
         [FindsBySequence]
+        [MobileFindsBySequence(Android = true, IOS = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -164,11 +128,9 @@ namespace Appium.Samples.PageObjects
         private IList<AndroidElement> foundByChainedSearchElements;
 
         /////////////////////////////////////////////////////////////////
-        private object foundByChainedSearchElementProperty;
-        private object foundByChainedSearchElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
         [FindsBySequence]
+        [MobileFindsBySequence(Android = true, IOS = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -182,17 +144,11 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IMobileElement<AndroidElement> TestFoundByChainedSearchElementProperty
         {
-            set
-            {
-                foundByChainedSearchElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) foundByChainedSearchElementProperty;
-            }
+            set; get;
         }
 
         [FindsBySequence]
+        [MobileFindsBySequence(Android = true, IOS = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -206,17 +162,11 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IList<AndroidElement> TestFoundByChainedSearchElementsProperty
         {
-            set
-            {
-                foundByChainedSearchElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) foundByChainedSearchElementsProperty;
-            }
+            set; get;
         }
 
         [FindsByAll]
+        [MobileFindsByAll(Android = true, IOS = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -232,6 +182,7 @@ namespace Appium.Samples.PageObjects
         private IMobileElement<AndroidElement> matchedToAllLocatorsElement;
 
         [FindsByAll]
+        [MobileFindsByAll(Android = true, IOS = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -247,11 +198,9 @@ namespace Appium.Samples.PageObjects
         private IList<AndroidElement> matchedToAllLocatorsElements;
 
         /////////////////////////////////////////////////////////////////
-        private object matchedToAllLocatorsElementProperty;
-        private object matchedToAllLocatorsElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
         [FindsByAll]
+        [MobileFindsByAll(Android = true, IOS = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -266,17 +215,11 @@ namespace Appium.Samples.PageObjects
         //The second selector will be commented till the problem is worked out
         private IMobileElement<AndroidElement> TestMatchedToAllLocatorsElementProperty
         {
-            set
-            {
-                matchedToAllLocatorsElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) matchedToAllLocatorsElementProperty;
-            }
+            set; get;
         }
 
         [FindsByAll]
+        [MobileFindsByAll(Android = true, IOS = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -291,14 +234,7 @@ namespace Appium.Samples.PageObjects
         //The second selector will be commented till the problem is worked out
         private IList<AndroidElement> TestMatchedToAllLocatorsElementsProperty
         {
-            set
-            {
-                matchedToAllLocatorsElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) matchedToAllLocatorsElementsProperty;
-            }
+            set; get;
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/samples/PageObjects/AndroidPageObjectChecksAttributesForNativeAndroidApp.cs
+++ b/samples/PageObjects/AndroidPageObjectChecksAttributesForNativeAndroidApp.cs
@@ -1,22 +1,12 @@
-﻿using OpenQA.Selenium;
-using OpenQA.Selenium.Appium.Android;
+﻿using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
-using OpenQA.Selenium.Support.PageObjects;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Appium.Samples.PageObjects
 {
     public class AndroidPageObjectChecksAttributesForNativeAndroidApp
     {
-        /////////////////////////////////////////////////////////////////
-        private object testMobileElementProperty;
-        private object testMobileElementsProperty;
-        /////////////////////////////////////////////////////////////////
-
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
         private IMobileElement<AndroidElement> testMobileElement;
 
@@ -26,27 +16,13 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
         private IMobileElement<AndroidElement> TestMobileElement
         {
-            set
-            {
-                testMobileElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) testMobileElementProperty;
-            }
+            set;get;
         }
 
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
         private IList<AndroidElement> TestMobileElements
         {
-            set
-            {
-                testMobileElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) testMobileElementsProperty;
-            }
+            set;get;
         }
 
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
@@ -95,13 +71,13 @@ namespace Appium.Samples.PageObjects
             }
         }
 
-        [FindsBySequence]
+        [MobileFindsBySequence(Android = true)]
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IMobileElement<AndroidElement> foundByChainedSearchElement;
 
-        [FindsBySequence]
+        [MobileFindsBySequence(Android = true)]
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
@@ -112,7 +88,7 @@ namespace Appium.Samples.PageObjects
         private object foundByChainedSearchElementsProperty;
         /////////////////////////////////////////////////////////////////
 
-        [FindsBySequence]
+        [MobileFindsBySequence(Android = true)]
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
@@ -128,7 +104,7 @@ namespace Appium.Samples.PageObjects
             }
         }
 
-        [FindsBySequence]
+        [MobileFindsBySequence(Android = true)]
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
@@ -144,14 +120,14 @@ namespace Appium.Samples.PageObjects
             }
         }
 
-        [FindsByAll]
+        [MobileFindsByAll(Android = true)]
         [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
         //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
         //Equals method of RemoteWebElement is not consistent for mobile apps
         //The second selector will be commented till the problem is worked out
         private IMobileElement<AndroidElement> matchedToAllLocatorsElement;
 
-        [FindsByAll]
+        [MobileFindsByAll(Android = true)]
         [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
         //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
         //Equals method of RemoteWebElement is not consistent for mobile apps
@@ -163,7 +139,7 @@ namespace Appium.Samples.PageObjects
         private object matchedToAllLocatorsElementsProperty;
         /////////////////////////////////////////////////////////////////
 
-        [FindsByAll]
+        [MobileFindsByAll(Android = true)]
         [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
         //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
         //Equals method of RemoteWebElement is not consistent for mobile apps
@@ -180,7 +156,7 @@ namespace Appium.Samples.PageObjects
             }
         }
 
-        [FindsByAll]
+        [MobileFindsByAll(Android = true)]
         [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
         //[FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 2)]
         //Equals method of RemoteWebElement is not consistent for mobile apps

--- a/samples/PageObjects/AndroidPageObjectChecksAttributesForNativeAndroidApp.cs
+++ b/samples/PageObjects/AndroidPageObjectChecksAttributesForNativeAndroidApp.cs
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace Appium.Samples.PageObjects
 {
-    public class AndroidPageObjectChecksAppributesForNativeAndroidApp
+    public class AndroidPageObjectChecksAttributesForNativeAndroidApp
     {
         /////////////////////////////////////////////////////////////////
         private object testMobileElementProperty;

--- a/samples/PageObjects/AndroidPageObjectChecksSelendroidModeOnNativeApp.cs
+++ b/samples/PageObjects/AndroidPageObjectChecksSelendroidModeOnNativeApp.cs
@@ -1,20 +1,12 @@
 ﻿using OpenQA.Selenium;
-using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
-using OpenQA.Selenium.Support.PageObjects;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Appium.Samples.PageObjects
 {
     public class AndroidPageObjectChecksSelendroidModeOnNativeApp
     {
-        /////////////////////////////////////////////////////////////////
-        private object testMobileElementProperty;
-        private object testMobileElementsProperty;
         /////////////////////////////////////////////////////////////////
 
         [FindsBySelendroid(ID = "my_text_field")]
@@ -26,27 +18,13 @@ namespace Appium.Samples.PageObjects
         [FindsBySelendroid(ID = "my_text_field")]
         private IWebElement TestMobileElement
         {
-            set
-            {
-                testMobileElementProperty = value;
-            }
-            get
-            {
-                return (IWebElement) testMobileElementProperty;
-            }
+            set; get;
         }
 
         [FindsBySelendroid(ID = "my_text_field")]
         private IList<IWebElement> TestMobileElements
         {
-            set
-            {
-                testMobileElementsProperty = value;
-            }
-            get
-            {
-                return (IList<IWebElement>) testMobileElementsProperty;
-            }
+            set; get;
         }
 
         [FindsBySelendroid(ID = "fake_content", Priority = 1)]
@@ -69,23 +47,13 @@ namespace Appium.Samples.PageObjects
 
 
         /////////////////////////////////////////////////////////////////
-        private object testMultipleFindByElementProperty;
-        private object testMultipleFindByElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
         [FindsBySelendroid(ID = "fake_content", Priority = 1)]
         [FindsBySelendroid(ClassName = "android.webkit.WebView", Priority = 2)] //There is no Webview at the screen
         [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 3)]
         private IWebElement TestMultipleFindByElementProperty
         {
-            set
-            {
-                testMultipleFindByElementProperty = value;
-            }
-            get
-            {
-                return (IWebElement) testMultipleFindByElementProperty;
-            }
+            set; get;
         }
 
         [FindsBySelendroid(ID = "fake_content", Priority = 1)]
@@ -93,17 +61,10 @@ namespace Appium.Samples.PageObjects
         [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 3)]
         private IList<IWebElement> MultipleFindByElementsProperty
         {
-            set
-            {
-                testMultipleFindByElementsProperty = value;
-            }
-            get
-            {
-                return (IList<IWebElement>)testMultipleFindByElementsProperty;
-            }
+            set; get;
         }
 
-        [FindsBySequence]
+        [MobileFindsBySequence(Android = true, Selendroid = true)]
         [FindsBySelendroid(ID = "content", Priority = 1)]
         [FindsBySelendroid(ClassName = "android.widget.FrameLayout", Priority = 2)]
         [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 3)]
@@ -113,7 +74,7 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IWebElement foundByChainedSearchElement;
 
-        [FindsBySequence]
+        [MobileFindsBySequence(Android = true, Selendroid = true)]
         [FindsBySelendroid(ID = "content", Priority = 1)]
         [FindsBySelendroid(ClassName = "android.widget.FrameLayout", Priority = 2)]
         [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 3)]
@@ -124,11 +85,8 @@ namespace Appium.Samples.PageObjects
         private IList<IWebElement> foundByChainedSearchElements;
 
         /////////////////////////////////////////////////////////////////
-        private object foundByChainedSearchElementProperty;
-        private object foundByChainedSearchElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
-        [FindsBySequence]
+        [MobileFindsBySequence(Android = true, Selendroid = true)]
         [FindsBySelendroid(ID = "content", Priority = 1)]
         [FindsBySelendroid(ClassName = "android.widget.FrameLayout", Priority = 2)]
         [FindsBySelendroid(PartialLinkText = "Press to throw unhandled exception", Priority = 3)]
@@ -138,17 +96,10 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IWebElement TestFoundByChainedSearchElementProperty
         {
-            set
-            {
-                foundByChainedSearchElementProperty = value;
-            }
-            get
-            {
-                return (IWebElement)foundByChainedSearchElementProperty;
-            }
+            set; get;
         }
 
-        [FindsBySequence]
+        [MobileFindsBySequence(Android = true, Selendroid = true)]
         [FindsBySelendroid(ID = "content", Priority = 1)]
         [FindsBySelendroid(ClassName = "android.widget.FrameLayout", Priority = 2)]
         [FindsBySelendroid(PartialLinkText = "Press to throw unhandled exception", Priority = 3)]
@@ -158,24 +109,17 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IList<IWebElement> TestFoundByChainedSearchElementsProperty
         {
-            set
-            {
-                foundByChainedSearchElementsProperty = value;
-            }
-            get
-            {
-                return (IList<IWebElement>)foundByChainedSearchElementsProperty;
-            }
+            set; get;
         }
 
-        [FindsByAll]
+        [MobileFindsByAll(Selendroid = true)]
         [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 1)]
         //[FindsByAndroidUIAutomator(ID = "waitingButtonTest", Priority = 2)]
         //Equals method of RemoteWebElement is not consistent for mobile apps
         //The second selector will be commented till the problem is worked out
         private IMobileElement<IWebElement> matchedToAllLocatorsElement;
 
-        [FindsByAll]
+        [MobileFindsByAll(Selendroid = true)]
         [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 1)]
         //[FindsByAndroidUIAutomator(ID = "waitingButtonTest", Priority = 2)]
         //Equals method of RemoteWebElement is not consistent for mobile apps
@@ -183,42 +127,25 @@ namespace Appium.Samples.PageObjects
         private IList<IWebElement> matchedToAllLocatorsElements;
 
         /////////////////////////////////////////////////////////////////
-        private object matchedToAllLocatorsElementProperty;
-        private object matchedToAllLocatorsElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
-        [FindsByAll]
+        [MobileFindsByAll(Selendroid = true)]
         [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 1)]
         //[FindsByAndroidUIAutomator(ID = "waitingButtonTest", Priority = 2)]
         //Equals method of RemoteWebElement is not consistent for mobile apps
         //The second selector will be commented till the problem is worked out
         private IWebElement TestMatchedToAllLocatorsElementProperty
         {
-            set
-            {
-                matchedToAllLocatorsElementProperty = value;
-            }
-            get
-            {
-                return (IWebElement) matchedToAllLocatorsElementProperty;
-            }
+            set; get;
         }
 
-        [FindsByAll]
+        [MobileFindsByAll(Selendroid = true)]
         [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 1)]
         //[FindsByAndroidUIAutomator(ID = "waitingButtonTest", Priority = 2)]
         //Equals method of RemoteWebElement is not consistent for mobile apps
         //The second selector will be commented till the problem is worked out
         private IList<IWebElement> TestMatchedToAllLocatorsElementsProperty
         {
-            set
-            {
-                matchedToAllLocatorsElementsProperty = value;
-            }
-            get
-            {
-                return (IList<IWebElement>)matchedToAllLocatorsElementsProperty;
-            }
+            set; get;
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/samples/PageObjects/AndroidPageObjectChecksSelendroidModeOnNativeApp.cs
+++ b/samples/PageObjects/AndroidPageObjectChecksSelendroidModeOnNativeApp.cs
@@ -1,0 +1,309 @@
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium.Appium.PageObjects.Attributes;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjects
+{
+    public class AndroidPageObjectChecksSelendroidModeOnNativeApp
+    {
+        /////////////////////////////////////////////////////////////////
+        private object testMobileElementProperty;
+        private object testMobileElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBySelendroid(ID = "my_text_field")]
+        private IWebElement testMobileElement;
+
+        [FindsBySelendroid(ID = "my_text_field")]
+        private IList<IWebElement> testMobileElements;
+
+        [FindsBySelendroid(ID = "my_text_field")]
+        private IWebElement TestMobileElement
+        {
+            set
+            {
+                testMobileElementProperty = value;
+            }
+            get
+            {
+                return (IWebElement) testMobileElementProperty;
+            }
+        }
+
+        [FindsBySelendroid(ID = "my_text_field")]
+        private IList<IWebElement> TestMobileElements
+        {
+            set
+            {
+                testMobileElementsProperty = value;
+            }
+            get
+            {
+                return (IList<IWebElement>) testMobileElementsProperty;
+            }
+        }
+
+        [FindsBySelendroid(ID = "fake_content", Priority = 1)]
+        [FindsBySelendroid(ClassName = "android.widget.FakeSelendroidClass", Priority = 2)]
+        [FindsBySelendroid(ID = "waitingButtonTest", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "FakeClass", Priority = 3)]
+        private IWebElement testMultipleElement;
+
+        [FindsBySelendroid(ID = "fake_content", Priority = 1)]
+        [FindsBySelendroid(ClassName = "fakeSelendroidClass", Priority = 2)]
+        [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "FakeClass", Priority = 3)]
+        private IList<IWebElement> testMultipleElements;
+
+
+        /////////////////////////////////////////////////////////////////
+        private object testMultipleFindByElementProperty;
+        private object testMultipleFindByElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBySelendroid(ID = "fake_content", Priority = 1)]
+        [FindsBySelendroid(ClassName = "fakeSelendroidClass", Priority = 2)]
+        [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 3)]
+        private IWebElement TestMultipleFindByElementProperty
+        {
+            set
+            {
+                testMultipleFindByElementProperty = value;
+            }
+            get
+            {
+                return (IWebElement) testMultipleFindByElementProperty;
+            }
+        }
+
+        [FindsBySelendroid(ID = "fake_content", Priority = 1)]
+        [FindsBySelendroid(ClassName = "fakeSelendroidClass", Priority = 2)]
+        [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 3)]
+        private IList<IWebElement> MultipleFindByElementsProperty
+        {
+            set
+            {
+                testMultipleFindByElementsProperty = value;
+            }
+            get
+            {
+                return (IList<IWebElement>)testMultipleFindByElementsProperty;
+            }
+        }
+
+        [FindsBySequence]
+        [FindsBySelendroid(ID = "content", Priority = 1)]
+        [FindsBySelendroid(ClassName = "android.widget.FrameLayout", Priority = 2)]
+        [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IWebElement foundByChainedSearchElement;
+
+        [FindsBySequence]
+        [FindsBySelendroid(ID = "content", Priority = 1)]
+        [FindsBySelendroid(ClassName = "android.widget.FrameLayout", Priority = 2)]
+        [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<IWebElement> foundByChainedSearchElements;
+
+        /////////////////////////////////////////////////////////////////
+        private object foundByChainedSearchElementProperty;
+        private object foundByChainedSearchElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBySequence]
+        [FindsBySelendroid(ID = "content", Priority = 1)]
+        [FindsBySelendroid(ClassName = "android.widget.FrameLayout", Priority = 2)]
+        [FindsBySelendroid(PartialLinkText = "Press to throw unhandled exception", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IWebElement TestFoundByChainedSearchElementProperty
+        {
+            set
+            {
+                foundByChainedSearchElementProperty = value;
+            }
+            get
+            {
+                return (IWebElement)foundByChainedSearchElementProperty;
+            }
+        }
+
+        [FindsBySequence]
+        [FindsBySelendroid(ID = "content", Priority = 1)]
+        [FindsBySelendroid(ClassName = "android.widget.FrameLayout", Priority = 2)]
+        [FindsBySelendroid(PartialLinkText = "Press to throw unhandled exception", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/content\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/list\")", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<IWebElement> TestFoundByChainedSearchElementsProperty
+        {
+            set
+            {
+                foundByChainedSearchElementsProperty = value;
+            }
+            get
+            {
+                return (IList<IWebElement>)foundByChainedSearchElementsProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ID = "waitingButtonTest", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IMobileElement<IWebElement> matchedToAllLocatorsElement;
+
+        [FindsByAll]
+        [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ID = "waitingButtonTest", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IList<IWebElement> matchedToAllLocatorsElements;
+
+        /////////////////////////////////////////////////////////////////
+        private object matchedToAllLocatorsElementProperty;
+        private object matchedToAllLocatorsElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsByAll]
+        [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ID = "waitingButtonTest", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IWebElement TestMatchedToAllLocatorsElementProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementProperty = value;
+            }
+            get
+            {
+                return (IWebElement) matchedToAllLocatorsElementProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 1)]
+        //[FindsByAndroidUIAutomator(ID = "waitingButtonTest", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IList<IWebElement> TestMatchedToAllLocatorsElementsProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementsProperty = value;
+            }
+            get
+            {
+                return (IList<IWebElement>)matchedToAllLocatorsElementsProperty;
+            }
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMobileElementText()
+        {
+            return testMobileElement.Text;
+        }
+
+        public int GetMobileElementSize()
+        {
+            return testMobileElements.Count;
+        }
+
+        public string GetMobileElementPropertyText()
+        {
+            return TestMobileElement.Text;
+        }
+
+        public int GetMobileElementPropertySize()
+        {
+            return TestMobileElements.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMultipleFindByElementText()
+        {
+            return testMultipleElement.Text;
+        }
+
+        public int GetMultipleFindByElementSize()
+        {
+            return testMultipleElements.Count;
+        }
+
+        public string GetMultipleFindByElementPropertyText()
+        {
+            return TestMultipleFindByElementProperty.Text;
+        }
+
+        public int GetMultipleFindByElementPropertySize()
+        {
+            return MultipleFindByElementsProperty.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetFoundByChainedSearchElementText()
+        {
+            return foundByChainedSearchElement.Text;
+        }
+
+        public int GetFoundByChainedSearchElementSize()
+        {
+            return foundByChainedSearchElements.Count;
+        }
+
+        public string GetFoundByChainedSearchElementPropertyText()
+        {
+            return TestFoundByChainedSearchElementProperty.Text;
+        }
+
+        public int GetFoundByChainedSearchElementPropertySize()
+        {
+            return TestFoundByChainedSearchElementsProperty.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMatchedToAllLocatorsElementText()
+        {
+            return matchedToAllLocatorsElement.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementSize()
+        {
+            return matchedToAllLocatorsElements.Count;
+        }
+
+        public string GetMatchedToAllLocatorsElementPropertyText()
+        {
+            return TestMatchedToAllLocatorsElementProperty.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementPropertySize()
+        {
+            return TestMatchedToAllLocatorsElementsProperty.Count;
+        }
+
+    }
+}

--- a/samples/PageObjects/AndroidPageObjectChecksSelendroidModeOnNativeApp.cs
+++ b/samples/PageObjects/AndroidPageObjectChecksSelendroidModeOnNativeApp.cs
@@ -50,7 +50,7 @@ namespace Appium.Samples.PageObjects
         }
 
         [FindsBySelendroid(ID = "fake_content", Priority = 1)]
-        [FindsBySelendroid(ClassName = "android.widget.FakeSelendroidClass", Priority = 2)]
+        [FindsBySelendroid(ClassName = "android.webkit.WebView", Priority = 2)] //There is no Webview at the screen
         [FindsBySelendroid(ID = "waitingButtonTest", Priority = 3)]
 
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
@@ -59,7 +59,7 @@ namespace Appium.Samples.PageObjects
         private IWebElement testMultipleElement;
 
         [FindsBySelendroid(ID = "fake_content", Priority = 1)]
-        [FindsBySelendroid(ClassName = "fakeSelendroidClass", Priority = 2)]
+        [FindsBySelendroid(ClassName = "android.webkit.WebView", Priority = 2)] //There is no Webview at the screen
         [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 3)]
 
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
@@ -74,7 +74,7 @@ namespace Appium.Samples.PageObjects
         /////////////////////////////////////////////////////////////////
 
         [FindsBySelendroid(ID = "fake_content", Priority = 1)]
-        [FindsBySelendroid(ClassName = "fakeSelendroidClass", Priority = 2)]
+        [FindsBySelendroid(ClassName = "android.webkit.WebView", Priority = 2)] //There is no Webview at the screen
         [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 3)]
         private IWebElement TestMultipleFindByElementProperty
         {
@@ -89,7 +89,7 @@ namespace Appium.Samples.PageObjects
         }
 
         [FindsBySelendroid(ID = "fake_content", Priority = 1)]
-        [FindsBySelendroid(ClassName = "fakeSelendroidClass", Priority = 2)]
+        [FindsBySelendroid(ClassName = "android.webkit.WebView", Priority = 2)] //There is no Webview at the screen
         [FindsBySelendroid(LinkText = "Press to throw unhandled exception", Priority = 3)]
         private IList<IWebElement> MultipleFindByElementsProperty
         {

--- a/samples/PageObjects/AndroidPageObjectChecksSeleniumFindsByCompatibility.cs
+++ b/samples/PageObjects/AndroidPageObjectChecksSeleniumFindsByCompatibility.cs
@@ -1,0 +1,341 @@
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjects
+{
+    public class AndroidPageObjectChecksSeleniumFindsByCompatibility
+    {
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
+        private IWebElement testElement;
+
+        /////////////////////////////////////////////////////////////////
+        private object propertyElement;
+        private object propertyElements;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
+        private IWebElement TestElement
+        {
+            set
+            {
+                propertyElement = value;
+            }
+            get
+            {
+                return (IWebElement) propertyElement;
+            }
+        }
+
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
+        private IList<IWebElement> testElements;
+
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
+        private IList<IWebElement> TestElements
+        {
+            set
+            {
+                propertyElements = value;
+            }
+            get
+            {
+                return (IList< IWebElement >) propertyElements;
+            }
+        }
+
+        /////////////////////////////////////////////////////////////////
+        private object testMobileElementProperty;
+        private object testMobileElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
+        private IMobileElement<AndroidElement> testMobileElement;
+
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
+        private IList<AndroidElement> testMobileElements;
+
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
+        private IMobileElement<AndroidElement> TestMobileElement
+        {
+            set
+            {
+                testMobileElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) testMobileElementProperty;
+            }
+        }
+
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
+        private IList<AndroidElement> TestMobileElements
+        {
+            set
+            {
+                testMobileElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) testMobileElementsProperty;
+            }
+        }
+
+        [FindsBy(How = How.Name, Using = "FakeName", Priority = 1)]
+        [FindsBy(How = How.Id, Using = "FakeId", Priority = 2)]
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> testMultipleElement;
+
+        [FindsBy(How = How.Name, Using = "FakeName", Priority = 1)]
+        [FindsBy(How = How.Id, Using = "FakeId", Priority = 2)]
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> testMultipleElements;
+
+
+        /////////////////////////////////////////////////////////////////
+        private object testMultipleFindByElementProperty;
+        private object testMultipleFindByElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBy(How = How.Name, Using = "FakeName", Priority = 1)]
+        [FindsBy(How = How.Id, Using = "FakeId", Priority = 2)]
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> TestMultipleFindByElementProperty
+        {
+            set
+            {
+                testMultipleFindByElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) testMultipleFindByElementProperty;
+            }
+        }
+
+        [FindsBy(How = How.Name, Using = "FakeName", Priority = 1)]
+        [FindsBy(How = How.Id, Using = "FakeId", Priority = 2)]
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> MultipleFindByElementsProperty
+        {
+            set
+            {
+                testMultipleFindByElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) testMultipleFindByElementsProperty;
+            }
+        }
+
+        [FindsBySequence]
+        [FindsBy(How = How.Id, Using = "android:id/content", Priority = 1)]
+        [FindsBy(How = How.Id, Using = "android:id/list", Priority = 2)]
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> foundByChainedSearchElement;
+
+        [FindsBySequence]
+        [FindsBy(How = How.Id, Using = "android:id/content", Priority = 1)]
+        [FindsBy(How = How.Id, Using = "android:id/list", Priority = 2)]
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> foundByChainedSearchElements;
+
+        /////////////////////////////////////////////////////////////////
+        private object foundByChainedSearchElementProperty;
+        private object foundByChainedSearchElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBySequence]
+        [FindsBy(How = How.Id, Using = "android:id/content", Priority = 1)]
+        [FindsBy(How = How.Id, Using = "android:id/list", Priority = 2)]
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<AndroidElement> TestFoundByChainedSearchElementProperty
+        {
+            set
+            {
+                foundByChainedSearchElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) foundByChainedSearchElementProperty;
+            }
+        }
+
+        [FindsBySequence]
+        [FindsBy(How = How.Id, Using = "android:id/content", Priority = 1)]
+        [FindsBy(How = How.Id, Using = "android:id/list", Priority = 2)]
+        [FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 3)]
+        private IList<AndroidElement> TestFoundByChainedSearchElementsProperty
+        {
+            set
+            {
+                foundByChainedSearchElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) foundByChainedSearchElementsProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "android:id/text1", Priority = 1)]
+        //[FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IMobileElement<AndroidElement> matchedToAllLocatorsElement;
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "android:id/text1", Priority = 1)]
+        //[FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IList<AndroidElement> matchedToAllLocatorsElements;
+
+        /////////////////////////////////////////////////////////////////
+        private object matchedToAllLocatorsElementProperty;
+        private object matchedToAllLocatorsElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "android:id/text1", Priority = 1)]
+        //[FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IMobileElement<AndroidElement> TestMatchedToAllLocatorsElementProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<AndroidElement>) matchedToAllLocatorsElementProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "android:id/text1", Priority = 1)]
+        //[FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 2)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector will be commented till the problem is worked out
+        private IList<AndroidElement> TestMatchedToAllLocatorsElementsProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementsProperty = value;
+            }
+            get
+            {
+                return (IList<AndroidElement>) matchedToAllLocatorsElementsProperty;
+            }
+        }
+
+        public string GetElementText()
+        {
+            return testElement.Text;
+        }
+
+        public int GetElementSize()
+        {
+            return testElements.Count;
+        }
+
+        public string GetElementPropertyText()
+        {
+            return TestElement.Text;
+        }
+
+        public int GetElementPropertySize()
+        {
+            return TestElements.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMobileElementText()
+        {
+            return testMobileElement.Text;
+        }
+
+        public int GetMobileElementSize()
+        {
+            return testMobileElements.Count;
+        }
+
+        public string GetMobileElementPropertyText()
+        {
+            return TestMobileElement.Text;
+        }
+
+        public int GetMobileElementPropertySize()
+        {
+            return TestMobileElements.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMultipleFindByElementText()
+        {
+            return testMultipleElement.Text;
+        }
+
+        public int GetMultipleFindByElementSize()
+        {
+            return testMultipleElements.Count;
+        }
+
+        public string GetMultipleFindByElementPropertyText()
+        {
+            return TestMultipleFindByElementProperty.Text;
+        }
+
+        public int GetMultipleFindByElementPropertySize()
+        {
+            return MultipleFindByElementsProperty.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetFoundByChainedSearchElementText()
+        {
+            return foundByChainedSearchElement.Text;
+        }
+
+        public int GetFoundByChainedSearchElementSize()
+        {
+            return foundByChainedSearchElements.Count;
+        }
+
+        public string GetFoundByChainedSearchElementPropertyText()
+        {
+            return TestFoundByChainedSearchElementProperty.Text;
+        }
+
+        public int GetFoundByChainedSearchElementPropertySize()
+        {
+            return TestFoundByChainedSearchElementsProperty.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMatchedToAllLocatorsElementText()
+        {
+            return matchedToAllLocatorsElement.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementSize()
+        {
+            return matchedToAllLocatorsElements.Count;
+        }
+
+        public string GetMatchedToAllLocatorsElementPropertyText()
+        {
+            return TestMatchedToAllLocatorsElementProperty.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementPropertySize()
+        {
+            return TestMatchedToAllLocatorsElementsProperty.Count;
+        }
+
+    }
+}

--- a/samples/PageObjects/AndroidPageObjectChecksSeleniumFindsByCompatibility.cs
+++ b/samples/PageObjects/AndroidPageObjectChecksSeleniumFindsByCompatibility.cs
@@ -15,21 +15,11 @@ namespace Appium.Samples.PageObjects
         private IWebElement testElement;
 
         /////////////////////////////////////////////////////////////////
-        private object propertyElement;
-        private object propertyElements;
-        /////////////////////////////////////////////////////////////////
 
         [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
         private IWebElement TestElement
         {
-            set
-            {
-                propertyElement = value;
-            }
-            get
-            {
-                return (IWebElement) propertyElement;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
@@ -38,19 +28,9 @@ namespace Appium.Samples.PageObjects
         [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
         private IList<IWebElement> TestElements
         {
-            set
-            {
-                propertyElements = value;
-            }
-            get
-            {
-                return (IList< IWebElement >) propertyElements;
-            }
+            set; get;
         }
 
-        /////////////////////////////////////////////////////////////////
-        private object testMobileElementProperty;
-        private object testMobileElementsProperty;
         /////////////////////////////////////////////////////////////////
 
         [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
@@ -62,27 +42,13 @@ namespace Appium.Samples.PageObjects
         [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
         private IMobileElement<AndroidElement> TestMobileElement
         {
-            set
-            {
-                testMobileElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) testMobileElementProperty;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.ClassName, Using = "android.widget.TextView")]
         private IList<AndroidElement> TestMobileElements
         {
-            set
-            {
-                testMobileElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) testMobileElementsProperty;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.Name, Using = "FakeName", Priority = 1)]
@@ -97,23 +63,13 @@ namespace Appium.Samples.PageObjects
 
 
         /////////////////////////////////////////////////////////////////
-        private object testMultipleFindByElementProperty;
-        private object testMultipleFindByElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
         [FindsBy(How = How.Name, Using = "FakeName", Priority = 1)]
         [FindsBy(How = How.Id, Using = "FakeId", Priority = 2)]
         [FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 3)]
         private IMobileElement<AndroidElement> TestMultipleFindByElementProperty
         {
-            set
-            {
-                testMultipleFindByElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) testMultipleFindByElementProperty;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.Name, Using = "FakeName", Priority = 1)]
@@ -121,14 +77,7 @@ namespace Appium.Samples.PageObjects
         [FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 3)]
         private IList<AndroidElement> MultipleFindByElementsProperty
         {
-            set
-            {
-                testMultipleFindByElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) testMultipleFindByElementsProperty;
-            }
+            set; get;
         }
 
         [FindsBySequence]
@@ -144,9 +93,6 @@ namespace Appium.Samples.PageObjects
         private IList<AndroidElement> foundByChainedSearchElements;
 
         /////////////////////////////////////////////////////////////////
-        private object foundByChainedSearchElementProperty;
-        private object foundByChainedSearchElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
         [FindsBySequence]
         [FindsBy(How = How.Id, Using = "android:id/content", Priority = 1)]
@@ -154,14 +100,7 @@ namespace Appium.Samples.PageObjects
         [FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 3)]
         private IMobileElement<AndroidElement> TestFoundByChainedSearchElementProperty
         {
-            set
-            {
-                foundByChainedSearchElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) foundByChainedSearchElementProperty;
-            }
+            set; get;
         }
 
         [FindsBySequence]
@@ -170,14 +109,7 @@ namespace Appium.Samples.PageObjects
         [FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 3)]
         private IList<AndroidElement> TestFoundByChainedSearchElementsProperty
         {
-            set
-            {
-                foundByChainedSearchElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) foundByChainedSearchElementsProperty;
-            }
+            set; get;
         }
 
         [FindsByAll]
@@ -195,10 +127,6 @@ namespace Appium.Samples.PageObjects
         private IList<AndroidElement> matchedToAllLocatorsElements;
 
         /////////////////////////////////////////////////////////////////
-        private object matchedToAllLocatorsElementProperty;
-        private object matchedToAllLocatorsElementsProperty;
-        /////////////////////////////////////////////////////////////////
-
         [FindsByAll]
         [FindsBy(How = How.Id, Using = "android:id/text1", Priority = 1)]
         //[FindsBy(How = How.ClassName, Using = "android.widget.TextView", Priority = 2)]
@@ -206,14 +134,7 @@ namespace Appium.Samples.PageObjects
         //The second selector will be commented till the problem is worked out
         private IMobileElement<AndroidElement> TestMatchedToAllLocatorsElementProperty
         {
-            set
-            {
-                matchedToAllLocatorsElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<AndroidElement>) matchedToAllLocatorsElementProperty;
-            }
+            set;get;
         }
 
         [FindsByAll]
@@ -223,14 +144,7 @@ namespace Appium.Samples.PageObjects
         //The second selector will be commented till the problem is worked out
         private IList<AndroidElement> TestMatchedToAllLocatorsElementsProperty
         {
-            set
-            {
-                matchedToAllLocatorsElementsProperty = value;
-            }
-            get
-            {
-                return (IList<AndroidElement>) matchedToAllLocatorsElementsProperty;
-            }
+            set;get;
         }
 
         public string GetElementText()

--- a/samples/PageObjects/AndroidWebView.cs
+++ b/samples/PageObjects/AndroidWebView.cs
@@ -1,0 +1,42 @@
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.PageObjects.Attributes;
+using OpenQA.Selenium.Support.PageObjects;
+using OpenQA.Selenium.Support.UI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjects
+{
+    public class AndroidWebView
+    {
+        [FindsBy(How = How.Id, Using = "name_input")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeID\")")]
+	    private IWebElement name;
+
+	    [FindsBy(How = How.Name, Using = "car")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeID\")")]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+	    private IWebElement carSelect;
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeID\")")]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+	    [FindsBy(How = How.XPath, Using =".//*[@type=\"submit\"]")]
+	    private IWebElement sendMeYourName;
+
+	    public void SetName(string name){
+		    this.name.  Clear();
+		    this.name.SendKeys(name);
+	    }
+	
+	    public void SelectCar(String car){
+            SelectElement select = new SelectElement(carSelect);
+		    select.SelectByValue(car);
+	    }
+	
+	    public void SendMeYourName() {
+		    sendMeYourName.Submit();
+	    }
+    }
+}

--- a/samples/PageObjects/IOSPageObjectChecksAttributeMixOnNativeApp.cs
+++ b/samples/PageObjects/IOSPageObjectChecksAttributeMixOnNativeApp.cs
@@ -1,22 +1,14 @@
-﻿using OpenQA.Selenium;
-using OpenQA.Selenium.Appium.Interfaces;
+﻿using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.iOS;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
 using OpenQA.Selenium.Support.PageObjects;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Appium.Samples.PageObjects
 {
     public class IOSPageObjectChecksAttributeMixOnNativeApp
     {
         /////////////////////////////////////////////////////////////////
-        private object testMobileElementProperty;
-        private object testMobileElementsProperty;
-        /////////////////////////////////////////////////////////////////
-
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
@@ -32,14 +24,7 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
         private IMobileElement<IOSElement> TestMobileElement
         {
-            set
-            {
-                testMobileElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<IOSElement>)testMobileElementProperty;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
@@ -47,14 +32,7 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
         private IList<IOSElement> TestMobileElements
         {
-            set
-            {
-                testMobileElementsProperty = value;
-            }
-            get
-            {
-                return (IList<IOSElement>)testMobileElementsProperty;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
@@ -85,9 +63,6 @@ namespace Appium.Samples.PageObjects
 
 
         /////////////////////////////////////////////////////////////////
-        private object testMultipleFindByElementProperty;
-        private object testMultipleFindByElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
@@ -102,14 +77,7 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IMobileElement<IOSElement> TestMultipleFindByElementProperty
         {
-            set
-            {
-                testMultipleFindByElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<IOSElement>)testMultipleFindByElementProperty;
-            }
+            set; get;
         }
 
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
@@ -125,17 +93,11 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
         private IList<IOSElement> MultipleFindByElementsProperty
         {
-            set
-            {
-                testMultipleFindByElementsProperty = value;
-            }
-            get
-            {
-                return (IList<IOSElement>)testMultipleFindByElementsProperty;
-            }
+            set; get;
         }
 
         [FindsByAll]
+        [MobileFindsByAll(Android = true, IOS = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -149,6 +111,7 @@ namespace Appium.Samples.PageObjects
         private IMobileElement<IOSElement> matchedToAllLocatorsElement;
 
         [FindsByAll]
+        [MobileFindsByAll(Android = true, IOS = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -162,11 +125,8 @@ namespace Appium.Samples.PageObjects
         private IList<IOSElement> matchedToAllLocatorsElements;
 
         /////////////////////////////////////////////////////////////////
-        private object matchedToAllLocatorsElementProperty;
-        private object matchedToAllLocatorsElementsProperty;
-        /////////////////////////////////////////////////////////////////
-
         [FindsByAll]
+        [MobileFindsByAll(Android = true, IOS = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -179,17 +139,11 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 1)]
         private IMobileElement<IOSElement> TestMatchedToAllLocatorsElementProperty
         {
-            set
-            {
-                matchedToAllLocatorsElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<IOSElement>)matchedToAllLocatorsElementProperty;
-            }
+            set; get;
         }
 
         [FindsByAll]
+        [MobileFindsByAll(Android = true, IOS = true)]
         [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
         [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
         [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
@@ -202,14 +156,7 @@ namespace Appium.Samples.PageObjects
         [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 1)]
         private IList<IOSElement> TestMatchedToAllLocatorsElementsProperty
         {
-            set
-            {
-                matchedToAllLocatorsElementsProperty = value;
-            }
-            get
-            {
-                return (IList<IOSElement>)matchedToAllLocatorsElementsProperty;
-            }
+            set; get;
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/samples/PageObjects/IOSPageObjectChecksAttributeMixOnNativeApp.cs
+++ b/samples/PageObjects/IOSPageObjectChecksAttributeMixOnNativeApp.cs
@@ -1,0 +1,279 @@
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.PageObjects.Attributes;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjects
+{
+    public class IOSPageObjectChecksAttributeMixOnNativeApp
+    {
+        /////////////////////////////////////////////////////////////////
+        private object testMobileElementProperty;
+        private object testMobileElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IMobileElement<IOSElement> testMobileElement;
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IList<IOSElement> testMobileElements;
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IMobileElement<IOSElement> TestMobileElement
+        {
+            set
+            {
+                testMobileElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<IOSElement>)testMobileElementProperty;
+            }
+        }
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/text1\")")]
+        private IList<IOSElement> TestMobileElements
+        {
+            set
+            {
+                testMobileElementsProperty = value;
+            }
+            get
+            {
+                return (IList<IOSElement>)testMobileElementsProperty;
+            }
+        }
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(ClassName = "UIAUAIFakeClass", Priority = 1)]
+        [FindsByIOSUIAutomation(ID = "FakeID", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<IOSElement> testMultipleElement;
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(ClassName = "UIAUAIFakeClass", Priority = 1)]
+        [FindsByIOSUIAutomation(ID = "FakeID", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<IOSElement> testMultipleElements;
+
+
+        /////////////////////////////////////////////////////////////////
+        private object testMultipleFindByElementProperty;
+        private object testMultipleFindByElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(ClassName = "UIAUAIFakeClass", Priority = 1)]
+        [FindsByIOSUIAutomation(ID = "FakeID", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IMobileElement<IOSElement> TestMultipleFindByElementProperty
+        {
+            set
+            {
+                testMultipleFindByElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<IOSElement>)testMultipleFindByElementProperty;
+            }
+        }
+
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(ClassName = "UIAUAIFakeClass", Priority = 1)]
+        [FindsByIOSUIAutomation(ID = "FakeID", Priority = 2)]
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]", Priority = 3)]
+
+        [FindsByAndroidUIAutomator(AndroidUIAutomator = "new UiSelector().resourceId(\"android:id/fakeId\")", Priority = 1)]
+        [FindsByAndroidUIAutomator(ID = "FakeId", Priority = 2)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 3)]
+        private IList<IOSElement> MultipleFindByElementsProperty
+        {
+            set
+            {
+                testMultipleFindByElementsProperty = value;
+            }
+            get
+            {
+                return (IList<IOSElement>)testMultipleFindByElementsProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 1)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector won't be added till the problem is worked out
+
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 1)]
+        private IMobileElement<IOSElement> matchedToAllLocatorsElement;
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 1)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector won't be added till the problem is worked out
+
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 1)]
+        private IList<IOSElement> matchedToAllLocatorsElements;
+
+        /////////////////////////////////////////////////////////////////
+        private object matchedToAllLocatorsElementProperty;
+        private object matchedToAllLocatorsElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 1)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector won't be added till the problem is worked out
+
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 1)]
+        private IMobileElement<IOSElement> TestMatchedToAllLocatorsElementProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<IOSElement>)matchedToAllLocatorsElementProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsBy(How = How.Id, Using = "FakeHTMLid", Priority = 1)]
+        [FindsBy(How = How.ClassName, Using = "FakeHTMLClass", Priority = 2)]
+        [FindsBy(How = How.XPath, Using = ".//fakeTag", Priority = 3)]
+
+        [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 1)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector won't be added till the problem is worked out
+
+        [FindsByAndroidUIAutomator(ID = "android:id/text1", Priority = 1)]
+        [FindsByAndroidUIAutomator(ClassName = "android.widget.TextView", Priority = 1)]
+        private IList<IOSElement> TestMatchedToAllLocatorsElementsProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementsProperty = value;
+            }
+            get
+            {
+                return (IList<IOSElement>)matchedToAllLocatorsElementsProperty;
+            }
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMobileElementText()
+        {
+            return testMobileElement.Text;
+        }
+
+        public int GetMobileElementSize()
+        {
+            return testMobileElements.Count;
+        }
+
+        public string GetMobileElementPropertyText()
+        {
+            return TestMobileElement.Text;
+        }
+
+        public int GetMobileElementPropertySize()
+        {
+            return TestMobileElements.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMultipleFindByElementText()
+        {
+            return testMultipleElement.Text;
+        }
+
+        public int GetMultipleFindByElementSize()
+        {
+            return testMultipleElements.Count;
+        }
+
+        public string GetMultipleFindByElementPropertyText()
+        {
+            return TestMultipleFindByElementProperty.Text;
+        }
+
+        public int GetMultipleFindByElementPropertySize()
+        {
+            return MultipleFindByElementsProperty.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMatchedToAllLocatorsElementText()
+        {
+            return matchedToAllLocatorsElement.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementSize()
+        {
+            return matchedToAllLocatorsElements.Count;
+        }
+
+        public string GetMatchedToAllLocatorsElementPropertyText()
+        {
+            return TestMatchedToAllLocatorsElementProperty.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementPropertySize()
+        {
+            return TestMatchedToAllLocatorsElementsProperty.Count;
+        }
+
+    }
+}

--- a/samples/PageObjects/IOSPageObjectChecksAttributesForNativeIOSApp.cs
+++ b/samples/PageObjects/IOSPageObjectChecksAttributesForNativeIOSApp.cs
@@ -1,0 +1,211 @@
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Appium.PageObjects.Attributes;
+using OpenQA.Selenium.Support.PageObjects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Samples.PageObjects
+{
+    public class IOSPageObjectChecksAttributesForNativeIOSApp
+    {
+        /////////////////////////////////////////////////////////////////
+        private object testMobileElementProperty;
+        private object testMobileElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        private IMobileElement<IOSElement> testMobileElement;
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        private IList<IOSElement> testMobileElements;
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        private IMobileElement<IOSElement> TestMobileElement
+        {
+            set
+            {
+                testMobileElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<IOSElement>)testMobileElementProperty;
+            }
+        }
+
+        [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
+        private IList<IOSElement> TestMobileElements
+        {
+            set
+            {
+                testMobileElementsProperty = value;
+            }
+            get
+            {
+                return (IList<IOSElement>)testMobileElementsProperty;
+            }
+        }
+
+        [FindsByIOSUIAutomation(ID = "FakeID", Priority = 1)]
+        [FindsByIOSUIAutomation(ClassName = "UIAUAIFakeClass", Priority = 2)]
+        [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 3)]
+        private IMobileElement<IOSElement> testMultipleElement;
+
+        [FindsByIOSUIAutomation(ID = "FakeID", Priority = 1)]
+        [FindsByIOSUIAutomation(ClassName = "UIAUAIFakeClass", Priority = 2)]
+        [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 3)]
+        private IList<IOSElement> testMultipleElements;
+
+
+        /////////////////////////////////////////////////////////////////
+        private object testMultipleFindByElementProperty;
+        private object testMultipleFindByElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsByIOSUIAutomation(ID = "FakeID", Priority = 1)]
+        [FindsByIOSUIAutomation(ClassName = "UIAUAIFakeClass", Priority = 2)]
+        [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 3)]
+        private IMobileElement<IOSElement> TestMultipleFindByElementProperty
+        {
+            set
+            {
+                testMultipleFindByElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<IOSElement>)testMultipleFindByElementProperty;
+            }
+        }
+
+        [FindsByIOSUIAutomation(ID = "FakeID", Priority = 1)]
+        [FindsByIOSUIAutomation(ClassName = "UIAUAIFakeClass", Priority = 2)]
+        [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 3)]
+        private IList<IOSElement> MultipleFindByElementsProperty
+        {
+            set
+            {
+                testMultipleFindByElementsProperty = value;
+            }
+            get
+            {
+                return (IList<IOSElement>)testMultipleFindByElementsProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 1)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector won't be added till the problem is worked out
+        private IMobileElement<IOSElement> matchedToAllLocatorsElement;
+
+        [FindsByAll]
+        [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 1)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector won't be added till the problem is worked out
+        private IList<IOSElement> matchedToAllLocatorsElements;
+
+        /////////////////////////////////////////////////////////////////
+        private object matchedToAllLocatorsElementProperty;
+        private object matchedToAllLocatorsElementsProperty;
+        /////////////////////////////////////////////////////////////////
+
+        [FindsByAll]
+        [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 1)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector won't be added till the problem is worked out
+        private IMobileElement<IOSElement> TestMatchedToAllLocatorsElementProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementProperty = value;
+            }
+            get
+            {
+                return (IMobileElement<IOSElement>)matchedToAllLocatorsElementProperty;
+            }
+        }
+
+        [FindsByAll]
+        [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 1)]
+        //Equals method of RemoteWebElement is not consistent for mobile apps
+        //The second selector won't be added till the problem is worked out
+        private IList<IOSElement> TestMatchedToAllLocatorsElementsProperty
+        {
+            set
+            {
+                matchedToAllLocatorsElementsProperty = value;
+            }
+            get
+            {
+                return (IList<IOSElement>)matchedToAllLocatorsElementsProperty;
+            }
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMobileElementText()
+        {
+            return testMobileElement.Text;
+        }
+
+        public int GetMobileElementSize()
+        {
+            return testMobileElements.Count;
+        }
+
+        public string GetMobileElementPropertyText()
+        {
+            return TestMobileElement.Text;
+        }
+
+        public int GetMobileElementPropertySize()
+        {
+            return TestMobileElements.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMultipleFindByElementText()
+        {
+            return testMultipleElement.Text;
+        }
+
+        public int GetMultipleFindByElementSize()
+        {
+            return testMultipleElements.Count;
+        }
+
+        public string GetMultipleFindByElementPropertyText()
+        {
+            return TestMultipleFindByElementProperty.Text;
+        }
+
+        public int GetMultipleFindByElementPropertySize()
+        {
+            return MultipleFindByElementsProperty.Count;
+        }
+
+        //////////////////////////////////////////////////////////////////////////
+        public string GetMatchedToAllLocatorsElementText()
+        {
+            return matchedToAllLocatorsElement.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementSize()
+        {
+            return matchedToAllLocatorsElements.Count;
+        }
+
+        public string GetMatchedToAllLocatorsElementPropertyText()
+        {
+            return TestMatchedToAllLocatorsElementProperty.Text;
+        }
+
+        public int GetMatchedToAllLocatorsElementPropertySize()
+        {
+            return TestMatchedToAllLocatorsElementsProperty.Count;
+        }
+
+    }
+}

--- a/samples/PageObjects/IOSPageObjectChecksAttributesForNativeIOSApp.cs
+++ b/samples/PageObjects/IOSPageObjectChecksAttributesForNativeIOSApp.cs
@@ -13,9 +13,6 @@ namespace Appium.Samples.PageObjects
     public class IOSPageObjectChecksAttributesForNativeIOSApp
     {
         /////////////////////////////////////////////////////////////////
-        private object testMobileElementProperty;
-        private object testMobileElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
         [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
         private IMobileElement<IOSElement> testMobileElement;
@@ -26,27 +23,13 @@ namespace Appium.Samples.PageObjects
         [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
         private IMobileElement<IOSElement> TestMobileElement
         {
-            set
-            {
-                testMobileElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<IOSElement>)testMobileElementProperty;
-            }
+            set; get;
         }
 
         [FindsByIOSUIAutomation(IosUIAutomation = ".elements()[0]")]
         private IList<IOSElement> TestMobileElements
         {
-            set
-            {
-                testMobileElementsProperty = value;
-            }
-            get
-            {
-                return (IList<IOSElement>)testMobileElementsProperty;
-            }
+            set; get;
         }
 
         [FindsByIOSUIAutomation(ID = "FakeID", Priority = 1)]
@@ -61,23 +44,13 @@ namespace Appium.Samples.PageObjects
 
 
         /////////////////////////////////////////////////////////////////
-        private object testMultipleFindByElementProperty;
-        private object testMultipleFindByElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
         [FindsByIOSUIAutomation(ID = "FakeID", Priority = 1)]
         [FindsByIOSUIAutomation(ClassName = "UIAUAIFakeClass", Priority = 2)]
         [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 3)]
         private IMobileElement<IOSElement> TestMultipleFindByElementProperty
         {
-            set
-            {
-                testMultipleFindByElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<IOSElement>)testMultipleFindByElementProperty;
-            }
+            set; get;
         }
 
         [FindsByIOSUIAutomation(ID = "FakeID", Priority = 1)]
@@ -85,63 +58,39 @@ namespace Appium.Samples.PageObjects
         [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 3)]
         private IList<IOSElement> MultipleFindByElementsProperty
         {
-            set
-            {
-                testMultipleFindByElementsProperty = value;
-            }
-            get
-            {
-                return (IList<IOSElement>)testMultipleFindByElementsProperty;
-            }
+            set; get;
         }
 
-        [FindsByAll]
+        [MobileFindsByAll(IOS = true)]
         [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 1)]
         //Equals method of RemoteWebElement is not consistent for mobile apps
         //The second selector won't be added till the problem is worked out
         private IMobileElement<IOSElement> matchedToAllLocatorsElement;
 
-        [FindsByAll]
+        [MobileFindsByAll(IOS = true)]
         [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 1)]
         //Equals method of RemoteWebElement is not consistent for mobile apps
         //The second selector won't be added till the problem is worked out
         private IList<IOSElement> matchedToAllLocatorsElements;
 
         /////////////////////////////////////////////////////////////////
-        private object matchedToAllLocatorsElementProperty;
-        private object matchedToAllLocatorsElementsProperty;
-        /////////////////////////////////////////////////////////////////
 
-        [FindsByAll]
+        [MobileFindsByAll(IOS = true)]
         [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 1)]
         //Equals method of RemoteWebElement is not consistent for mobile apps
         //The second selector won't be added till the problem is worked out
         private IMobileElement<IOSElement> TestMatchedToAllLocatorsElementProperty
         {
-            set
-            {
-                matchedToAllLocatorsElementProperty = value;
-            }
-            get
-            {
-                return (IMobileElement<IOSElement>)matchedToAllLocatorsElementProperty;
-            }
+            set; get;
         }
 
-        [FindsByAll]
+        [MobileFindsByAll(IOS = true)]
         [FindsByIOSUIAutomation(ClassName = "UIAButton", Priority = 1)]
         //Equals method of RemoteWebElement is not consistent for mobile apps
         //The second selector won't be added till the problem is worked out
         private IList<IOSElement> TestMatchedToAllLocatorsElementsProperty
         {
-            set
-            {
-                matchedToAllLocatorsElementsProperty = value;
-            }
-            get
-            {
-                return (IList<IOSElement>)matchedToAllLocatorsElementsProperty;
-            }
+            set; get;
         }
 
         //////////////////////////////////////////////////////////////////////////

--- a/samples/packages.config
+++ b/samples/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
-  <package id="Selenium.WebDriver" version="2.44.0" targetFramework="net40" />
+  <package id="Selenium.Support" version="2.46.0" targetFramework="net40" />
+  <package id="Selenium.WebDriver" version="2.46.0" targetFramework="net40" />
 </packages>

--- a/samples/samples.csproj
+++ b/samples/samples.csproj
@@ -38,9 +38,13 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.6.0.5\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver, Version=2.44.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="WebDriver, Version=2.46.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SolutionDir)\packages\Selenium.WebDriver.2.44.0\lib\net40\WebDriver.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Selenium.WebDriver.2.46.0\lib\net40\WebDriver.dll</HintPath>
+    </Reference>
+    <Reference Include="WebDriver.Support, Version=2.46.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>$(SolutionDir)\packages\Selenium.Support.2.46.0\lib\net40\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -65,6 +69,16 @@
     <Compile Include="AndroidWebviewTest.cs" />
     <Compile Include="AndroidComplexTest.cs" />
     <Compile Include="AndroidLocalServerTest.cs" />
+    <Compile Include="PageObjects\AndroidPageObjectChecksSelendroidModeOnNativeApp.cs" />
+    <Compile Include="PageObjects\AndroidPageObjectChecksAttributeMixOnNativeApp2.cs" />
+    <Compile Include="PageObjects\AndroidPageObjectChecksAttributeMixOnNativeApp1.cs" />
+    <Compile Include="PageObjects\AndroidPageObjectChecksAppributesForNativeAndroidApp.cs" />
+    <Compile Include="PageObjects\AndroidPageObjectChecksSeleniumFindsByCompatibility.cs" />
+    <Compile Include="PageObjectTests\Android\AndroidTestThatChecksAttributeMix3SelendroidMode.cs" />
+    <Compile Include="PageObjectTests\Android\AndroidTestThatChecksAttributeMix2.cs" />
+    <Compile Include="PageObjectTests\Android\AndroidTestThatChecksAttributeMix1.cs" />
+    <Compile Include="PageObjectTests\Android\AndroidNativeAppAttributesTest.cs" />
+    <Compile Include="PageObjectTests\Android\SeleniumAttributesCompatipilityTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/samples/samples.csproj
+++ b/samples/samples.csproj
@@ -69,6 +69,7 @@
     <Compile Include="AndroidWebviewTest.cs" />
     <Compile Include="AndroidComplexTest.cs" />
     <Compile Include="AndroidLocalServerTest.cs" />
+    <Compile Include="PageObjects\AndroidWebView.cs" />
     <Compile Include="PageObjects\IOSPageObjectChecksAttributeMixOnNativeApp.cs" />
     <Compile Include="PageObjects\IOSPageObjectChecksAttributesForNativeIOSApp.cs" />
     <Compile Include="PageObjects\AndroidPageObjectChecksSelendroidModeOnNativeApp.cs" />
@@ -80,10 +81,12 @@
     <Compile Include="PageObjectTests\Android\AndroidTestThatChecksAttributeMix2.cs" />
     <Compile Include="PageObjectTests\Android\AndroidTestThatChecksAttributeMix1.cs" />
     <Compile Include="PageObjectTests\Android\AndroidNativeAppAttributesTest.cs" />
+    <Compile Include="PageObjectTests\Android\AndroidWebViewTest.cs" />
     <Compile Include="PageObjectTests\Android\SeleniumAttributesCompatipilityTest.cs" />
     <Compile Include="PageObjectTests\DesktopBrowserCompatibility\DesctopBrowserCompatibilityTest.cs" />
     <Compile Include="PageObjectTests\IOS\IOSTestThatChecksAttributeMix.cs" />
     <Compile Include="PageObjectTests\IOS\IOSNativeAppAttributesTest.cs" />
+    <Compile Include="PageObjectTests\NegativeTests\NoSuchElementTestOnAndroid.cs" />
     <Compile Include="PageObjectTests\TimeOutManagement\TimeOutManagementTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/samples/samples.csproj
+++ b/samples/samples.csproj
@@ -69,16 +69,20 @@
     <Compile Include="AndroidWebviewTest.cs" />
     <Compile Include="AndroidComplexTest.cs" />
     <Compile Include="AndroidLocalServerTest.cs" />
+    <Compile Include="PageObjects\IOSPageObjectChecksAttributeMixOnNativeApp.cs" />
+    <Compile Include="PageObjects\IOSPageObjectChecksAttributesForNativeIOSApp.cs" />
     <Compile Include="PageObjects\AndroidPageObjectChecksSelendroidModeOnNativeApp.cs" />
     <Compile Include="PageObjects\AndroidPageObjectChecksAttributeMixOnNativeApp2.cs" />
     <Compile Include="PageObjects\AndroidPageObjectChecksAttributeMixOnNativeApp1.cs" />
-    <Compile Include="PageObjects\AndroidPageObjectChecksAppributesForNativeAndroidApp.cs" />
+    <Compile Include="PageObjects\AndroidPageObjectChecksAttributesForNativeAndroidApp.cs" />
     <Compile Include="PageObjects\AndroidPageObjectChecksSeleniumFindsByCompatibility.cs" />
     <Compile Include="PageObjectTests\Android\AndroidTestThatChecksAttributeMix3SelendroidMode.cs" />
     <Compile Include="PageObjectTests\Android\AndroidTestThatChecksAttributeMix2.cs" />
     <Compile Include="PageObjectTests\Android\AndroidTestThatChecksAttributeMix1.cs" />
     <Compile Include="PageObjectTests\Android\AndroidNativeAppAttributesTest.cs" />
     <Compile Include="PageObjectTests\Android\SeleniumAttributesCompatipilityTest.cs" />
+    <Compile Include="PageObjectTests\IOS\IOSTestThatChecksAttributeMix.cs" />
+    <Compile Include="PageObjectTests\IOS\IOSNativeAppAttributesTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/samples/samples.csproj
+++ b/samples/samples.csproj
@@ -81,8 +81,10 @@
     <Compile Include="PageObjectTests\Android\AndroidTestThatChecksAttributeMix1.cs" />
     <Compile Include="PageObjectTests\Android\AndroidNativeAppAttributesTest.cs" />
     <Compile Include="PageObjectTests\Android\SeleniumAttributesCompatipilityTest.cs" />
+    <Compile Include="PageObjectTests\DesktopBrowserCompatibility\DesctopBrowserCompatibilityTest.cs" />
     <Compile Include="PageObjectTests\IOS\IOSTestThatChecksAttributeMix.cs" />
     <Compile Include="PageObjectTests\IOS\IOSNativeAppAttributesTest.cs" />
+    <Compile Include="PageObjectTests\TimeOutManagement\TimeOutManagementTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/test/packages.config
+++ b/test/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
-  <package id="Selenium.WebDriver" version="2.43.0" targetFramework="net40" />
+  <package id="Selenium.WebDriver" version="2.46.0" targetFramework="net40" />
 </packages>

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -38,9 +38,9 @@
     <Reference Include="nunit.framework">
       <HintPath>$(SolutionDir)\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver, Version=2.43.0.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="WebDriver, Version=2.46.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SolutionDir)\packages\Selenium.WebDriver.2.43.0\lib\net40\WebDriver.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Selenium.WebDriver.2.46.0\lib\net40\WebDriver.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hi guys!

There is the change list:
- interface IMobileElement was added and AppiumWebElement is implementing it

- the project is referring to WebDriver.Support 2.46.0.0 and Castle.Core 3.3.0.0 now.

- integration with Selenium page object tools. Details are below.
[Information about Page Object design pattern.](https://code.google.com/p/selenium/wiki/PageObjects).  [Information about PageFactory. Here is java version. Sorry. The .Net version works the similar way.](https://code.google.com/p/selenium/wiki/PageFactory)

## The common use case looks as usual.

A single element:
```c#
using OpenQA.Selenium.Support.PageObjects;
...

[FindsBy(How = How.ClassName, Using = "theClassOfAnElement")]
IWebElement targetElement;
```

or

```c#
using OpenQA.Selenium.Support.PageObjects;
using OpenQA.Selenium.Appium.Interfaces;
using OpenQA.Selenium.Appium;
...

[FindsBy(How = How.ClassName, Using = "theClassOfAnElement")]
IMobileElement<AppiumWebElement> targetElement;
```

A list of elements:

```c#
using OpenQA.Selenium.Support.PageObjects;
...

[FindsBy(How = How.ClassName, Using = "theClassOfAnElement")]
IList<IWebElement> targetElements;
```

or

```c#
using OpenQA.Selenium.Support.PageObjects;
using OpenQA.Selenium.Appium.Interfaces;
using OpenQA.Selenium.Appium;
...

[FindsBy(How = How.ClassName, Using = "theClassOfAnElement")]
IList<AppiumWebElement> targetElement;
```

### The following is also available:

A single element property:

```c#
using OpenQA.Selenium.Support.PageObjects;
...

[FindsBy(How = How.ClassName, Using = "theClassOfAnElement")]]
private IWebElement TargetElement
{
       set; get;
}
```

or

```c#
using OpenQA.Selenium.Support.PageObjects;
using OpenQA.Selenium.Appium.Interfaces;
using OpenQA.Selenium.Appium;
...

[FindsBy(How = How.ClassName, Using = "theClassOfAnElement")]]
private IMobileElement<AppiumWebElement> TargetElement
{
       set; get;
}
```

A list of elements property:

```c#
using OpenQA.Selenium.Support.PageObjects;
...

[FindsBy(How = How.ClassName, Using = "theClassOfAnElement")]]
private IList<IWebElement> TargetElements
{
       set; get;
}
```

or

```c#
using OpenQA.Selenium.Support.PageObjects;
using OpenQA.Selenium.Appium.Interfaces;
using OpenQA.Selenium.Appium;
...

[FindsBy(How = How.ClassName, Using = "theClassOfAnElement")]]
private IList<AppiumWebElement> TargetElement
{
       set; get;
}
```

### How to populate fields and properties

```c#
using OpenQA.Selenium.Appium.PageObjects;
using OpenQA.Selenium.Support.PageObjects;
...

PageObject screenOrPage = new PageObject();
ISearcContext context;
...
PageFactory.InitElements(context, screenOrPage , new AppiumPageObjectMemberDecorator());
```

or 

```c#
using OpenQA.Selenium.Appium.PageObjects;
using OpenQA.Selenium.Support.PageObjects;
...

PageObject screenOrPage = new PageObject();
ISearcContext context;
TimeOutDuration timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0)); //time 
//of the waiting for elements in general
...
PageFactory.InitElements(context, screenOrPage , new 
AppiumPageObjectMemberDecorator(timeSpan ));
```

### What fields and properties are populated: 

If there is a single element then __IWebElement__ and __IMobileElement<>__ are available. The list of __IMobileElement<>__ parameters is below:
                    - IWebElement
                    - RemoteWebElement
                    - AppiumWebElement
                    - AndroidElement
                    - IOSElement

If there is a list of elements then __IList<>__ with same parameters is can be populated.

The described use case is good when Page/Screen object is for web testing or testing on Android/IOS only. Locators such as __css__, __linkText__ and __partialLinkText__ are invalid for Android/IOS native app testing.

## Advanced use cases

If Page/Screen object is supposed to be reused in crossplatform testing (web testing + Android/iOS native app testing) and a target service/app has the similar  UI for all plaforms then

```c#
using OpenQA.Selenium.Appium.PageObjects.Attributes;
using OpenQA.Selenium.Support.PageObjects;
...

[FindsBy(How = How.Id, Using = "TargetID")] //this locator will be used for Html content at desktop
//or mobile browser/webview
[FindsByIOSUIAutomation(Name = "The name of the iOS native element")] //this locator will be used
//for an iOS native content
[FindsByAndroidUIAutomator(Accesibility = "The accessibility id of the Android native element")] 
//this locator will be used for an Android native content
[FindsBySelendroid(ID = "The selendroid mode element Id")]
IWebElenent target;

//the same is available for lists and element/list properties.
```

### If there are few possible locators

```c#
using OpenQA.Selenium.Appium.PageObjects.Attributes;
using OpenQA.Selenium.Support.PageObjects;
...

[FindsBy(How = How.Id, Using = "TargetID1", Priority = 1)] [FindsBy(How = How.Id, Using = "TargetID2", Priority = 2)] 
[FindsByIOSUIAutomation(Name = "The name of the iOS native element", Priority = 1)] 
[FindsByIOSUIAutomation(Id = "The id of the iOS native element", Priority = 2)] 
//and so on
//The "Priority" property defines a queue of the using of the locator to find elements 
IWebElenent target;

```

### If there is chained searching

```c#
using OpenQA.Selenium.Appium.PageObjects.Attributes;
using OpenQA.Selenium.Support.PageObjects;
...

[FindsBySequence] //is used with Selenium FindsBy
[FindsBy(How = How.Id, Using = "TargetID1", Priority = 1)] [FindsBy(How = How.Id, Using = "TargetID2", Priority = 2)] 
[MobileFindsBySequence(Android = true, IOS = true)] //"Android" and "IOS" properties = true
//mean that the chained searching uses defined locators on these platforms/with these automation
//types
[FindsByIOSUIAutomation(Name = "The name of the iOS native element", Priority = 1)] 
[FindsByIOSUIAutomation(Id = "The id of the iOS native element", Priority = 2)] 
//and so on
IWebElenent target;

```

### If desired elements should match few locators 

then

```c#
using OpenQA.Selenium.Appium.PageObjects.Attributes;
using OpenQA.Selenium.Support.PageObjects;
...

[FindsByAll] //is used with Selenium FindsBy
[FindsBy(How = How.Id, Using = "TargetID1", Priority = 1)] [FindsBy(How = How.ClassName, Using = "TargetID2", Priority = 2)] 
[MobileFindsByAll(Android = true, IOS = true)] //"Android" and "IOS" properties = true
//mean that found elements should match all defined locators on these platforms/with these
// automation types
[FindsByIOSUIAutomation(Name = "The name of the iOS native element", Priority = 1)] 
[FindsByIOSUIAutomation(ID = "The id of the iOS native element", Priority = 2)] 
//and so on
IWebElenent target;

```

### If time of the waiting for elements differs from general

```c#
using OpenQA.Selenium.Appium.PageObjects.Attributes;
using OpenQA.Selenium.Support.PageObjects;
...

[WithTimeSpan(Seconds = 15)]
[FindsBy(How = How.Id, Using = "TargetID")] 
//and so on
IWebElenent target;

```

### If it needs to change general timeout of the waiting for elements 

```c#
using OpenQA.Selenium.Appium.PageObjects;
using OpenQA.Selenium.Support.PageObjects;
...

PageObject screenOrPage = new PageObject();
ISearcContext context;
TimeOutDuration duration = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0)); //time 
//of the waiting for elements in general
...
PageFactory.InitElements(context, screenOrPage , new 
AppiumPageObjectMemberDecorator(duration));

//tons of user's code
TimeSpan newTime = new TimeSpan(0, 0, 0, 20, 500);
duration.WaitingDuration = newTime; //and here we go!
```

@Astro03 @Jonahss @bootstraponline 
Please review this. Be careful. There is tons of code : )

PS: Maybe @jimevans would like to look at this PR too ;)