### PR TITLE
Patch to enable xmldoc

### DIFF
--- a/appium-dotnet-driver/appium-dotnet-driver.csproj
+++ b/appium-dotnet-driver/appium-dotnet-driver.csproj
@@ -26,6 +26,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <DocumentationFile>bin\Release\appium-dotnet-driver.XML</DocumentationFile>    
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Castle.Core">

--- a/appium-dotnet-driver/appium-dotnet-driver.nuspec
+++ b/appium-dotnet-driver/appium-dotnet-driver.nuspec
@@ -49,7 +49,8 @@
   </dependencies>
   </metadata>
   <files>
-    <file src="bin/Release/appium-dotnet-driver.dll" target="lib/net40/appium-dotnet-driver.dll" /> 
+    <file src="bin/Release/appium-dotnet-driver.dll" target="lib/net40/appium-dotnet-driver.dll" />
+    <file src="bin/Release/appium-dotnet-driver.XML" target="lib/net40/appium-dotnet-driver.XML" /> 
   </files>
 </package>
  


### PR DESCRIPTION
This patch enables xmldoc generation:
- during a release build, xmldoc file is generated
- during creation of the nuget package, the xmldoc is included in the nuget package

This enables to see the xml documentation using intellisense:
![image](https://cloud.githubusercontent.com/assets/1618378/11213617/2eabb5f0-8d3d-11e5-8655-4e894b6d82c1.png)
