### PR TITLE
#137 fix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ##1.5.1.1
 - Update to Selenium.Webdriver v2.52.0 and Selenium.Support v2.52.0
 - FIXED The issue of compatibility of AppiumServiceBuilder with Appium node server v >= 1.5.x.
+- Page object tools were updated. By.Name locator strategy is deprecated for Android and iOS. It is still valid for the Selendroid mode. 
 
 ##1.5.0.1
 - Update to Selenium.Webdriver v2.48.2 and Selenium.Support v2.48.2

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/Abstract/FindsByMobileAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/Abstract/FindsByMobileAttribute.cs
@@ -238,21 +238,7 @@ namespace OpenQA.Selenium.Appium.PageObjects.Attributes.Abstract
             }
         }
 
-        /// <summary>
-        /// Sets the target element name
-        /// </summary>
-        public String Name
-        {
-            set
-            {
-                byList.Add(By.Name(value));
-            }
-            get
-            {
-                return null;
-            }
-        }
-
+        
         /// <summary>
         /// Sets the target element xpath
         /// </summary>

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/Abstract/FindsByUIAutomatorsAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/Abstract/FindsByUIAutomatorsAttribute.cs
@@ -32,5 +32,22 @@ namespace OpenQA.Selenium.Appium.PageObjects.Attributes.Abstract
                 return null;
             }
         }
+
+        /// <summary>
+        /// Sets the target element name
+        /// </summary>
+        [Obsolete("By.name selector is not supported by Appium server node since 1.5.x. " +
+            "So this option is going to be removed further. Be careful.")]
+        public String Name
+        {
+            set
+            {
+                byList.Add(By.Name(value));
+            }
+            get
+            {
+                return null;
+            }
+        }
     }
 }

--- a/appium-dotnet-driver/Appium/PageObjects/Attributes/FindsBySelendroidAttribute.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Attributes/FindsBySelendroidAttribute.cs
@@ -50,5 +50,20 @@ namespace OpenQA.Selenium.Appium.PageObjects.Attributes
                 return null;
             }
         }
+
+        /// <summary>
+        /// Sets the target element name
+        /// </summary>
+        public String Name
+        {
+            set
+            {
+                byList.Add(By.Name(value));
+            }
+            get
+            {
+                return null;
+            }
+        }
     }
 }

--- a/appium-dotnet-driver/Appium/PageObjects/ByFactory.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/ByFactory.cs
@@ -50,8 +50,7 @@ namespace OpenQA.Selenium.Appium.PageObjects
 
             if (attributes.Length == 0)
             {
-                bys.Add(new ByIdOrName(member.Name));
-                return bys.AsReadOnly();
+                return null;
             }
 
             Array.Sort(attributes);
@@ -166,19 +165,35 @@ namespace OpenQA.Selenium.Appium.PageObjects
             string automation = GetAutomation(context);
 
             IEnumerable<By> defaultBys = CreateDefaultLocatorList(member);
-            ReadOnlyCollection<By> defaultByList = new List<By>(defaultBys).AsReadOnly();
-
             IEnumerable<By> nativeBys = CreateNativeContextLocatorList(member, platform, automation);
-            IList<By> nativeByList = null;
+
+            if (defaultBys == null && nativeBys == null)
+            {
+                List<By> defaultList = new List<By>();
+                defaultList.Add(new ByIdOrName(member.Name));
+
+                List<By> nativeList = new List<By>();
+                nativeList.Add(By.Id(member.Name));
+
+                defaultBys = defaultList;
+                nativeBys = nativeList;
+            }
+
+            if (defaultBys == null)
+            {
+                List<By> defaultList = new List<By>();
+                defaultList.Add(new ByIdOrName(member.Name));
+                defaultBys = defaultList;
+            }
 
             if (nativeBys == null)
-                nativeByList = defaultByList;
-            else
-                nativeByList = new List<By>(nativeBys).AsReadOnly();
+            {
+                nativeBys = defaultBys;
+            }
 
             Dictionary<ContentTypes, IEnumerable<By>> map = new Dictionary<ContentTypes, IEnumerable<By>>();
-            map.Add(ContentTypes.HTML, defaultByList);
-            map.Add(ContentTypes.NATIVE, nativeByList);
+            map.Add(ContentTypes.HTML, defaultBys);
+            map.Add(ContentTypes.NATIVE, nativeBys);
             ContentMappedBy by = new ContentMappedBy(map);
             List<By> bys = new List<By>();
             bys.Add(by);

--- a/appium-dotnet-driver/Appium/PageObjects/Interceptors/SearchingInterceptor.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Interceptors/SearchingInterceptor.cs
@@ -44,21 +44,6 @@ namespace OpenQA.Selenium.Appium.PageObjects.Interceptors
 
         internal abstract object getTarget(IInvocation invocation);
 
-        private static bool IsInvalidSelectorRootCause(Exception e)
-        {
-            String invalid_selector_pattern = "Invalid locator strategy:";
-            if (e == null)
-                return false;
-
-            string message = e.Message;
-
-            if (!String.IsNullOrWhiteSpace(message) && message.Contains(invalid_selector_pattern))
-                return true;
-
-            return IsInvalidSelectorRootCause(e.InnerException);
-        }
-
-
         internal static Func<IElementLocator, ReadOnlyCollection<IWebElement>> ReturnWaitingFunction(IElementLocator locator,
             IEnumerable<By> bys)
         {
@@ -80,9 +65,7 @@ namespace OpenQA.Selenium.Appium.PageObjects.Interceptors
                     }
                     catch (Exception e)
                     {
-                        if (!IsInvalidSelectorRootCause(e))
-                            throw e;
-                        continue;
+                        throw e;
                     }
 
                 }

--- a/appium-dotnet-driver/appium-dotnet-driver.nuspec
+++ b/appium-dotnet-driver/appium-dotnet-driver.nuspec
@@ -15,6 +15,7 @@
       1.5.1.1
       Update to Selenium.Webdriver v2.52.0 and Selenium.Support v2.52.0
       FIXED The issue of compatibility of AppiumServiceBuilder with Appium node server v >= 1.5.x.
+      Page object tools were updated. By.Name locator strategy is deprecated for Android and iOS. It is still valid for the Selendroid mode. 
       1.5.0.1
       Update to Selenium.Webdriver v2.48.2 and Selenium.Support v2.48.2
       The ability to start appium server programmatically was provided. The ICommandServer implementation (AppiumLocalService).

--- a/integration_tests/integration_tests.csproj
+++ b/integration_tests/integration_tests.csproj
@@ -38,13 +38,13 @@
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="WebDriver, Version=2.48.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SolutionDir)\packages\Selenium.WebDriver.2.48.1\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=2.52.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.2.52.0\lib\net40\WebDriver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=2.48.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SolutionDir)\packages\Selenium.Support.2.48.1\lib\net40\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=2.52.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.2.52.0\lib\net40\WebDriver.Support.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/integration_tests/packages.config
+++ b/integration_tests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
-  <package id="Selenium.Support" version="2.48.1" targetFramework="net40" />
-  <package id="Selenium.WebDriver" version="2.48.1" targetFramework="net40" />
+  <package id="Selenium.Support" version="2.52.0" targetFramework="net4" />
+  <package id="Selenium.WebDriver" version="2.52.0" targetFramework="net4" />
 </packages>

--- a/test/packages.config
+++ b/test/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net40" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
-  <package id="Selenium.Support" version="2.48.1" targetFramework="net40" />
-  <package id="Selenium.WebDriver" version="2.48.1" targetFramework="net40" />
+  <package id="Selenium.Support" version="2.52.0" targetFramework="net4" />
+  <package id="Selenium.WebDriver" version="2.52.0" targetFramework="net4" />
 </packages>

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -38,13 +38,13 @@
     <Reference Include="nunit.framework">
       <HintPath>$(SolutionDir)\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver, Version=2.48.1.0, Culture=neutral, processorArchitecture=MSIL">
-	  <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SolutionDir)\packages\Selenium.WebDriver.2.48.1\lib\net40\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=2.52.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.2.52.0\lib\net40\WebDriver.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=2.48.1.0, Culture=neutral, processorArchitecture=MSIL">
-	  <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SolutionDir)\packages\Selenium.Support.2.48.1\lib\net40\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=2.52.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.2.52.0\lib\net40\WebDriver.Support.dll</HintPath>
+      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Chang List:
- tests were updated to Selenium v2.52.0

- fix of #137. Page object tools were updated. By.Name locator strategy is deprecated for Android and iOS. It is still valid for the Selendroid mode.