### PR TITLE
#138 fix

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,12 @@ AndroidDriver.Lock()()...AndroidDriver.Unlock() or IOSDriver.Lock(int seconds) i
 - The GetAppStrings(string language = null) method is obsolete now. It is going to be removed. 
 - The  GetAppStringDictionary(string language = null, string stringFile = null) was added instead. It returns a dictionary with app strings (keys and values) instead of a string.
 Also it allows the searching app strings in the specified file.
+- All capabilities were added according to https://github.com/appium/appium/blob/1.5/docs/en/writing-running-appium/caps.md. There are three classes: 
+	OpenQA.Selenium.Appium.Enums.MobileCapabilityType (just modified), 
+	OpenQA.Selenium.Appium.Enums.AndroidMobileCapabilityType (android-specific capabilities), 
+	OpenQA.Selenium.Appium.Enums.IOSMobileCapabilityType (iOS-specific capabilities).
+- Some server flags were marked as obsolete because they are deprecated since server node v1.5.x. These options are going to be removed at the next .Net client release.
+- The ability to start Appium node programmatically using desired capabilities. This feature is compatible with Appium node server v >= 1.5.x.
 
 ##1.5.0.1
 - Update to Selenium.Webdriver v2.48.2 and Selenium.Support v2.48.2

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ##1.5.1.1 (still not released)
 - Update to Selenium.Webdriver v2.52.0 and Selenium.Support v2.52.0
+- Update to Newtonsoft.Json v8.0.2
 - FIXED The issue of compatibility of AppiumServiceBuilder with Appium node server v >= 1.5.x.
 - Page object tools were updated. By.Name locator strategy is deprecated for Android and iOS. It is still valid for the Selendroid mode. 
 - The DeviceTime property was added and it works with Appium node 1.5

--- a/appium-dotnet-driver/Appium/Enums/AndroidMobileCapabilityType.cs
+++ b/appium-dotnet-driver/Appium/Enums/AndroidMobileCapabilityType.cs
@@ -1,0 +1,206 @@
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+namespace OpenQA.Selenium.Appium.Enums
+{
+    /// <summary>
+    /// The list of Android-specific capabilities
+    /// Read: https://github.com/appium/appium/blob/1.5/docs/en/writing-running-appium/caps.md#android-only
+    /// </summary>
+    public sealed class AndroidMobileCapabilityType
+    {
+        /// <summary>
+        /// Activity name for the Android activity you want to launch from your package. This often needs to be preceded
+        /// by a . (e.g., .MainActivity instead of MainActivity)
+        /// </summary>
+        public static readonly string AppActivity = "appActivity";
+
+        /// <summary>
+        /// Java package of the Android app you want to run
+        /// </summary>
+        public static readonly string AppPackage = "appPackage";
+
+        /// <summary>
+        /// Activity name for the Android activity you want to wait for
+        /// </summary>
+        public static readonly string AppWaitActivity = "appWaitActivity";
+
+        /// <summary>
+        /// Java package of the Android app you want to wait for
+        /// </summary>
+        public static readonly string AppWaitPackage = "appWaitPackage";
+
+        /// <summary>
+        /// Timeout in seconds while waiting for device to become ready
+        /// </summary>
+        public static readonly string DeviceReadyTimeout = "deviceReadyTimeout";
+
+        /// <summary>
+        ///  Fully qualified instrumentation class. Passed to -w in adb shell am instrument -e coverage true -w
+        /// </summary>
+        public static readonly string AndroidCoverage = "androidCoverage";
+
+        /// <summary>
+        /// (Chrome and webview only) Enable Chromedriver's performance logging (default false)
+        /// </summary>
+        public static readonly string EnablePerformanceLogging = "enablePerformanceLogging";
+
+        /// <summary>
+        /// Timeout in seconds used to wait for a device to become ready after booting
+        /// </summary>
+        public static readonly string AndroidDeviceReadyTimeout = "androidDeviceReadyTimeout";
+
+        /// <summary>
+        /// Port used to connect to the ADB server (default 5037)
+        /// </summary>
+        public static readonly string AdbPort = "adbPort";
+
+        /// <summary>
+        /// Devtools socket name. Needed only when tested app is a Chromium embedding browser.
+        /// The socket is open by the browser and Chromedriver connects to it as a devtools client.
+        /// </summary>
+        public static readonly string AndroidDeviceSocket = "androidDeviceSocket";
+
+        /// <summary>
+        /// Name of avd to launch
+        /// </summary>
+        public static readonly string Avd = "avd";
+
+        /// <summary>
+        /// How long to wait in milliseconds for an avd to launch and connect to ADB (default 120000)
+        /// </summary>
+        public static readonly string AvdLaunchTimeout = "avdLaunchTimeout";
+
+        /// <summary>
+        /// How long to wait in milliseconds for an avd to finish its boot animations (default 120000)
+        /// </summary>
+        public static readonly string AvdReadyTimeout = "avdReadyTimeout";
+
+        /// <summary>
+        /// Additional emulator arguments used when launching an avd
+        /// </summary>
+        public static readonly string AvdArgs = "avdArgs";
+
+        /// <summary>
+        /// Use a custom keystore to sign apks, default false
+        /// </summary>
+        public static readonly string UseKeystore = "useKeystore";
+
+        /// <summary>
+        /// Path to custom keystore, default ~/.android/debug.keystore
+        /// </summary>
+        public static readonly string KeystorePath = "keystorePath";
+
+        /// <summary>
+        /// Password for custom keystore
+        /// </summary>
+        public static readonly string KeystorePassword = "keystorePassword";
+
+        /// <summary>
+        /// Alias for key
+        /// </summary>
+        public static readonly string KeyAlias = "keyAlias";
+
+        /// <summary>
+        /// Password for key
+        /// </summary>
+        public static readonly string KeyPassword = "keyPassword";
+
+        /// <summary>
+        /// The absolute local path to webdriver executable (if Chromium embedder provides its own webdriver,
+        /// it should be used instead of original chromedriver bundled with Appium)
+        /// </summary>
+        public static readonly string ChromedriverExecutable = "chromedriverExecutable";
+
+        /// <summary>
+        /// Amount of time to wait for Webview context to become active, in ms. Defaults to 2000
+        /// </summary>
+        public static readonly string AutoWebviewTimeout = "autoWebviewTimeout";
+
+        /// <summary>
+        /// Intent action which will be used to start activity (default android.intent.action.MAIN)
+        /// </summary>
+        public static readonly string IntentAction = "intentAction";
+
+        /// <summary>
+        /// Intent category which will be used to start activity (default android.intent.category.LAUNCHER)
+        /// </summary>
+        public static readonly string IntentCategory = "intentCategory";
+
+        /// <summary>
+        /// Flags that will be used to start activity (default 0x10200000)
+        /// </summary>
+        public static readonly string IntentFlags = "intentFlags";
+
+        /// <summary>
+        /// Additional intent arguments that will be used to start activity. See Intent arguments:
+        /// http://developer.android.com/tools/help/adb.html#IntentSpec
+        /// </summary>
+        public static readonly string OptionalIntentArguments = "optionalIntentArguments";
+
+        /// <summary>
+        /// Doesn't stop the process of the app under test, before starting the app using adb.
+        /// If the app under test is created by another anchor app, setting this false,
+        /// allows the process of the anchor app to be still alive, during the start of the test app using adb.
+        /// In other words, with dontStopAppOnReset set to true, we will not include the -S flag in the adb shell am start call.
+        /// With this capability omitted or set to false, we include the -S flag. Default false
+        /// </summary>
+        public static readonly string DontStopAppOnReset = "dontStopAppOnReset";
+
+        /// <summary>
+        /// Enable Unicode input, default false
+        /// </summary>
+        public static readonly string UnicodeKeyboard = "unicodeKeyboard";
+
+        /// <summary>
+        /// Reset keyboard to its original state, after running Unicode tests with unicodeKeyboard capability.
+        /// Ignored if used alone. Default false
+        /// </summary>
+        public static readonly string ResetKeyboard = "resetKeyboard";
+
+        /// <summary>
+        /// Skip checking and signing of app with debug keys, will work only with
+        /// UiAutomator and not with selendroid, default false
+        /// </summary>
+        public static readonly string NoSign = "noSign";
+
+        /// <summary>
+        /// Calls the setCompressedLayoutHierarchy() uiautomator function. This capability can speed up test execution,
+        /// since Accessibility commands will run faster ignoring some elements. The ignored elements will not be findable,
+        /// which is why this capability has also been implemented as a toggle-able setting as well as a capability.
+        /// Defaults to false
+        /// </summary>
+        public static readonly string IgnoreUnimportantViews = "ignoreUnimportantViews";
+
+        /// <summary>
+        /// Disables android watchers that watch for application not responding and application crash,
+        /// this will reduce cpu usage on android device/emulator. This capability will work only with
+        /// UiAutomator and not with selendroid, default false
+        /// </summary>
+        public static readonly string DisableAndroidWatchers = "disableAndroidWatchers";
+
+        /// <summary>
+        /// Allows passing chromeOptions capability for ChromeDriver. For more information see chromeOptions:
+        /// https://sites.google.com/a/chromium.org/chromedriver/capabilities
+        /// </summary>
+        public static readonly string ChromeOptions = "chromeOptions";
+
+        /**
+         * Kill ChromeDriver session when moving to a non-ChromeDriver webview. Defaults to false
+         */
+        public static readonly string RECREATE_CHROME_DRIVER_SESSIONS = "recreateChromeDriverSessions";
+
+        public static readonly string SELENDROID_PORT = "selendroidPort";
+    }
+}

--- a/appium-dotnet-driver/Appium/Enums/IOSMobileCapabilityType.cs
+++ b/appium-dotnet-driver/Appium/Enums/IOSMobileCapabilityType.cs
@@ -1,0 +1,149 @@
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+namespace OpenQA.Selenium.Appium.Enums
+{
+    /// <summary>
+    /// The list of iOS-specific capabilities
+    /// Read: https://github.com/appium/appium/blob/1.5/docs/en/writing-running-appium/caps.md#ios-only
+    /// </summary>
+    public sealed class IOSMobileCapabilityType
+    {
+
+        /// <summary>
+        /// (Sim-only) Calendar format to set for the iOS Simulator
+        /// </summary>
+        public static readonly string CalendarFormat = "calendarFormat";
+
+        /// <summary>
+        /// Bundle ID of the app under test. Useful for starting an app on a real device or for using other caps which require
+        /// the bundle ID during test startup. To run a test on a real device using the bundle ID,
+        /// you may omit the 'app' capability, but you must provide 'udid'.
+        /// </summary>
+        public static readonly string BundleId = "bundleId";
+
+        /// <summary>
+        /// Amount of time in ms to wait for instruments before assuming it hung and failing the session
+        /// </summary>
+        public static readonly string LaunchTimeout = "launchTimeout";
+
+        /// <summary>
+        /// (Sim-only) Force location services to be either on or off. Default is to keep current sim setting.
+        /// </summary>
+        public static readonly string LocationServicesEnabled = "locationServicesEnabled";
+
+        /// <summary>
+        /// (Sim-only) Set location services to be authorized or not authorized for app via plist, so that location services
+        /// alert doesn't pop up. Default is to keep current sim setting. Note that
+        /// if you use this setting you MUST also use the bundleId capability to send in your app's bundle ID.
+        /// </summary>
+        public static readonly string LocationServicesAuthorized = "locationServicesAuthorized";
+
+        /// <summary>
+        /// Accept all iOS alerts automatically if they pop up. This includes privacy access permission alerts
+        /// (e.g., location, contacts, photos). Default is false.
+        /// </summary>
+        public static readonly string AutoAcceptAlerts = "autoAcceptAlerts";
+
+        /// <summary>
+        /// Dismiss all iOS alerts automatically if they pop up.
+        /// This includes privacy access permission alerts (e.g.,
+        /// location, contacts, photos). Default is false.
+        /// </summary>
+        public static readonly string AutoDismissAlerts = "autoDismissAlerts";
+
+        /// <summary>
+        /// Use native intruments lib (ie disable instruments-without-delay).
+        /// </summary>
+        public static readonly string NativeInstrumentsLib = "nativeInstrumentsLib";
+
+        /// <summary>
+        /// (Sim-only) Enable "real", non-javascript-based web taps in Safari.
+        /// Default: false.
+        /// Warning: depending on viewport size/ratio this might not accurately tap an element
+        /// </summary>
+        public static readonly string NativeWebTap = "nativeWebTap";
+
+        /// <summary>
+        /// (Sim-only) (>= 8.1) Initial safari url, default is a local welcome page
+        /// </summary>
+        public static readonly string SafariInitialUrl = "safariInitialUrl";
+
+        /// <summary>
+        /// (Sim-only) Allow javascript to open new windows in Safari. Default keeps current sim setting
+        /// </summary>
+        public static readonly string SafariAllowPopups = "safariAllowPopups";
+
+        /// <summary>
+        /// (Sim-only) Prevent Safari from showing a fraudulent website warning. Default keeps current sim setting.
+        /// </summary>
+        public static readonly string SafariIgnoreFraudWarning = "safariIgnoreFraudWarning";
+
+        /// <summary>
+        /// (Sim-only) Whether Safari should allow links to open in new windows. Default keeps current sim setting.
+        /// </summary>
+        public static readonly string SafariOpenLinksInBackground = "safariOpenLinksInBackground";
+
+        /// <summary>
+        /// (Sim-only) Whether to keep keychains (Library/Keychains) when appium session is started/finished
+        /// </summary>
+        public static readonly string KeepKeyChains = "keepKeyChains";
+
+        /// <summary>
+        /// Where to look for localizable strings. Default en.lproj
+        /// </summary>
+        public static readonly string LOCALIZABLE_STRINGS_DIR = "localizableStringsDir";
+
+        /// <summary>
+        /// Arguments to pass to the AUT using instruments
+        /// </summary>
+        public static readonly string ProcessArguments = "processArguments";
+
+        /// <summary>
+        /// The delay, in ms, between keystrokes sent to an element when typing.
+        /// </summary>
+        public static readonly string InterKeyDelay = "interKeyDelay";
+
+        /// <summary>
+        /// Whether to show any logs captured from a device in the appium logs. Default false
+        /// </summary>
+        public static readonly string ShowIOSLog = "showIOSLog";
+
+        /// <summary>
+        /// strategy to use to type test into a test field. Simulator default: oneByOne. Real device default: grouped
+        /// </summary>
+        public static readonly string SendKeyStrategy = "sendKeyStrategy";
+
+        /// <summary>
+        /// Max timeout in sec to wait for a screenshot to be generated. default: 10
+        /// </summary>
+        public static readonly string ScreenshotWaitTimeout = "screenshotWaitTimeout";
+
+        /// <summary>
+        /// The ios automation script used to determined if the app has been launched,
+        /// by default the system wait for the page source not to be empty. The result must be a boolean
+        /// </summary>
+        public static readonly string WaitForAppScript = "waitForAppScript";
+
+        /// <summary>
+        /// Number of times to send connection message to remote debugger, to get webview. Default: 8
+        /// </summary>
+        public static readonly string WebviewConnectRetries = "webviewConnectRetries";
+
+        /// <summary>
+        /// The display name of the application under test. Used to automate backgrounding the app in iOS 9+.
+        /// </summary>
+        public static readonly string AppName = "appName";
+    }
+}

--- a/appium-dotnet-driver/Appium/Enums/MobileCapabilityType.cs
+++ b/appium-dotnet-driver/Appium/Enums/MobileCapabilityType.cs
@@ -11,11 +11,12 @@
 //WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //See the License for the specific language governing permissions and
 //limitations under the License.
+using System;
+
 namespace OpenQA.Selenium.Appium.Enums
 {
     public sealed class MobileCapabilityType
     {
-        #region App and platform
         /// <summary>
         /// Capability name used for the apllication setting.
         /// </summary>
@@ -35,9 +36,7 @@ namespace OpenQA.Selenium.Appium.Enums
         /// Capability name used for the automation name (e.g. Appium, Selendroid and so on) setting.
         /// </summary>
         public static readonly string DeviceName = "deviceName";
-        #endregion App and platform
 
-        #region Common
         /// <summary>
         /// Time out for the waiting for a new command.
         /// </summary>
@@ -46,13 +45,19 @@ namespace OpenQA.Selenium.Appium.Enums
         /// <summary>
         /// Time out for the waiting for the device is ready.
         /// </summary>
+        [Obsolete("Moved to AndroidMobileCapabilityType.DeviceReadyTimeout and it is going to be removed from here")]
         public static readonly string DeviceReadyTimeout = "deviceReadyTimeout";
 
         /// <summary>
         /// Time out for the waiting for the app is launched.
         /// </summary>
+        [Obsolete("Moved to IOSMobileCapabilityType.LaunchTimeout and it is going to be removed from here")]
         public static readonly string LaunchTimeout = "launchTimeout";
 
+        /// <summary>
+        /// Name of mobile web browser to automate. Should be an empty string if automating an app instead.
+        /// </summary>
+        public static readonly string BrowserName = "browserName";
 
         /// <summary>
         /// Capability name used for the automation name (e.g. Appium, Selendroid and so on) setting.
@@ -64,43 +69,71 @@ namespace OpenQA.Selenium.Appium.Enums
         /// </summary>
         public static readonly string AppiumVersion = "appium-version";
 
-        #endregion Common
-
-        #region ANDROID
-
         /// <summary>
         /// It is the required package name.
         /// </summary>
+        [Obsolete("Moved to AndroidMobileCapabilityType.AppPackage and it is going to be removed from here")]
         public static readonly string AppPackage = "appPackage";
 
         /// <summary>
         /// It is the required activity name.
         /// </summary>
+        [Obsolete("Moved to AndroidMobileCapabilityType.AppActivity and it is going to be removed from here")]
         public static readonly string AppActivity = "appActivity";
 
-        // <summary>
+        /// <summary>
         /// It is the name of the activity which is expected.
         /// </summary>
+        [Obsolete("Moved to AndroidMobileCapabilityType.AppWaitActivity and it is going to be removed from here")]
         public static readonly string AppWaitActivity = "appWaitActivity";
 
-        // <summary>
+        /// <summary>
         /// It is the name of the package which is expected.
         /// </summary>
+        [Obsolete("Moved to AndroidMobileCapabilityType.AppWaitPackage and it is going to be removed from here")]
         public static readonly string AppWaitPackage = "appWaitPackage";
+
+        // <summary>
+        /// Unique device identifier of the connected physical device
+        /// </summary>
+        public static readonly string Udid = "udid";
+
+        /// <summary>
+        /// (Sim/Emu-only) Language to set for the simulator / emulator
+        /// </summary>
+        public static readonly string Language = "language";
+
+        /// <summary>
+        /// (Sim/Emu-only) Locale to set for the simulator / emulator
+        /// </summary>
+        public static readonly string Locale = "locale";
+
+        /// <summary>
+        /// (Sim/Emu-only) start in a certain orientation
+        /// </summary>
+        public static readonly string Orientation = "orientation";
+
+        /// <summary>
+        ///  Move directly into Webview context. Default false
+        /// </summary>
+        public static readonly string AutoWebview = "autoWebview";
+
+        /// <summary>
+        /// Don't reset app state before this session. Default false
+        /// </summary>
+        public static readonly string NoReset = "noReset";
+
+        /// <summary>
+        /// (iOS) Delete the entire simulator folder. (Android) Reset app state by uninstalling app instead of clearing app data.
+        /// On Android, this will also remove the app after the session is complete. Default false
+        /// </summary>
+        public static readonly string FullReset = "fullReset";
 
         // <summary>
         /// It is Selendroid port.
         /// </summary>
+        [Obsolete("Moved to AndroidMobileCapabilityType.SelendroidPort and it is going to be removed from here")]
         public static readonly string SelendroidPort = "selendroidPort";
-
-        // <summary>
-        /// true or false. 
-        /// </summary>
-        public static readonly string AutoWebview = "autoWebview";
-
-        #endregion ANDROID
-
-        //Some more setting names can be added below
 
     }
 }

--- a/appium-dotnet-driver/Appium/Service/AppiumServiceBuilder.cs
+++ b/appium-dotnet-driver/Appium/Service/AppiumServiceBuilder.cs
@@ -492,7 +492,6 @@ namespace OpenQA.Selenium.Appium.Service
                 {
                     result = result + value + " ";
                 }
-
                 return result.Trim();
             }
         }

--- a/appium-dotnet-driver/Appium/Service/AppiumServiceConstants.cs
+++ b/appium-dotnet-driver/Appium/Service/AppiumServiceConstants.cs
@@ -12,6 +12,7 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
+using OpenQA.Selenium.Appium.Enums;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -55,5 +56,11 @@ namespace OpenQA.Selenium.Appium.Service
         internal static readonly string AppiumNodeOldMask = Path.DirectorySeparatorChar + BinFolder + Path.DirectorySeparatorChar + AppiumJSName;
         internal static readonly string AppiumNodeMask = Path.DirectorySeparatorChar + BuildFolder + Path.DirectorySeparatorChar + LibFolder +
             Path.DirectorySeparatorChar + MainJSName;
+
+        internal static readonly IList<string> FilePathCapabilitiesForWindows = new List<string>(new string[] {
+            AndroidMobileCapabilityType.KeystorePath,
+            AndroidMobileCapabilityType.ChromedriverExecutable,
+            MobileCapabilityType.App
+        }).AsReadOnly();
     }
 }

--- a/appium-dotnet-driver/Appium/Service/Options/AndroidOptionList.cs
+++ b/appium-dotnet-driver/Appium/Service/Options/AndroidOptionList.cs
@@ -57,6 +57,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --app-pkg com.example.android.MyApp
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> Package(string value)
         {
             string argument = "--app-pkg";
@@ -71,6 +72,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --app-activity MainActivity
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> Activity(string value)
         {
             string argument = "--app-activity";
@@ -84,6 +86,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --app-wait-package com.example.android.MyApp
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> AppWaitPackage(string value)
         {
             string argument = "--app-wait-package";
@@ -97,6 +100,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --app-wait-activity SplashActivity
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> AppWaitActivity(string value)
         {
             string argument = "--app-wait-activity";
@@ -111,6 +115,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample: <br/>
         /// --android-coverage com.my.Pkg/com.my.Pkg.instrumentation.MyInstrumentation
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> AndroidCoverage(string value)
         {
             string argument = "--android-coverage";
@@ -123,6 +128,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --avd @default
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> Avd(string value)
         {
             string argument = "--avd";
@@ -136,6 +142,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --avd-args -no-snapshot-load
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> AvdArguments(string value)
         {
             string argument = "--avd-args";
@@ -149,6 +156,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --device-ready-timeout 5
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> DeviceReadyTimeout(string value)
         {
             if (String.IsNullOrEmpty(value))
@@ -182,6 +190,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         ///<summary>
         /// When set the keystore will be used to sign apks.<br/>
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> UseKeyStore()
         {
             return new KeyValuePair<string, string>("--use-keystore", string.Empty);
@@ -192,6 +201,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --keystore-path /Users/user/.android/debug.keystore
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> KeyStorePath(string value)
         {
             string argument = "--keystore-path";
@@ -202,6 +212,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         ///<summary>
         /// Password to keystore<br/>
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> KeystorePassword(string value)
         {
             if (String.IsNullOrEmpty(value))
@@ -217,6 +228,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         ///<summary>
         /// Key alias<br/>
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> KeyAlias(string value)
         {
             if (String.IsNullOrEmpty(value))
@@ -232,6 +244,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         ///<summary>
         /// Key password<br/>
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> KeyPassword(string value)
         {
             if (String.IsNullOrEmpty(value))
@@ -249,6 +262,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --intent-action android.intent.action.MAIN
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> IntentAction(string value)
         {
             Dictionary<string, string> result = new Dictionary<string, string>();
@@ -267,6 +281,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --intent-category android.intent.category.APP_CONTACTS
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> IntentCategory(string value)
         {
             if (String.IsNullOrEmpty(value))
@@ -284,6 +299,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --intent-flags 0x10200000
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> IntentFlags(string value)
         {
             if (String.IsNullOrEmpty(value))
@@ -302,6 +318,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --intent-args 0x10200000
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> IntentArgumants(string value)
         {
             string argument = "--intent-args";
@@ -313,6 +330,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// When included, refrains from stopping the app before
         /// restart<br/>
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> DoNotStopAppOnReset()
         {
             return new KeyValuePair<string, string>("--dont-stop-app-on-reset", string.Empty);
@@ -325,6 +343,33 @@ namespace OpenQA.Selenium.Appium.Service.Options
         public static KeyValuePair<string, string> SuppressAdbKillServer()
         {
             return new KeyValuePair<string, string>("--suppress-adb-kill-server", string.Empty);
+        }
+
+        ///<summary>
+        /// Port upon which ChromeDriver will run<br/>
+        /// Sample:<br/>
+        /// --chromedriver-port 9515
+        ///</summary>
+        public static KeyValuePair<string, string> ChromeDriverPort(string value)
+        {
+            if (String.IsNullOrEmpty(value))
+            {
+                return new KeyValuePair<string, string>("--chromedriver-port", "9515");
+            }
+            else
+            {
+                return new KeyValuePair<string, string>("--chromedriver-port", value);
+            }
+        }
+
+        ///<summary>
+        /// ChromeDriver executable full path
+        ///</summary>
+        public static KeyValuePair<string, string> ChromeDriverExecutable(string value)
+        {
+            string argument = "--chromedriver-executable";
+            CheckArgumentAndThrowException(argument, value);
+            return new KeyValuePair<string, string>(argument, value);
         }
     }
 }

--- a/appium-dotnet-driver/Appium/Service/Options/GeneralOptionList.cs
+++ b/appium-dotnet-driver/Appium/Service/Options/GeneralOptionList.cs
@@ -49,6 +49,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample 
         /// --app /abs/path/to/my.app
         /// </summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> App(string value)
         {
             string argument = "--app";
@@ -61,6 +62,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample <br/>
         /// --udid 1adsf-sdfas-asdf-123sdf
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> UIID(string value)
         {
             string argument = "--udid";
@@ -91,6 +93,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         ///<summary>
         /// Enables session override (clobbering) <br/>
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> OverrideSession()
         {
             return new KeyValuePair<string, string>("--session-override", string.Empty);
@@ -99,6 +102,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         ///<summary>
         /// Don’t reset app state between sessions (IOS: don’t delete app plist files; Android: don’t uninstall app before new session)<br/>
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> NoReset()
         {
             return new KeyValuePair<string, string>("--no-reset", string.Empty);
@@ -171,6 +175,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample: <br/>
         /// --device-name iPhone Retina (4-inch), Android Emulator
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> DeviceName(string value)
         {
             string argument = "--device-name";
@@ -183,6 +188,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --platform-name iOS
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> PlatformName(string value)
         {
             string argument = "--platform-name";
@@ -195,6 +201,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --platform-version 7.1
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> PlatformVersion(string value)
         {
             string argument = "--platform-version";
@@ -207,6 +214,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --automation-name Appium
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> AutomationName(string value)
         {
             string argument = "--automation-name";
@@ -219,6 +227,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample: <br/>
         /// --browser-name Safari
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> BrowserName(string value)
         {
             string argument = "--browser-name";
@@ -232,6 +241,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --language en
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> Language(string value)
         {
             string argument = "--language";
@@ -244,6 +254,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --locale en_US
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> Locale(string value)
         {
             string argument = "--locale";
@@ -303,6 +314,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --chromedriver-port 9515
         ///</summary>
+        [Obsolete("This flag is deprecated because it is moved to AndroidOptionList.ChromeDriverPort(value)")]
         public static KeyValuePair<string, string> ChromeDriverPort(string value)
         {
             if (String.IsNullOrEmpty(value))
@@ -318,6 +330,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         ///<summary>
         /// ChromeDriver executable full path
         ///</summary>
+        [Obsolete("This flag is deprecated because it is moved to AndroidOptionList.ChromeDriverExecutable(value)")]
         public static KeyValuePair<string, string> ChromeDriverExecutable(string value)
         {
             string argument = "--chromedriver-executable";
@@ -347,6 +360,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// still be overridden by newCommandTimeout cap<br/>
         /// Default: 60
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> CommandTimeOut(string value)
         {
             if (String.IsNullOrEmpty(value))

--- a/appium-dotnet-driver/Appium/Service/Options/GeneralOptionList.cs
+++ b/appium-dotnet-driver/Appium/Service/Options/GeneralOptionList.cs
@@ -93,7 +93,6 @@ namespace OpenQA.Selenium.Appium.Service.Options
         ///<summary>
         /// Enables session override (clobbering) <br/>
         ///</summary>
-        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> OverrideSession()
         {
             return new KeyValuePair<string, string>("--session-override", string.Empty);

--- a/appium-dotnet-driver/Appium/Service/Options/IOSOptionList.cs
+++ b/appium-dotnet-driver/Appium/Service/Options/IOSOptionList.cs
@@ -39,6 +39,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --localizable-strings-dir en.lproj
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> LocalizableStringsDir(string value)
         {
             if (String.IsNullOrEmpty(value))
@@ -84,6 +85,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         ///<summary>
         ///  how long in ms to wait for Instruments to launch<br/>
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> LaunchTimeout(string value)
         {
             if (String.IsNullOrEmpty(value))
@@ -100,6 +102,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// IOS has a weird built-in unavoidable delay. We patch this in
         /// appium. If you do not want it patched, pass in this flag.<br/>
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> UseNativeInstruments()
         {
             return new KeyValuePair<string, string>("--native-instruments-lib", string.Empty);
@@ -143,6 +146,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --calendar-format gregorian
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> CalendarFormat(string value)
         {
             string argument = "--calendar-format";
@@ -156,6 +160,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Sample:<br/>
         /// --orientation LANDSCAPE
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> Orientation(string value)
         {
             string argument = "--orientation";
@@ -191,6 +196,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         ///<summary>
         /// if set, the iOS simulator log will be written to the console<br/>
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> ShowSimLog()
         {
             return new KeyValuePair<string, string>("--show-sim-log", string.Empty);
@@ -200,6 +206,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         ///<summary>
         /// if set, the iOS system log will be written to the console<br/>
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> ShowIosLog()
         {
             return new KeyValuePair<string, string>("--show-ios-log", string.Empty);
@@ -209,6 +216,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// Whether to keep keychains (Library/Keychains) when reset app
         /// between sessions<br/>
         ///</summary>
+        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
         public static KeyValuePair<string, string> KeepKeychains()
         {
             return new KeyValuePair<string, string>("--keep-keychains", string.Empty);

--- a/appium-dotnet-driver/Appium/Service/Options/OptionCollector.cs
+++ b/appium-dotnet-driver/Appium/Service/Options/OptionCollector.cs
@@ -97,6 +97,13 @@ namespace OpenQA.Selenium.Appium.Service.Options
                             value = "\\\"" + value + "\\\"";
                         }
                     }
+                    else
+                    {
+                        if (typeof(bool).IsAssignableFrom(value.GetType()))
+                        {
+                            value = Convert.ToString(value).ToLower();
+                        }
+                    }
 
                     string key = "\\\"" + item.Key + "\\\"";
                     if (String.IsNullOrEmpty(result))
@@ -110,7 +117,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
                 }
             }
 
-            return "{" + result + "}";
+            return "\"{" + result + "}\"";
         }
 
         private string ParseCapabilitiesIfUNIX()
@@ -135,6 +142,14 @@ namespace OpenQA.Selenium.Appium.Service.Options
                         value = "\"" + value + "\""; ;
                     }
 
+                    else
+                    {
+                        if (typeof(bool).IsAssignableFrom(value.GetType()))
+                        {
+                            value = Convert.ToString(value).ToLower();
+                        }
+                    }
+
                     string key = "\"" + item.Key + "\"";
                     if (String.IsNullOrEmpty(result))
                     {
@@ -147,7 +162,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
                 }
             }
 
-            return "{" + result + "}";
+            return "'{" + result + "}'";
         }
 
         /// <summary>
@@ -171,19 +186,21 @@ namespace OpenQA.Selenium.Appium.Service.Options
                     {
                         result.Add(value);
                     }
-                    if (this.capabilities != null && this.capabilities.ToDictionary().Count > 0)
+                }
+
+                if (this.capabilities != null && this.capabilities.ToDictionary().Count > 0)
+                {
+                    result.Add(CapabilitiesFlag);
+                    if (Platform.CurrentPlatform.IsPlatformType(PlatformType.Windows))
                     {
-                        result.Add(CapabilitiesFlag);
-                        if (Platform.CurrentPlatform.IsPlatformType(PlatformType.Windows))
-                        {
-                            result.Add(ParseCapabilitiesIfWindows());
-                        }
-                        else
-                        {
-                            result.Add(ParseCapabilitiesIfUNIX());
-                        }
+                        result.Add(ParseCapabilitiesIfWindows());
+                    }
+                    else
+                    {
+                        result.Add(ParseCapabilitiesIfUNIX());
                     }
                 }
+
                 return result.AsReadOnly();
             }
         }

--- a/appium-dotnet-driver/Appium/Service/Options/OptionCollector.cs
+++ b/appium-dotnet-driver/Appium/Service/Options/OptionCollector.cs
@@ -12,6 +12,7 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
+using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.Generic;
 
@@ -20,6 +21,8 @@ namespace OpenQA.Selenium.Appium.Service.Options
     public sealed class OptionCollector
     {
         private readonly IDictionary<string, string> CollectedArgs = new Dictionary<string, string>();
+        private DesiredCapabilities capabilities;
+        private static readonly string CapabilitiesFlag = "--default-capabilities";
 
         /// <summary>
         /// Adds an argument and its value
@@ -31,6 +34,120 @@ namespace OpenQA.Selenium.Appium.Service.Options
         {
             CollectedArgs.Add(arguments);
             return this;
+        }
+
+        /// <summary>
+        /// Adds/merges server-specific capabilities
+        /// </summary>
+        /// <param name="capabilities">is an instance of OpenQA.Selenium.Remote.DesiredCapabilities</param>
+        /// <returns>the self-reference</returns>        
+        public OptionCollector AddCapabilities(DesiredCapabilities capabilities)
+        {
+            if (this.capabilities == null)
+            {
+                this.capabilities = capabilities;
+            }
+            else
+            {
+                Dictionary<string, object> originalDictionary = this.capabilities.ToDictionary();
+                Dictionary<string, object> givenDictionary = capabilities.ToDictionary();
+                Dictionary<string, object> result = new Dictionary<string, object>(originalDictionary);
+
+                foreach (var item in givenDictionary)
+                {
+                    if (originalDictionary.ContainsKey(item.Key))
+                    {
+                        result[item.Key] = item.Value;
+                    }
+                    else
+                    {
+                        result.Add(item.Key, item.Value);
+                    }
+                }
+                this.capabilities = new DesiredCapabilities(result);
+            }
+            return this;
+        }
+
+        private string ParseCapabilitiesIfWindows()
+        {
+            String result = String.Empty;
+
+            if (capabilities != null)
+            {
+                Dictionary<string, object> capabilitiesDictionary = capabilities.ToDictionary();
+
+                foreach (var item in capabilitiesDictionary)
+                {
+                    object value = item.Value;
+
+                    if (value == null)
+                    {
+                        continue;
+                    }
+
+                    if (typeof(string).IsAssignableFrom(value.GetType()))
+                    {
+                        if (AppiumServiceConstants.FilePathCapabilitiesForWindows.Contains(item.Key))
+                        {
+                            value = "\\\"" + Convert.ToString(value).Replace("\\", "/") + "\\\"";
+                        }
+                        else
+                        {
+                            value = "\\\"" + value + "\\\"";
+                        }
+                    }
+
+                    string key = "\\\"" + item.Key + "\\\"";
+                    if (String.IsNullOrEmpty(result))
+                    {
+                        result = key + ": " + value;
+                    }
+                    else
+                    {
+                        result = result + ", " + key + ": " + value;
+                    }
+                }
+            }
+
+            return "{" + result + "}";
+        }
+
+        private string ParseCapabilitiesIfUNIX()
+        {
+            String result = String.Empty;
+
+            if (capabilities != null)
+            {
+                Dictionary<string, object> capabilitiesDictionary = capabilities.ToDictionary();
+
+                foreach (var item in capabilitiesDictionary)
+                {
+                    object value = item.Value;
+
+                    if (value == null)
+                    {
+                        continue;
+                    }
+
+                    if (typeof(string).IsAssignableFrom(value.GetType()))
+                    {
+                        value = "\"" + value + "\""; ;
+                    }
+
+                    string key = "\"" + item.Key + "\"";
+                    if (String.IsNullOrEmpty(result))
+                    {
+                        result = key + ": " + value;
+                    }
+                    else
+                    {
+                        result = result + ", " + key + ": " + value;
+                    }
+                }
+            }
+
+            return "{" + result + "}";
         }
 
         /// <summary>
@@ -53,6 +170,18 @@ namespace OpenQA.Selenium.Appium.Service.Options
                     if (!String.IsNullOrEmpty(value))
                     {
                         result.Add(value);
+                    }
+                    if (this.capabilities != null && this.capabilities.ToDictionary().Count > 0)
+                    {
+                        result.Add(CapabilitiesFlag);
+                        if (Platform.CurrentPlatform.IsPlatformType(PlatformType.Windows))
+                        {
+                            result.Add(ParseCapabilitiesIfWindows());
+                        }
+                        else
+                        {
+                            result.Add(ParseCapabilitiesIfUNIX());
+                        }
                     }
                 }
                 return result.AsReadOnly();

--- a/appium-dotnet-driver/appium-dotnet-driver.csproj
+++ b/appium-dotnet-driver/appium-dotnet-driver.csproj
@@ -32,9 +32,9 @@
     <Reference Include="Castle.Core">
       <HintPath>$(SolutionDir)\packages\Castle.Core.3.3.3\lib\net40-client\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.8.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />

--- a/appium-dotnet-driver/appium-dotnet-driver.csproj
+++ b/appium-dotnet-driver/appium-dotnet-driver.csproj
@@ -57,7 +57,9 @@
     <Compile Include="Appium\Android\Interfaces\IPushesFiles.cs" />
     <Compile Include="Appium\Android\Interfaces\IStartsActivity.cs" />
     <Compile Include="Appium\AppiumCommand.cs" />
+    <Compile Include="Appium\Enums\AndroidMobileCapabilityType.cs" />
     <Compile Include="Appium\Enums\AutomationName.cs" />
+    <Compile Include="Appium\Enums\IOSMobileCapabilityType.cs" />
     <Compile Include="Appium\Enums\MobilePlatform.cs" />
     <Compile Include="Appium\Enums\MobileBrowserType.cs" />
     <Compile Include="Appium\Enums\MobileCapabilityType.cs" />

--- a/appium-dotnet-driver/appium-dotnet-driver.nuspec
+++ b/appium-dotnet-driver/appium-dotnet-driver.nuspec
@@ -14,6 +14,7 @@
     <releaseNotes>
       1.5.1.1
       Update to Selenium.Webdriver v2.52.0 and Selenium.Support v2.52.0
+      Update to Newtonsoft.Json v8.0.2
       FIXED The issue of compatibility of AppiumServiceBuilder with Appium node server v >= 1.5.x.
       Page object tools were updated. By.Name locator strategy is deprecated for Android and iOS. It is still valid for the Selendroid mode.
       The DeviceTime property was added and it works with Appium node 1.5
@@ -64,7 +65,7 @@
     <copyright>Copyright 2014</copyright>
     <tags>Appium Webdriver device automation</tags>
     <dependencies>
-      <dependency id="Newtonsoft.Json" version="7.0.1"/>
+      <dependency id="Newtonsoft.Json" version="8.0.2"/>
       <dependency id="Selenium.WebDriver" version="2.52.0"/>
       <dependency id="Selenium.Support" version="2.52.0"/>
       <dependency id="Castle.Core" version="3.3.3"/>

--- a/appium-dotnet-driver/appium-dotnet-driver.nuspec
+++ b/appium-dotnet-driver/appium-dotnet-driver.nuspec
@@ -22,6 +22,12 @@
       AndroidDriver.KeyEvent() is obsolete and it is going to be removed soon. Please use AndroidDriver.PressKeyCode or AndroidDriver.LongPressKeyCode instead.
       The GetAppStrings(string language = null) method is obsolete now. It is going to be removed. 
       The  GetAppStringDictionary(string language = null, string stringFile = null) was added instead. It returns a dictionary with app strings (keys and values) instead of a string. Also it allows the searching app strings in the specified file.
+      All capabilities were added according to https://github.com/appium/appium/blob/1.5/docs/en/writing-running-appium/caps.md. There are three classes: 
+	      OpenQA.Selenium.Appium.Enums.MobileCapabilityType (just modified), 
+	      OpenQA.Selenium.Appium.Enums.AndroidMobileCapabilityType (android-specific capabilities), 
+	      OpenQA.Selenium.Appium.Enums.IOSMobileCapabilityType (iOS-specific capabilities).
+      Some server flags were marked as obsolete because they are deprecated since server node v1.5.x. These options are going to be removed at the next .Net client release.
+      The ability to start Appium node programmatically using desired capabilities. This feature is compatible with Appium node server v >= 1.5.x.
       1.5.0.1
       Update to Selenium.Webdriver v2.48.2 and Selenium.Support v2.48.2
       The ability to start appium server programmatically was provided. The ICommandServer implementation (AppiumLocalService).

--- a/appium-dotnet-driver/packages.config
+++ b/appium-dotnet-driver/packages.config
@@ -1,22 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!--
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-See the NOTICE file distributed with this work for additional
-information regarding copyright ownership.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
--->
 <packages>
-  <package id="Castle.Core" version="3.3.3" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
+  <package id="Castle.Core" version="3.3.3" targetFramework="net4" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net4" />
   <package id="Selenium.Support" version="2.52.0" targetFramework="net4" />
   <package id="Selenium.WebDriver" version="2.52.0" targetFramework="net4" />
 </packages>

--- a/integration_tests/ServerTests/AppiumLocalServerLaunchingTest.cs
+++ b/integration_tests/ServerTests/AppiumLocalServerLaunchingTest.cs
@@ -1,10 +1,13 @@
 ﻿using NUnit.Framework;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Appium.Enums;
 using OpenQA.Selenium.Appium.Service;
 using OpenQA.Selenium.Appium.Service.Options;
+using OpenQA.Selenium.Remote;
 using System;
 using System.IO;
 using System.Net;
+using System.Threading;
 
 namespace Appium.Integration.Tests.ServerTests
 {
@@ -12,6 +15,7 @@ namespace Appium.Integration.Tests.ServerTests
     public class AppiumLocalServerLaunchingTest
     {
         private string PathToCustomizedAppiumJS;
+        private string testIP;
 
         [TestFixtureSetUp]
         public void BeforeAll()
@@ -22,179 +26,118 @@ namespace Appium.Integration.Tests.ServerTests
             bool isMacOS = Platform.CurrentPlatform.IsPlatformType(PlatformType.Mac);
             bool isLinux = Platform.CurrentPlatform.IsPlatformType(PlatformType.Linux);
 
-            if (isWindows)
-            {
-                bytes = Properties.Resources.PathToWindowsNode;
-				PathToCustomizedAppiumJS = System.Text.Encoding.UTF8.GetString(bytes);
-				return;			
-            }
-            if (isMacOS)
-            {
-                bytes = Properties.Resources.PathToMacOSNode;
-				PathToCustomizedAppiumJS = System.Text.Encoding.UTF8.GetString(bytes);
-				return;
-            }
-            if (isLinux)
-            {
-                bytes = Properties.Resources.PathToLinuxNode;
-				PathToCustomizedAppiumJS = System.Text.Encoding.UTF8.GetString(bytes);
-				return;
-            }
-        }
-
-        [Test]
-        public void CheckAbilityToBuildDefaultService()
-        {
-            AppiumLocalService.BuildDefaultService();
-        }
-
-        [Test]
-        public void CheckAbilityToBuildServiceWithDefinedParametersAndNodeSetInProperties()
-        {
-            try
-            {
-                string definedNode = PathToCustomizedAppiumJS;
-                Environment.SetEnvironmentVariable(AppiumServiceConstants.AppiumBinaryPath, definedNode);
-                OptionCollector args = new OptionCollector().AddArguments(GeneralOptionList.OverrideSession());
-                new AppiumServiceBuilder().UsingPort(4000).WithArguments(args).Build();
-            }
-            finally
-            {
-
-                Environment.SetEnvironmentVariable(AppiumServiceConstants.AppiumBinaryPath, string.Empty);
-            }
-        }
-
-        [Test]
-        public void CheckAbilityToBuildServiceWithDefinedParametersAndExternallyDefinedNode()
-        {
-            OptionCollector args = new OptionCollector().AddArguments(GeneralOptionList.OverrideSession());
-            new AppiumServiceBuilder().WithAppiumJS(new FileInfo(PathToCustomizedAppiumJS)).
-                    UsingPort(4000).WithArguments(args).Build();
-        }
-
-        [Test]
-        public void CheckStartingOfDefaultService()
-        {
-            AppiumLocalService service = AppiumLocalService.BuildDefaultService();
-            try
-            {
-                service.Start();
-                Assert.IsTrue(service.IsRunning);
-            }
-            finally
-            {
-                service.Dispose();
-            }
-        }
-
-        [Test]
-        public void CheckAbilityToStartServiceOnAFreePort()
-        {
-            AppiumLocalService service = new AppiumServiceBuilder().UsingAnyFreePort().Build();
-            try
-            {
-                service.Start();
-                Assert.IsTrue(service.IsRunning);
-            }
-            finally
-            {
-                service.Dispose();
-            }
-        }
-
-        [Test]
-        public void CheckStartingOfAServiceWithNonDefaultArguments()
-        {
-            OptionCollector args = new OptionCollector().AddArguments(GeneralOptionList.LogNoColors());
-            AppiumLocalService service = new AppiumServiceBuilder().UsingPort(4000).WithArguments(args).Build();
-            try
-            {
-                service.Start();
-                Assert.IsTrue(service.IsRunning);
-            }
-            finally
-            {
-                service.Dispose();
-            }
-        }
-
-        [Test]
-        public void CheckStartingOfTheServiceDefinedByProperty()
-        {
-            try
-            {
-                string definedNode = PathToCustomizedAppiumJS;
-                Environment.SetEnvironmentVariable(AppiumServiceConstants.AppiumBinaryPath, definedNode);
-                AppiumLocalService service = new AppiumServiceBuilder().Build();
-
-                try
-                {
-                    service.Start();
-                    Assert.IsTrue(service.IsRunning);
-                }
-                finally
-                {
-                    service.Dispose();
-                }
-            }
-            finally
-            {
-                Environment.SetEnvironmentVariable(AppiumServiceConstants.AppiumBinaryPath, string.Empty);
-            }
-        }
-
-        [Test]
-        public void CheckStartingOfTheServiceDefinedExternally()
-        {
-            AppiumLocalService service = new AppiumServiceBuilder().WithAppiumJS(new FileInfo(PathToCustomizedAppiumJS)).Build();
-            try
-            {
-                service.Start();
-                Assert.IsTrue(service.IsRunning);
-            }
-            finally
-            {
-                service.Dispose();
-            }
-        }
-
-        [Test]
-        public void CheckStartingOfTheServiceDefinedExternallyWithNonDefaultArguments()
-        {
-            OptionCollector args = new OptionCollector().AddArguments(GeneralOptionList.LogNoColors());
-            AppiumLocalService service = new AppiumServiceBuilder().WithAppiumJS(new FileInfo(PathToCustomizedAppiumJS)).
-                UsingPort(4000).WithArguments(args).Build();
-            try
-            {
-                service.Start();
-                Assert.IsTrue(service.IsRunning);
-            }
-            finally
-            {
-                service.Dispose();
-            }
-        }
-
-        [Test]
-        public void CheckStartingOfAServiceWithNonLocalhostIP()
-        {
-
             IPHostEntry host;
-            string localIp = "?";
             string hostName = Dns.GetHostName();
             host = Dns.GetHostEntry(hostName);
             foreach (IPAddress ip in host.AddressList)
             {
                 if (ip.AddressFamily.ToString() == "InterNetwork")
                 {
-                    localIp = ip.ToString();
+                    testIP = ip.ToString();
                     break;
                 }
             }
-            Console.WriteLine(localIp);
+            Console.WriteLine(testIP);
 
-            AppiumLocalService service = new AppiumServiceBuilder().WithIPAddress(localIp).UsingPort(4000).
+            if (isWindows)
+            {
+                bytes = Properties.Resources.PathToWindowsNode;
+                PathToCustomizedAppiumJS = System.Text.Encoding.UTF8.GetString(bytes);
+                return;
+            }
+            if (isMacOS)
+            {
+                bytes = Properties.Resources.PathToMacOSNode;
+                PathToCustomizedAppiumJS = System.Text.Encoding.UTF8.GetString(bytes);
+                return;
+            }
+            if (isLinux)
+            {
+                bytes = Properties.Resources.PathToLinuxNode;
+                PathToCustomizedAppiumJS = System.Text.Encoding.UTF8.GetString(bytes);
+                return;
+            }
+        }
+
+        [Test]
+        public void CheckAbilityToBuildDefaultService()
+        {
+            AppiumLocalService service = AppiumLocalService.BuildDefaultService();
+            try
+            {
+                service.Start();
+                Assert.AreEqual(true, service.IsRunning);
+            }
+            finally
+            {
+                service.Dispose();
+            }
+        }
+
+        [Test]
+        public void CheckAbilityToBuildServiceUsingNodeDefinedInProperties()
+        {
+            AppiumLocalService service = null;
+            try
+            {
+                string definedNode = PathToCustomizedAppiumJS;
+                Environment.SetEnvironmentVariable(AppiumServiceConstants.AppiumBinaryPath, definedNode);
+                service = AppiumLocalService.BuildDefaultService();
+                service.Start();
+                Assert.AreEqual(true, service.IsRunning);
+            }
+            finally
+            {
+                if (service != null)
+                {
+                    service.Dispose();
+                }
+                Environment.SetEnvironmentVariable(AppiumServiceConstants.AppiumBinaryPath, string.Empty);
+            }
+        }
+
+        [Test]
+        public void CheckAbilityToBuildServiceUsingNodeDefinedExplicitly()
+        {
+            AppiumLocalService service = null;
+            try
+            {
+                service = new AppiumServiceBuilder().WithAppiumJS(new FileInfo(PathToCustomizedAppiumJS)).Build();
+                service.Start();
+                Assert.AreEqual(true, service.IsRunning);
+            }
+            finally
+            {
+                if (service != null)
+                {
+                    service.Dispose();
+                }
+            }
+        }
+
+        [Test]
+        public void CheckAbilityToStartServiceOnAFreePort()
+        {
+            AppiumLocalService service = null;
+            try
+            {
+                service = new AppiumServiceBuilder().UsingAnyFreePort().Build();
+                service.Start();
+                Assert.AreEqual(true, service.IsRunning);
+            }
+            finally
+            {
+                if (service != null)
+                {
+                    service.Dispose();
+                }
+            }
+        }
+
+        [Test]
+        public void CheckStartingOfAServiceWithNonLocalhostIP()
+        {
+            AppiumLocalService service = new AppiumServiceBuilder().WithIPAddress(testIP).UsingPort(4000).
                 Build();
             try
             {
@@ -208,9 +151,120 @@ namespace Appium.Integration.Tests.ServerTests
         }
 
         [Test]
+        public void CheckAbilityToStartServiceUsingFlags()
+        {
+            AppiumLocalService service = null;
+            OptionCollector args = new OptionCollector().AddArguments(GeneralOptionList.CallbackAddress(testIP))
+                .AddArguments(GeneralOptionList.OverrideSession());
+            try
+            {
+                service = new AppiumServiceBuilder().WithArguments(args).Build();
+                service.Start();
+                Assert.IsTrue(service.IsRunning);
+            }
+            finally
+            {
+                if (service != null)
+                {
+                    service.Dispose();
+                }
+            }
+        }
+
+        [Test]
+        public void CheckAbilityToStartServiceUsingCapabilities()
+        {
+            DesiredCapabilities capabilities = new DesiredCapabilities();
+            capabilities.SetCapability(MobileCapabilityType.PlatformName, "Android");
+            capabilities.SetCapability(MobileCapabilityType.FullReset, true);
+            capabilities.SetCapability(MobileCapabilityType.NewCommandTimeout, 60);
+            capabilities.SetCapability(AndroidMobileCapabilityType.AppPackage, "io.appium.android.apis");
+            capabilities.SetCapability(AndroidMobileCapabilityType.AppActivity, ".view.WebView1");
+
+            OptionCollector args = new OptionCollector().AddCapabilities(capabilities);
+            AppiumLocalService service = null;
+            try
+            {
+                service = new AppiumServiceBuilder().WithArguments(args).Build();
+                service.Start();
+                Assert.IsTrue(service.IsRunning);
+            }
+            finally
+            {
+                if (service != null)
+                {
+                    service.Dispose();
+                }
+            }
+        }
+
+        [Test]
+        public void CheckAbilityToStartServiceUsingCapabilitiesAndFlags()
+        {
+            DesiredCapabilities capabilities = new DesiredCapabilities();
+            capabilities.SetCapability(MobileCapabilityType.PlatformName, "Android");
+            capabilities.SetCapability(MobileCapabilityType.FullReset, true);
+            capabilities.SetCapability(MobileCapabilityType.NewCommandTimeout, 60);
+            capabilities.SetCapability(AndroidMobileCapabilityType.AppPackage, "io.appium.android.apis");
+            capabilities.SetCapability(AndroidMobileCapabilityType.AppActivity, ".view.WebView1");
+
+            OptionCollector args = new OptionCollector().AddCapabilities(capabilities).AddArguments(GeneralOptionList.CallbackAddress(testIP))
+                .AddArguments(GeneralOptionList.OverrideSession());
+            AppiumLocalService service = null;
+            try
+            {
+                service = new AppiumServiceBuilder().WithArguments(args).
+                    Build();
+                service.Start();
+                Assert.IsTrue(service.IsRunning);
+            }
+            finally
+            {
+                if (service != null)
+                {
+                    service.Dispose();
+                }
+            }
+        }
+
+        [Test]
+        public void CheckAbilityToShutDownService()
+        {
+            AppiumLocalService service = AppiumLocalService.BuildDefaultService();
+            service.Start();
+            service.Dispose();
+            Assert.IsTrue(!service.IsRunning);
+        }
+
+        [Test]
+        public void CheckAbilityToStartAndShutDownFewServices()
+        {
+            AppiumLocalService service1 = new AppiumServiceBuilder().UsingAnyFreePort().Build();
+            AppiumLocalService service2 = new AppiumServiceBuilder().UsingAnyFreePort().Build();
+            AppiumLocalService service3 = new AppiumServiceBuilder().UsingAnyFreePort().Build();
+            AppiumLocalService service4 = new AppiumServiceBuilder().UsingAnyFreePort().Build();
+            service1.Start();
+            service2.Start();
+            service3.Start();
+            service4.Start();
+            service1.Dispose();
+            Thread.Sleep(1000);
+            service2.Dispose();
+            Thread.Sleep(1000);
+            service3.Dispose();
+            Thread.Sleep(1000);
+            service4.Dispose();
+            Assert.IsTrue(!service1.IsRunning);
+            Assert.IsTrue(!service2.IsRunning);
+            Assert.IsTrue(!service3.IsRunning);
+            Assert.IsTrue(!service4.IsRunning);
+        }
+
+
+        [Test]
         public void CheckTheAbilityToDefineTheDesiredLogFile()
         {
-            FileInfo log = new FileInfo("Log");
+            FileInfo log = new FileInfo("Log.txt");
             AppiumLocalService service = new AppiumServiceBuilder().WithLogFile(log).Build();
             try
             {
@@ -228,6 +282,7 @@ namespace Appium.Integration.Tests.ServerTests
                 service.Dispose();
             }
         }
+
     }
 }
 

--- a/integration_tests/ServerTests/StartingAppLocallyTest.cs
+++ b/integration_tests/ServerTests/StartingAppLocallyTest.cs
@@ -38,19 +38,52 @@ namespace Appium.Integration.Tests.ServerTests
         [Test]
         public void StartingAndroidAppWithCapabilitiesAndServiceTest()
         {
-            string app = Apps.get("androidApiDemos");
 
-            DesiredCapabilities capabilities = new DesiredCapabilities();
-            capabilities.SetCapability(MobileCapabilityType.DeviceName, "Android Emulator");
+            DesiredCapabilities capabilities = Env.isSauce() ?
+                Caps.getAndroid501Caps(Apps.get("androidApiDemos")) :
+                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
 
-            OptionCollector argCollector = new OptionCollector().AddArguments(GeneralOptionList.App(app))
-                .AddArguments(GeneralOptionList.AutomationName(AutomationName.Appium));
+
+            OptionCollector argCollector = new OptionCollector()
+                .AddArguments(GeneralOptionList.OverrideSession()).AddArguments(GeneralOptionList.StrictCaps());
             AppiumServiceBuilder builder = new AppiumServiceBuilder().WithArguments(argCollector);
 
             AndroidDriver<AppiumWebElement> driver = null;
             try
             {
                 driver = new AndroidDriver<AppiumWebElement>(builder, capabilities);
+                driver.CloseApp();
+            }
+            finally
+            {
+                if (driver != null)
+                {
+                    driver.Quit();
+                }
+            }
+        }
+
+
+        [Test]
+        public void StartingAndroidAppWithCapabilitiesOnTheServerSideTest()
+        {
+            string app = Apps.get("androidApiDemos");
+
+            DesiredCapabilities serverCapabilities = Env.isSauce() ?
+                Caps.getAndroid501Caps(Apps.get("androidApiDemos")) :
+                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
+
+            DesiredCapabilities clientCapabilities = new DesiredCapabilities();
+            clientCapabilities.SetCapability(AndroidMobileCapabilityType.AppPackage, "io.appium.android.apis");
+            clientCapabilities.SetCapability(AndroidMobileCapabilityType.AppActivity, ".view.WebView1");
+
+            OptionCollector argCollector = new OptionCollector().AddCapabilities(serverCapabilities);
+            AppiumServiceBuilder builder = new AppiumServiceBuilder().WithArguments(argCollector);
+
+            AndroidDriver<AppiumWebElement> driver = null;
+            try
+            {
+                driver = new AndroidDriver<AppiumWebElement>(builder, clientCapabilities);
                 driver.CloseApp();
             }
             finally
@@ -88,13 +121,11 @@ namespace Appium.Integration.Tests.ServerTests
         public void StartingIOSAppWithCapabilitiesAndServiseTest()
         {
             string app = Apps.get("iosTestApp");
+            DesiredCapabilities capabilities =
+                Caps.getIos82Caps(app);
 
-            DesiredCapabilities capabilities = new DesiredCapabilities();
-            capabilities.SetCapability(MobileCapabilityType.DeviceName, "iPhone Simulator");
-
-            OptionCollector argCollector = new OptionCollector().AddArguments(GeneralOptionList.App(app))
-                .AddArguments(GeneralOptionList.AutomationName(AutomationName.Appium)).
-                AddArguments(GeneralOptionList.PlatformVersion("8.2"));
+            OptionCollector argCollector = new OptionCollector()
+                .AddArguments(GeneralOptionList.OverrideSession()).AddArguments(GeneralOptionList.StrictCaps());
 
             AppiumServiceBuilder builder = new AppiumServiceBuilder().WithArguments(argCollector);
             IOSDriver<AppiumWebElement> driver = null;
@@ -115,16 +146,13 @@ namespace Appium.Integration.Tests.ServerTests
         [Test]
         public void CheckThatServiseIsNotRunWhenTheCreatingOfANewSessionIsFailed()
         {
-            string app = Apps.get("androidApiDemos");
-
-            DesiredCapabilities capabilities = new DesiredCapabilities();
+            DesiredCapabilities capabilities = Env.isSauce() ?   //it will be a cause of error
+                Caps.getAndroid501Caps(Apps.get("androidApiDemos")) :
+                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
             capabilities.SetCapability(MobileCapabilityType.DeviceName, "iPhone Simulator");
+            capabilities.SetCapability(MobileCapabilityType.PlatformName, MobilePlatform.IOS);
 
-            OptionCollector argCollector = new OptionCollector().AddArguments(GeneralOptionList.App(app)) //it will be a cause of error
-                //that is expected
-                .AddArguments(GeneralOptionList.AutomationName(AutomationName.Appium)).AddArguments(GeneralOptionList.PlatformName("Android"));
-
-            AppiumServiceBuilder builder = new AppiumServiceBuilder().WithArguments(argCollector);
+            AppiumServiceBuilder builder = new AppiumServiceBuilder();
             AppiumLocalService service = builder.Build();
             service.Start();
 

--- a/integration_tests/helpers/AppiumServers.cs
+++ b/integration_tests/helpers/AppiumServers.cs
@@ -1,5 +1,7 @@
-﻿using OpenQA.Selenium.Appium.Service;
+﻿using OpenQA.Selenium.Appium.Enums;
+using OpenQA.Selenium.Appium.Service;
 using OpenQA.Selenium.Appium.Service.Options;
+using OpenQA.Selenium.Remote;
 using System;
 
 namespace Appium.Integration.Tests.Helpers
@@ -36,8 +38,9 @@ namespace Appium.Integration.Tests.Helpers
                 if (LocalService == null)
                 {
                     AppiumServiceBuilder builder = new AppiumServiceBuilder();
-                    OptionCollector collector = new OptionCollector().
-                        AddArguments(IOSOptionList.LaunchTimeout(Convert.ToString(Env.INIT_TIMEOUT_SEC.TotalMilliseconds))).
+                    DesiredCapabilities capabilities = new DesiredCapabilities();
+                    capabilities.SetCapability(IOSMobileCapabilityType.LaunchTimeout, Env.INIT_TIMEOUT_SEC.TotalMilliseconds);
+                    OptionCollector collector = new OptionCollector().AddCapabilities(capabilities).
                         //I use MAC OS X VMWare image. Sometimes it is very slow. 
                         AddArguments(IOSOptionList.BackEndRetries("5"));
                     LocalService = builder.WithArguments(collector).Build();

--- a/integration_tests/helpers/Caps.cs
+++ b/integration_tests/helpers/Caps.cs
@@ -18,8 +18,8 @@ namespace Appium.Integration.Tests.Helpers
 			DesiredCapabilities capabilities = new DesiredCapabilities();
             capabilities.SetCapability(CapabilityType.BrowserName, "");
             capabilities.SetCapability(MobileCapabilityType.PlatformVersion, "5.0.1");
-            capabilities.SetCapability(MobileCapabilityType.AppPackage, "io.appium.android.apis");
-            capabilities.SetCapability(MobileCapabilityType.AppActivity, ".Apidemos");
+            capabilities.SetCapability(AndroidMobileCapabilityType.AppPackage, "io.appium.android.apis");
+            capabilities.SetCapability(AndroidMobileCapabilityType.AppActivity, ".Apidemos");
             capabilities.SetCapability(MobileCapabilityType.DeviceName, "Android Emulator");
             capabilities.SetCapability(MobileCapabilityType.App, app);
 			return capabilities;

--- a/integration_tests/integration_tests.csproj
+++ b/integration_tests/integration_tests.csproj
@@ -29,8 +29,9 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.7.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>$(SolutionDir)\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/integration_tests/packages.config
+++ b/integration_tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net40" />
-  <package id="NUnit" version="2.6.4" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net4" />
+  <package id="NUnit" version="2.6.4" targetFramework="net4" />
   <package id="Selenium.Support" version="2.52.0" targetFramework="net4" />
   <package id="Selenium.WebDriver" version="2.52.0" targetFramework="net4" />
 </packages>

--- a/test/packages.config
+++ b/test/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net40" />
-  <package id="NUnit" version="2.6.3" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net4" />
+  <package id="NUnit" version="2.6.3" targetFramework="net4" />
   <package id="Selenium.Support" version="2.52.0" targetFramework="net4" />
   <package id="Selenium.WebDriver" version="2.52.0" targetFramework="net4" />
 </packages>

--- a/test/specs/MJsonMethodTest.cs
+++ b/test/specs/MJsonMethodTest.cs
@@ -200,16 +200,6 @@ namespace OpenQA.Selenium.Appium.Test.Specs
         }
 
         [Test]
-        public void GetAppStringsTestCase()
-        {
-            AndroidDriver<IWebElement> driver = new AndroidDriver<IWebElement>(defaultUri, capabilities);
-            var data = "21343n2312j3jw";
-            server.respondTo("POST", "/appium/app/strings", data);
-            var result = driver.GetAppStrings();
-            Assert.AreEqual(result, data);
-        }
-
-        [Test]
         public void SetImmediateValueTestCase()
         {
             IOSDriver<IOSElement> driver = new IOSDriver<IOSElement>(defaultUri, capabilities);

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -29,9 +29,9 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.6.0.5\lib\net40\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
## Change list

#138 fix: The ability to start an Appium node server using _OpenQA.Selenium.Remote.DesiredCapabilities_
 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

##Details

Change list: 

- all capabilities were added.
Capabilities were added according to https://github.com/appium/appium/blob/1.5/docs/en/writing-running-appium/caps.md. Therea three classes:
**OpenQA.Selenium.Appium.Enums.remote.MobileCapabilityType** (just modified), 
**OpenQA.Selenium.Appium.Enums.AndroidMobileCapabilityType** (android-specific capabilities), 
**OpenQA.Selenium.Appium.Enums.IOSMobileCapabilityType** (iOS-specific capabilities).

Some existing capabilities were marked _Obsolete_ and they are going to be removed at the next java client release: 

```c#
    public sealed class MobileCapabilityType
    {
        [Obsolete("Moved to AndroidMobileCapabilityType.DeviceReadyTimeout and it is going to be removed from here")]
        public static readonly string DeviceReadyTimeout = "deviceReadyTimeout";

        [Obsolete("Moved to IOSMobileCapabilityType.LaunchTimeout and it is going to be removed from here")]
        public static readonly string LaunchTimeout = "launchTimeout";

        [Obsolete("Moved to AndroidMobileCapabilityType.AppPackage and it is going to be removed from here")]
        public static readonly string AppPackage = "appPackage";

        [Obsolete("Moved to AndroidMobileCapabilityType.AppActivity and it is going to be removed from here")]
        public static readonly string AppActivity = "appActivity";

        [Obsolete("Moved to AndroidMobileCapabilityType.AppWaitActivity and it is going to be removed from here")]
        public static readonly string AppWaitActivity = "appWaitActivity";

        [Obsolete("Moved to AndroidMobileCapabilityType.AppWaitPackage and it is going to be removed from here")]
        public static readonly string AppWaitPackage = "appWaitPackage";

        [Obsolete("Moved to AndroidMobileCapabilityType.SelendroidPort and it is going to be removed from here")]
        public static readonly string SelendroidPort = "selendroidPort";

    }
```

 - some server options were marked _Obsolete_ because they are deprecated since server node v1.5.x. These flags are going to be removed at the next .Net client release:

```c#
    public sealed class GeneralOptionList
    {
        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> App(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> UIID(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> NoReset()

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> DeviceName(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> PlatformName(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> PlatformVersion(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> AutomationName(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> BrowserName(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> Language(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> Locale(string value)

        [Obsolete("This flag is deprecated because it is moved to AndroidOptionList.ChromeDriverPort(value)")]
        public static KeyValuePair<string, string> ChromeDriverPort(string value)

        [Obsolete("This flag is deprecated because it is moved to AndroidOptionList.ChromeDriverExecutable(value)")]
        public static KeyValuePair<string, string> ChromeDriverExecutable(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> CommandTimeOut(string value)
    }
```

```c#
   public sealed class AndroidOptionList
    {
        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> Package(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> Activity(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> AppWaitPackage(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> AppWaitActivity(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> AndroidCoverage(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> Avd(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> AvdArguments(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> DeviceReadyTimeout(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> UseKeyStore()

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> KeyStorePath(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> KeystorePassword(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> KeyAlias(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> KeyPassword(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> IntentAction(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> IntentCategory(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> IntentFlags(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> IntentArgumants(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> DoNotStopAppOnReset()
    }
```

```c#
    public sealed class IOSOptionList
    {
        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> LocalizableStringsDir(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> LaunchTimeout(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> UseNativeInstruments()

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> CalendarFormat(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> Orientation(string value)

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> ShowSimLog()

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> ShowIosLog()

        [Obsolete("This flag is obsolete since appium node 1.5.x. It will be removed in the next release. Be careful. Please use capabilities instead")]
        public static KeyValuePair<string, string> KeepKeychains()
    }
```

- The ability to start Appium node programmatically using desired capabilities. This feature is compatible with Appium node server v >= 1.5.x.

It is the addition to usecases which have been provided here: #126. Now it is possible to do something like that: 


```с#
DesiredCapabilities serverCapabilities = new DesiredCapabilities();
//the filling of server default capabilities is going below

DesiredCapabilities clientCapabilities = new DesiredCapabilities();
//the filling of server default capabilities is going below

OptionCollector argCollector = new OptionCollector().AddCapabilities(serverCapabilities);
AppiumServiceBuilder builder = new AppiumServiceBuilder().WithArguments(argCollector);
AppiumLocalService service = builder.WithArguments(args).Build();
```

then

```C#
AndroidDriver<AppiumWebElement> driver = new AndroidDriver<AppiumWebElement>
(service, clientCapabilities);
```

or 

```C#
AndroidDriver<AppiumWebElement> driver = new AndroidDriver<AppiumWebElement>
(builder, clientCapabilities);
```

or 

```C#
service.Start();
AndroidDriver<AppiumWebElement> driver = new AndroidDriver<AppiumWebElement>
(service.getUrl(), clientCapabilities);
```