### PR TITLE
#134 FIX

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,9 @@
 - Update to Selenium.Webdriver v2.52.0 and Selenium.Support v2.52.0
 - FIXED The issue of compatibility of AppiumServiceBuilder with Appium node server v >= 1.5.x.
 - Page object tools were updated. By.Name locator strategy is deprecated for Android and iOS. It is still valid for the Selendroid mode. 
+- The DeviceTime property was added and it works with Appium node 1.5
+- improvements of locking methods. The LockDevice(seconds) is obsolete and it is going to be removed in the next release. Since Appium node server v1.5.x it is recommended to use 
+AndroidDriver.Lock()()...AndroidDriver.Unlock() or IOSDriver.Lock(int seconds) instead.
 
 ##1.5.0.1
 - Update to Selenium.Webdriver v2.48.2 and Selenium.Support v2.48.2

--- a/appium-dotnet-driver/Appium/Android/AndroidDriver.cs
+++ b/appium-dotnet-driver/Appium/Android/AndroidDriver.cs
@@ -231,17 +231,6 @@ namespace OpenQA.Selenium.Appium.Android
 
 
         /// <summary>
-        /// Check if the device is locked
-        /// </summary>
-        /// <returns>true if device is locked, false otherwise</returns>
-        public bool IsLocked()
-        {
-            var commandResponse = this.Execute(AppiumDriverCommand.IsLocked, null);
-            return (bool)commandResponse.Value;
-        }
-
-
-        /// <summary>
         /// Gets Current Device Activity.
         /// </summary>
         /// 
@@ -381,7 +370,36 @@ namespace OpenQA.Selenium.Appium.Android
         {
             return "new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(" + uiSelector + ".instance(0));";
         }
+        #endregion
 
+        #region locking
+        /**
+        * This method locks a device.
+        */
+        public void Lock()
+        {
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters.Add("seconds", 0);
+            this.Execute(AppiumDriverCommand.LockDevice, parameters);
+        }
+
+        /// <summary>
+        /// Check if the device is locked
+        /// </summary>
+        /// <returns>true if device is locked, false otherwise</returns>
+        public bool IsLocked()
+        {
+            var commandResponse = this.Execute(AppiumDriverCommand.IsLocked, null);
+            return (bool)commandResponse.Value;
+        }
+
+        /**
+         * This method unlocks a device.
+         */
+        public void Unlock()
+        {
+            this.Execute(AppiumDriverCommand.UnlockDevice, null);
+        }
         #endregion
 
     }

--- a/appium-dotnet-driver/Appium/AppiumCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumCommand.cs
@@ -33,6 +33,7 @@ namespace OpenQA.Selenium.Appium
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.ShakeDevice, "/session/{sessionId}/appium/device/shake"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.LockDevice, "/session/{sessionId}/appium/device/lock"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.IsLocked, "/session/{sessionId}/appium/device/is_locked"),
+                new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.UnlockDevice, "/session/{sessionId}/appium/device/unlock"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.ToggleAirplaneMode, "/session/{sessionId}/appium/device/toggle_airplane_mode"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.KeyEvent, "/session/{sessionId}/appium/device/keyevent"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.Rotate, "/session/{sessionId}/appium/device/rotate"),
@@ -82,6 +83,10 @@ namespace OpenQA.Selenium.Appium
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.ReplaceValue, "/session/{sessionId}/appium/element/{id}/replace_value"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.SetValue, "/session/{sessionId}/appium/element/{id}/value"),
                 #endregion Input value
+
+                #region Device Time
+                 new AppiumCommand(CommandInfo.GetCommand, AppiumDriverCommand.GetDeviceTime, "/session/{sessionId}/appium/device/system_time"),
+                #endregion Device Time
 
                 #endregion JSON Wire Protocol Commands
                 

--- a/appium-dotnet-driver/Appium/AppiumDriver.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriver.cs
@@ -902,7 +902,10 @@ namespace OpenQA.Selenium.Appium
         #endregion
 
         #region Device Time
-
+        /// <summary>
+        /// Gets device date and time for both iOS(Supports only real device) and Android devices
+        /// </summary>
+        /// <returns>A string which consists of date and time</returns>
         public String DeviceTime
         {
             get

--- a/appium-dotnet-driver/Appium/AppiumDriver.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriver.cs
@@ -352,6 +352,9 @@ namespace OpenQA.Selenium.Appium
         /// Locks the device.
         /// </summary>
         /// <param name="seconds">The number of seconds during which the device need to be locked for.</param>
+        [Obsolete("This method works incorrectly. It is deprecated and it is going to be removed further. " +
+            "Be careful. Since Appium node 1.5.x you are free to use. " +
+            "IOSDriver.Lock(int seconds) or AndroidDriver.Lock()...AndroidDriver.Unlock() instead")]
         public void LockDevice(int seconds)
         {
             Dictionary<string, object> parameters = new Dictionary<string, object>();
@@ -897,6 +900,19 @@ namespace OpenQA.Selenium.Appium
         }
 
         #endregion
+
+        #region Device Time
+
+        public String DeviceTime
+        {
+            get
+            {
+                var commandResponse = this.Execute(AppiumDriverCommand.GetDeviceTime, null);
+                return commandResponse.Value.ToString();
+            }
+        }
+
+        #endregion Device Time
 
         #endregion Public Methods
 

--- a/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
@@ -30,6 +30,11 @@ namespace OpenQA.Selenium.Appium
         public const string LockDevice = "lockDevice";
 
         /// <summary>
+        /// Represents the Unlock Device Mapping command
+        /// </summary>
+        public const string UnlockDevice = "unlockDevice";
+
+        /// <summary>
         /// Represents the Is Device Locked Mapping command
         /// </summary>
         public const string IsLocked = "isLocked";
@@ -251,6 +256,8 @@ namespace OpenQA.Selenium.Appium
         public const string ReplaceValue = "replaceValue";
 
         public const string SetValue = "setValue";
+
+        public const string GetDeviceTime = "getDeviceTime";
 
         #endregion JSON Wire Protocol
     }

--- a/appium-dotnet-driver/Appium/iOS/IOSDriver.cs
+++ b/appium-dotnet-driver/Appium/iOS/IOSDriver.cs
@@ -17,6 +17,7 @@ using OpenQA.Selenium.Appium.iOS.Interfaces;
 using OpenQA.Selenium.Appium.Service;
 using OpenQA.Selenium.Remote;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 namespace OpenQA.Selenium.Appium.iOS
@@ -176,6 +177,17 @@ namespace OpenQA.Selenium.Appium.iOS
                 return (W)((IFindByAccessibilityId<W>)element).FindElementByAccessibilityId(name);
             }
             return element;
+        }
+
+        /// <summary>
+        /// Locks the device.
+        /// </summary>
+        /// <param name="seconds">The number of seconds during which the device need to be locked for.</param>
+        public void Lock(int seconds)
+        {
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters.Add("seconds", seconds);
+            this.Execute(AppiumDriverCommand.LockDevice, parameters);
         }
     }
 }

--- a/appium-dotnet-driver/appium-dotnet-driver.nuspec
+++ b/appium-dotnet-driver/appium-dotnet-driver.nuspec
@@ -15,9 +15,9 @@
       1.5.1.1
       Update to Selenium.Webdriver v2.52.0 and Selenium.Support v2.52.0
       FIXED The issue of compatibility of AppiumServiceBuilder with Appium node server v >= 1.5.x.
-      Page object tools were updated. By.Name locator strategy is deprecated for Android and iOS. It is still valid for the Selendroid mode. 
-	  The DeviceTime property was added and it works with Appium node 1.5
-	  improvements of locking methods. The LockDevice(seconds) is obsolete and it is going to be removed in the next release. Since Appium node server v1.5.x it is recommended to use AndroidDriver.Lock()()...AndroidDriver.Unlock() or IOSDriver.Lock(int seconds) instead.
+      Page object tools were updated. By.Name locator strategy is deprecated for Android and iOS. It is still valid for the Selendroid mode.
+      The DeviceTime property was added and it works with Appium node 1.5
+      improvements of locking methods. The LockDevice(seconds) is obsolete and it is going to be removed in the next release. Since Appium node server v1.5.x it is recommended to use AndroidDriver.Lock()()...AndroidDriver.Unlock() or IOSDriver.Lock(int seconds) instead.
       1.5.0.1
       Update to Selenium.Webdriver v2.48.2 and Selenium.Support v2.48.2
       The ability to start appium server programmatically was provided. The ICommandServer implementation (AppiumLocalService).

--- a/appium-dotnet-driver/appium-dotnet-driver.nuspec
+++ b/appium-dotnet-driver/appium-dotnet-driver.nuspec
@@ -16,6 +16,8 @@
       Update to Selenium.Webdriver v2.52.0 and Selenium.Support v2.52.0
       FIXED The issue of compatibility of AppiumServiceBuilder with Appium node server v >= 1.5.x.
       Page object tools were updated. By.Name locator strategy is deprecated for Android and iOS. It is still valid for the Selendroid mode. 
+	  The DeviceTime property was added and it works with Appium node 1.5
+	  improvements of locking methods. The LockDevice(seconds) is obsolete and it is going to be removed in the next release. Since Appium node server v1.5.x it is recommended to use AndroidDriver.Lock()()...AndroidDriver.Unlock() or IOSDriver.Lock(int seconds) instead.
       1.5.0.1
       Update to Selenium.Webdriver v2.48.2 and Selenium.Support v2.48.2
       The ability to start appium server programmatically was provided. The ICommandServer implementation (AppiumLocalService).

--- a/integration_tests/Android/AndroidEmulatorDeviceTime.cs
+++ b/integration_tests/Android/AndroidEmulatorDeviceTime.cs
@@ -1,0 +1,54 @@
+﻿using Appium.Integration.Tests.Helpers;
+using NUnit.Framework;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Remote;
+using System;
+
+namespace Appium.Integration.Tests.Android
+{
+    class AndroidEmulatorDeviceTime
+    {
+        private AppiumDriver<AndroidElement> driver;
+
+        [SetUp]
+        public void BeforeAll()
+        {
+            DesiredCapabilities capabilities = Env.isSauce() ?
+                Caps.getAndroid501Caps(Apps.get("androidApiDemos")) :
+                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
+            if (Env.isSauce())
+            {
+                capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+                capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+                capabilities.SetCapability("name", "android - complex");
+                capabilities.SetCapability("tags", new string[] { "sample" });
+            }
+            Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.LocalServiceURIAndroid;
+            driver = new AndroidDriver<AndroidElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
+        }
+
+        [TearDown]
+        public void AfterEach()
+        {
+            if (driver != null)
+            {
+                driver.Quit();
+            }
+            if (!Env.isSauce())
+            {
+                AppiumServers.StopLocalService();
+            }
+        }
+
+        [Test()]
+        public void DeviceTimeTest()
+        {
+            string time = driver.DeviceTime;
+            Console.WriteLine(time);
+            Assert.AreEqual(true, time.Length == 28);
+        }
+
+    }
+}

--- a/integration_tests/Android/AndroidLockDeviceTest.cs
+++ b/integration_tests/Android/AndroidLockDeviceTest.cs
@@ -1,0 +1,53 @@
+﻿using Appium.Integration.Tests.Helpers;
+using NUnit.Framework;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Remote;
+using System;
+
+namespace Appium.Integration.Tests.Android
+{
+    class AndroidLockDeviceTest
+    {
+        private AndroidDriver<AndroidElement> driver;
+
+        [SetUp]
+        public void BeforeAll()
+        {
+            DesiredCapabilities capabilities = Env.isSauce() ?
+                Caps.getAndroid501Caps(Apps.get("androidApiDemos")) :
+                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
+            if (Env.isSauce())
+            {
+                capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+                capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+                capabilities.SetCapability("name", "android - complex");
+                capabilities.SetCapability("tags", new string[] { "sample" });
+            }
+            Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.LocalServiceURIAndroid;
+            driver = new AndroidDriver<AndroidElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
+        }
+
+        [TearDown]
+        public void AfterEach()
+        {
+            if (driver != null)
+            {
+                driver.Quit();
+            }
+            if (!Env.isSauce())
+            {
+                AppiumServers.StopLocalService();
+            }
+        }
+
+        [Test()]
+        public void LockTest()
+        {
+            driver.Lock();
+            Assert.AreEqual(true, driver.IsLocked());
+            driver.Unlock();
+            Assert.AreEqual(false, driver.IsLocked());
+        }
+    }
+}

--- a/integration_tests/iOS/iOSLockDeviceTest.cs
+++ b/integration_tests/iOS/iOSLockDeviceTest.cs
@@ -1,0 +1,51 @@
+﻿using Appium.Integration.Tests.Helpers;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Remote;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Appium.Integration.Tests.iOS
+{
+    class iOSLockDeviceTest
+    {
+        private IOSDriver<IWebElement> driver;
+
+        [TestFixtureSetUp]
+        public void BeforeAll()
+        {
+            DesiredCapabilities capabilities = Caps.getIos82Caps(Apps.get("iosWebviewApp"));
+            if (Env.isSauce())
+            {
+                capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+                capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+                capabilities.SetCapability("tags", new string[] { "sample" });
+            }
+            Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.LocalServiceURIForIOS;
+            driver = new IOSDriver<IWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
+        }
+
+        [TestFixtureTearDown]
+        public void AfterAll()
+        {
+            if (driver != null)
+            {
+                driver.Quit();
+            }
+            if (!Env.isSauce())
+            {
+                AppiumServers.StopLocalService();
+            }
+        }
+
+        [Test()]
+        public void LockTest()
+        {
+            driver.Lock(20);
+        }
+    }
+}

--- a/integration_tests/integration_tests.csproj
+++ b/integration_tests/integration_tests.csproj
@@ -48,6 +48,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Android\AndroidEmulatorDeviceTime.cs" />
+    <Compile Include="Android\AndroidLockDeviceTest.cs" />
     <Compile Include="Android\AndroidActivityTest.cs" />
     <Compile Include="Android\AndroidConnectionTest.cs" />
     <Compile Include="Android\AndroidElementTest.cs" />
@@ -68,6 +70,7 @@
     <Compile Include="iOS\iOSElementTest.cs" />
     <Compile Include="iOS\iOSGestureTest.cs" />
     <Compile Include="iOS\iOSLocationTest.cs" />
+    <Compile Include="iOS\iOSLockDeviceTest.cs" />
     <Compile Include="iOS\iOSOrientationTest.cs" />
     <Compile Include="iOS\iOSScrollTest.cs" />
     <Compile Include="iOS\iOSSearchingTest.cs" />

--- a/test/specs/MJsonMethodTest.cs
+++ b/test/specs/MJsonMethodTest.cs
@@ -49,7 +49,7 @@ namespace OpenQA.Selenium.Appium.Test.Specs
         {
             IOSDriver<IWebElement> driver = new IOSDriver<IWebElement>(defaultUri, capabilities);
             server.respondTo("POST", "/appium/device/lock", null);
-            driver.LockDevice(3);
+            driver.Lock(3);
         }
 
 


### PR DESCRIPTION
Change List:
- #134 FIX. The DeviceTime property was added and it works with Appium
node 1.5

-  improvements of locking methods. The LockDevice(seconds) is obsolete
and it is going to be removed in the next release. Since Appium node
server v1.5.x it is recommended to use
AndroidDriver.Lock()()...AndroidDriver.Unlock() or IOSDriver.Lock(int
seconds) instead.