### PR TITLE
The updating of Android key event methods.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 - The DeviceTime property was added and it works with Appium node 1.5
 - improvements of locking methods. The LockDevice(seconds) is obsolete and it is going to be removed in the next release. Since Appium node server v1.5.x it is recommended to use 
 AndroidDriver.Lock()()...AndroidDriver.Unlock() or IOSDriver.Lock(int seconds) instead.
+- AndroidDriver.KeyEvent() is obsolete and it is going to be removed soon. Please use AndroidDriver.PressKeyCode or AndroidDriver.LongPressKeyCode instead.
 
 ##1.5.0.1
 - Update to Selenium.Webdriver v2.48.2 and Selenium.Support v2.48.2

--- a/appium-dotnet-driver/Appium/Android/AndroidDriver.cs
+++ b/appium-dotnet-driver/Appium/Android/AndroidDriver.cs
@@ -202,6 +202,7 @@ namespace OpenQA.Selenium.Appium.Android
         /// </summary>
         /// <param name="keyCode">Code for the long key pressed on the Android device</param>
         /// <param name="metastate">metastate for the long key press</param>
+        [Obsolete("This method is obsolete and it is going to be removed soon. Please use PressKeyCode or LongPressKeyCode instead")]
         public void KeyEvent(int keyCode, int metastate)
         {
             var parameters = new Dictionary<string, object>();
@@ -214,11 +215,44 @@ namespace OpenQA.Selenium.Appium.Android
         /// Triggers device key event
         /// </summary>
         /// <param name="keyCode">Code for the long key pressed on the Android device</param>
+        [Obsolete("This method is obsolete and it is going to be removed soon. Please use PressKeyCode or LongPressKeyCode instead")]
         public void KeyEvent(int keyCode)
         {
             var parameters = new Dictionary<string, object>();
             parameters.Add("keycode", keyCode);
             this.Execute(AppiumDriverCommand.KeyEvent, parameters);
+        }
+
+        /// <summary>
+        /// Sends a device key event with metastate
+        /// </summary>
+        /// <param name="keyCode">Code for the long key pressed on the Android device</param>
+        /// <param name="metastate">metastate for the long key press</param>
+        public void PressKeyCode(int keyCode, int metastate = -1)
+        {
+            var parameters = new Dictionary<string, object>();
+            parameters.Add("keycode", keyCode);
+            if (metastate > 0)
+            {
+                parameters.Add("metastate", metastate);
+            }
+            Execute(AppiumDriverCommand.PressKeyCode, parameters);
+        }
+
+        /// <summary>
+        /// Sends a device long key event with metastate
+        /// </summary>
+        /// <param name="keyCode">Code for the long key pressed on the Android device</param>
+        /// <param name="metastate">metastate for the long key press</param>
+        public void LongPressKeyCode(int keyCode, int metastate = -1)
+        {
+            var parameters = new Dictionary<string, object>();
+            parameters.Add("keycode", keyCode);
+            if (metastate > 0)
+            {
+                parameters.Add("metastate", metastate);
+            }
+            Execute(AppiumDriverCommand.LongPressKeyCode, parameters);
         }
 
         /// <summary>

--- a/appium-dotnet-driver/Appium/Android/Interfaces/ISendsKeyEvents.cs
+++ b/appium-dotnet-driver/Appium/Android/Interfaces/ISendsKeyEvents.cs
@@ -11,7 +11,8 @@
 //WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //See the License for the specific language governing permissions and
 //limitations under the License.
-using OpenQA.Selenium.Appium.Interfaces;
+
+using System;
 
 namespace OpenQA.Selenium.Appium.Android.Interfaces
 {
@@ -21,12 +22,28 @@ namespace OpenQA.Selenium.Appium.Android.Interfaces
         /// Triggers device key event with metastate for the keypress
         /// </summary>
         /// <param name="connectionType"></param>
+        [Obsolete("This method is obsolete and it is going to be removed soon. Please use PressKeyCode or LongPressKeyCode instead")]
         void KeyEvent(int keyCode, int metastate);
 
         /// <summary>
         /// Triggers device key event
         /// </summary>
         /// <param name="keyCode">Code for the long key pressed on the Android device</param>
+        [Obsolete("This method is obsolete and it is going to be removed soon. Please use PressKeyCode or LongPressKeyCode instead")]
         void KeyEvent(int keyCode);
+
+        /// <summary>
+        /// Sends a device key event with metastate
+        /// </summary>
+        /// <param name="keyCode">Code for the long key pressed on the Android device</param>
+        /// <param name="metastate">metastate for the long key press</param>
+        void PressKeyCode(int keyCode, int metastate = -1);
+
+        /// <summary>
+        /// Sends a device long key event with metastate
+        /// </summary>
+        /// <param name="keyCode">Code for the long key pressed on the Android device</param>
+        /// <param name="metastate">metastate for the long key press</param>
+        void LongPressKeyCode(int keyCode, int metastate = -1);
     }
 }

--- a/appium-dotnet-driver/Appium/AppiumCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumCommand.cs
@@ -36,6 +36,8 @@ namespace OpenQA.Selenium.Appium
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.UnlockDevice, "/session/{sessionId}/appium/device/unlock"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.ToggleAirplaneMode, "/session/{sessionId}/appium/device/toggle_airplane_mode"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.KeyEvent, "/session/{sessionId}/appium/device/keyevent"),
+                new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.PressKeyCode, "/session/{sessionId}/appium/device/press_keycode"),
+                new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.LongPressKeyCode, "/session/{sessionId}/appium/device/long_press_keycode"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.Rotate, "/session/{sessionId}/appium/device/rotate"),
                 new AppiumCommand(CommandInfo.GetCommand, AppiumDriverCommand.GetCurrentActivity, "/session/{sessionId}/appium/device/current_activity"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.InstallApp, "/session/{sessionId}/appium/device/install_app"),

--- a/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
@@ -54,7 +54,18 @@ namespace OpenQA.Selenium.Appium
         /// <summary>
         /// Press Key Event Command.
         /// </summary>
+        [Obsolete("The keyevent function has been deprecated and will be removed. Please use the pressKeyCode function instead.")]
         public const string KeyEvent = "keyEvent";
+
+        /// <summary>
+        /// Press key code 
+        /// </summary>
+        public const string PressKeyCode = "pressKeyCode";
+
+        /// <summary>
+        /// Long press key code
+        /// </summary>
+        public const string LongPressKeyCode = "longPressKeyCode";
 
         /// <summary>
         /// Rotate Command.

--- a/appium-dotnet-driver/appium-dotnet-driver.nuspec
+++ b/appium-dotnet-driver/appium-dotnet-driver.nuspec
@@ -18,6 +18,7 @@
       Page object tools were updated. By.Name locator strategy is deprecated for Android and iOS. It is still valid for the Selendroid mode.
       The DeviceTime property was added and it works with Appium node 1.5
       improvements of locking methods. The LockDevice(seconds) is obsolete and it is going to be removed in the next release. Since Appium node server v1.5.x it is recommended to use AndroidDriver.Lock()()...AndroidDriver.Unlock() or IOSDriver.Lock(int seconds) instead.
+      AndroidDriver.KeyEvent() is obsolete and it is going to be removed soon. Please use AndroidDriver.PressKeyCode or AndroidDriver.LongPressKeyCode instead.
       1.5.0.1
       Update to Selenium.Webdriver v2.48.2 and Selenium.Support v2.48.2
       The ability to start appium server programmatically was provided. The ICommandServer implementation (AppiumLocalService).

--- a/integration_tests/Android/AndroidActivityTest.cs
+++ b/integration_tests/Android/AndroidActivityTest.cs
@@ -86,7 +86,7 @@ namespace Appium.Integration.Tests.Android
             driver.StartActivity("com.android.contacts", ".ContactsListActivity");
 
             Assert.AreEqual(driver.CurrentActivity, ".ContactsListActivity");
-            driver.KeyEvent(AndroidKeyCode.Back);
+            driver.PressKeyCode(AndroidKeyCode.Back);
             Assert.AreEqual(driver.CurrentActivity, ".ContactsListActivity");
         }
 
@@ -100,7 +100,7 @@ namespace Appium.Integration.Tests.Android
             driver.StartActivity("com.android.contacts", ".ContactsListActivity", "com.android.contacts", ".ContactsListActivity", false);
 
             Assert.AreEqual(driver.CurrentActivity, ".ContactsListActivity");
-            driver.KeyEvent(AndroidKeyCode.Back);
+            driver.PressKeyCode(AndroidKeyCode.Back);
             Assert.AreEqual(driver.CurrentActivity, ".accessibility.AccessibilityNodeProviderActivity");
 
         }

--- a/integration_tests/Android/AndroidKeyPressTest.cs
+++ b/integration_tests/Android/AndroidKeyPressTest.cs
@@ -1,0 +1,78 @@
+﻿using Appium.Integration.Tests.Helpers;
+using NUnit.Framework;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.Android.Enums;
+using OpenQA.Selenium.Remote;
+using System;
+
+namespace Appium.Integration.Tests.Android
+{
+    class AndroidKeyPressTest
+    {
+        private AndroidDriver<AndroidElement> driver;
+
+        [TestFixtureSetUp]
+        public void BeforeAll()
+        {
+            DesiredCapabilities capabilities = Env.isSauce() ?
+                Caps.getAndroid501Caps(Apps.get("androidApiDemos")) :
+                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
+            if (Env.isSauce())
+            {
+                capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+                capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+                capabilities.SetCapability("name", "android - simple");
+                capabilities.SetCapability("tags", new string[] { "sample" });
+            }
+            Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.LocalServiceURIAndroid;
+            driver = new AndroidDriver<AndroidElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            if (driver != null)
+            {
+                driver.ResetApp();
+            }
+        }
+
+        [TestFixtureTearDown]
+        public void AfterAll()
+        {
+            if (driver != null)
+            {
+                driver.Quit();
+            }
+            if (!Env.isSauce())
+            {
+                AppiumServers.StopLocalService();
+            }
+        }
+
+        [Test]
+        public void PressKeyCodeTest()
+        {
+            driver.PressKeyCode(AndroidKeyCode.Home);
+        }
+
+        [Test]
+        public void PressKeyCodeWithMetastateTest()
+        {
+            driver.PressKeyCode(AndroidKeyCode.Space, AndroidKeyMetastate.Meta_Shift_On);
+        }
+
+        [Test]
+        public void LongPressKeyCodeTest()
+        {
+            driver.LongPressKeyCode(AndroidKeyCode.Home);
+        }
+
+        [Test]
+        public void LongPressKeyCodeWithMetastateTest()
+        {
+            driver.LongPressKeyCode(AndroidKeyCode.Space, AndroidKeyMetastate.Meta_Shift_On);
+        }
+    }
+}

--- a/integration_tests/integration_tests.csproj
+++ b/integration_tests/integration_tests.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Android\AndroidEmulatorDeviceTime.cs" />
+    <Compile Include="Android\AndroidKeyPressTest.cs" />
     <Compile Include="Android\AndroidLockDeviceTest.cs" />
     <Compile Include="Android\AndroidActivityTest.cs" />
     <Compile Include="Android\AndroidConnectionTest.cs" />


### PR DESCRIPTION
Change list: 

- AndroidDriver.KeyEvent() were marked obsolete. They are going to be removed.

- The AndroidDriver.PressKeyCode method was added.

- The AndroidDriver.LongPressKeyCode method was added.
