### PR TITLE
Fixing a compiler error: missing JSON.net namespace

### DIFF
--- a/appium-dotnet-driver/Appium/AppiumDriver.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriver.cs
@@ -13,6 +13,7 @@
 //limitations under the License.
 
 using Appium.Interfaces.Generic.SearchContext;
+using Newtonsoft.Json;
 using OpenQA.Selenium.Appium.Enums;
 using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.MultiTouch;


### PR DESCRIPTION
## Change list

Very simple, compiler error fix
 
## Types of changes

Added a JSON.net namespace to a file to fix a compiler error

##Details

Added a JSON.net namespace to a file to fix a compiler error
