### PR TITLE
#153 fix & #152 fix. The `SessionDetails` property

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,23 +6,26 @@
 - Update to Selenium.Webdriver v2.53.1 and Selenium.Support v2.53.1.
 - Update to Newtonsoft.Json v9.0.1.
 - Re-design of mobile searching strategies:
-	- The class OpenQA.Selenium.Appium.MobileBy was added.
-	- Classes ByAccessibilityId, ByAndroidUIAutomator, ByIosUIAutomation were grouped by the new class.
-	- Static methods that create instances of ByAccessibilityId, ByAndroidUIAutomator, ByIosUIAutomation were added.
-- The method public W GetNamedTextField(String name) was marked obsolete. It is going to be removed.	   
-- ScrollTo() and ScrollToExact() became deprecated. They are going to be removed in the next release. The swiping action and OpenQA.Selenium.Appium.ByAndroidUIAutomator or
-OpenQA.Selenium.Appium.ByIosUIAutomation are recommended to use instead.
+	- The class `OpenQA.Selenium.Appium.MobileBy` was added.
+	- Classes `ByAccessibilityId`, `ByAndroidUIAutomator`, `ByIosUIAutomation` were grouped by the new class.
+	- Static methods that create instances of `ByAccessibilityId`, `ByAndroidUIAutomator`, `ByIosUIAutomation` were added.
+- The method public `W GetNamedTextField(String name)` was marked obsolete. It is going to be removed.	   
+- `ScrollTo()` and `ScrollToExact()` became deprecated. They are going to be removed in the next release. The swiping action and `OpenQA.Selenium.Appium.ByAndroidUIAutomator` or
+`OpenQA.Selenium.Appium.ByIosUIAutomatio`n are recommended to use instead.
 - Server flags were added:
-	- GeneralOptionList.AsyncTrace
-	- IOSOptionList.WebkitDebugProxyPort
+	- `GeneralOptionList.AsyncTrace`
+	- `IOSOptionList.WebkitDebugProxyPort`
+- The `SessionDetails` property was added.  This property returns a dictionary of the current session data.
+- [#153](https://github.com/appium/appium-dotnet-driver/issues/153) fix & [#152](https://github.com/appium/appium-dotnet-driver/issues/152) fix. These changes are supposed to be the temporary workaround. We are searching for a more convenient solution. 
+  It seems it requires some changes on the server side.
 - FIX of the swiping issue (iOS, server version >= 1.5.0). Now the swiping is implemented differently by AndroidDriver and IOSDriver.
 - the ability to start an activity using Android intent actions, intent categories, flags and arguments was added to OpenQA.Selenium.Appium.Android.AndroidDriver. 
 The StartActivityWithIntent method.
 - [Android] ability to push a common string as a file to the remote mobile device. The method was redesigned.
 - [Android] ability to push base64 encoded bytes as a file to the remote mobile device. The method was added.
 - [Android] ability to push a file as the file to the remote mobile device. The method was added.
-- Constructors like AppiumDriver(ICommandExecutor commandExecutor, ICapabilities desiredCapabilities) were added to OpenQA.Selenium.Appium.Android.AndroidDriver and OpenQA.Selenium.Appium.iOS.IOSDriver. Also 
-      OpenQA.Selenium.Appium.AppiumCommand became public. The binding of these features may allow to use realated solutions of other vendors/modified Appium server builds which support JSONWP commands 
+- Constructors like `AppiumDriver(ICommandExecutor commandExecutor, ICapabilities desiredCapabilities)` were added to `OpenQA.Selenium.Appium.Android.AndroidDriver` and `OpenQA.Selenium.Appium.iOS.IOSDriver`. Also 
+      `OpenQA.Selenium.Appium.AppiumCommand` became public. The binding of these features may allow to use realated solutions of other vendors/modified Appium server builds which support JSONWP commands 
       that default Appium/Selenium do not support.
 
 ##1.5.1.1

--- a/appium-dotnet-driver/Appium/AppiumCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumCommand.cs
@@ -86,8 +86,12 @@ namespace OpenQA.Selenium.Appium
                 #endregion Input value
 
                 #region Device Time
-                 new AppiumCommand(CommandInfo.GetCommand, AppiumDriverCommand.GetDeviceTime, "/session/{sessionId}/appium/device/system_time"),
+                new AppiumCommand(CommandInfo.GetCommand, AppiumDriverCommand.GetDeviceTime, "/session/{sessionId}/appium/device/system_time"),
                 #endregion Device Time
+
+                #region SeassionData
+                new AppiumCommand(CommandInfo.GetCommand, AppiumDriverCommand.GetSession, "/session/{sessionId}/")
+                #endregion SeassionData
 
                 #endregion JSON Wire Protocol Commands
                 

--- a/appium-dotnet-driver/Appium/AppiumDriver.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriver.cs
@@ -725,8 +725,8 @@ namespace OpenQA.Selenium.Appium
                 yOffset = scrHeight - y;
             }
 
-            ITouchAction action0 = new TouchAction(this).Press(x, y - yOffset).MoveTo(x, y).Release();
-            ITouchAction action1 = new TouchAction(this).Press(x, y + yOffset).MoveTo(x, y).Release();
+            ITouchAction action0 = new TouchAction(this).Press(x, y - yOffset).MoveTo(0, yOffset).Release();
+            ITouchAction action1 = new TouchAction(this).Press(x, y + yOffset).MoveTo(0, -yOffset).Release();
 
             multiTouch.Add(action0).Add(action1);
 
@@ -759,8 +759,8 @@ namespace OpenQA.Selenium.Appium
                 yOffset = scrHeight - y;
             }
 
-            ITouchAction action0 = new TouchAction(this).Press(x, y).MoveTo(x, y - yOffset).Release();
-            ITouchAction action1 = new TouchAction(this).Press(x, y).MoveTo(x, y + yOffset).Release();
+            ITouchAction action0 = new TouchAction(this).Press(x, y).MoveTo(0, - yOffset).Release();
+            ITouchAction action1 = new TouchAction(this).Press(x, y).MoveTo(0, yOffset).Release();
 
             multiTouch.Add(action0).Add(action1);
 
@@ -785,8 +785,8 @@ namespace OpenQA.Selenium.Appium
             Point center = new Point(upperLeft.X + dimensions.Width / 2, upperLeft.Y + dimensions.Height / 2);
             int yOffset = center.Y - upperLeft.Y;
 
-            ITouchAction action0 = new TouchAction(this).Press(el).MoveTo(el, center.X, center.Y - yOffset).Release();
-            ITouchAction action1 = new TouchAction(this).Press(el).MoveTo(el, center.X, center.Y + yOffset).Release();
+            ITouchAction action0 = new TouchAction(this).Press(el).MoveTo(el, 0,  - yOffset).Release();
+            ITouchAction action1 = new TouchAction(this).Press(el).MoveTo(el, 0, yOffset).Release();
 
             multiTouch.Add(action0).Add(action1);
 
@@ -800,7 +800,7 @@ namespace OpenQA.Selenium.Appium
         /// Gets device date and time for both iOS(Supports only real device) and Android devices
         /// </summary>
         /// <returns>A string which consists of date and time</returns>
-        public String DeviceTime
+        public string DeviceTime
         {
             get
             {
@@ -810,31 +810,23 @@ namespace OpenQA.Selenium.Appium
 
         #endregion Device Time
 
+        #region Session Data
+        /// <summary>
+        /// This property returns a dictionary of the current session data
+        /// </summary>
+        public Dictionary<string, object> SessionDetails
+        {
+            get
+            {
+                return (Dictionary<string, object>) Execute(AppiumDriverCommand.GetSession, null).Value;
+            }
+        }
+        #endregion Session Data
+
         #endregion Public Methods
 
         #region Support methods
-        /// <summary>
-        /// Find the element in the response
-        /// </summary>
-        /// <param name="response">Response from the browser</param>
-        /// <returns>Element from the page</returns>
-        internal IWebElement GetElementFromResponse(Response response)
-        {
-            if (response == null)
-            {
-                throw new NoSuchElementException();
-            }
 
-            RemoteWebElement element = null;
-            Dictionary<string, object> elementDictionary = response.Value as Dictionary<string, object>;
-            if (elementDictionary != null)
-            {
-                string id = (string)elementDictionary["ELEMENT"];
-                element = this.CreateElement(id);
-            }
-
-            return element;
-        }
 
         internal static DesiredCapabilities SetPlatformToCapabilities(DesiredCapabilities dc, string desiredPlatform)
         {

--- a/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
@@ -257,6 +257,8 @@ namespace OpenQA.Selenium.Appium
 
         public const string GetDeviceTime = "getDeviceTime";
 
+        public const string GetSession = "getSession";
+
         #endregion JSON Wire Protocol
     }
 }

--- a/appium-dotnet-driver/appium-dotnet-driver.nuspec
+++ b/appium-dotnet-driver/appium-dotnet-driver.nuspec
@@ -18,24 +18,27 @@
       Update to Selenium.Webdriver v2.53.1 and Selenium.Support v2.53.1.
       Update to Newtonsoft.Json v9.0.1.
       Re-design of mobile searching strategies:
-	      - The class OpenQA.Selenium.Appium.MobileBy was added.
-	      - Classes ByAccessibilityId, ByAndroidUIAutomator, ByIosUIAutomation were grouped by the new class.
-	      - Static methods that create instances of ByAccessibilityId, ByAndroidUIAutomator, ByIosUIAutomation were added.
-      The method public W GetNamedTextField(String name) was marked obsolete. It is going to be removed.	   
+      - The class OpenQA.Selenium.Appium.MobileBy was added.
+      - Classes ByAccessibilityId, ByAndroidUIAutomator, ByIosUIAutomation were grouped by the new class.
+      - Static methods that create instances of ByAccessibilityId, ByAndroidUIAutomator, ByIosUIAutomation were added.
+      The method public W GetNamedTextField(String name) was marked obsolete. It is going to be removed.
       ScrollTo() and ScrollToExact() became deprecated. They are going to be removed in the next release. The swiping action and OpenQA.Selenium.Appium.ByAndroidUIAutomator or
-        OpenQA.Selenium.Appium.ByIosUIAutomation are recommended to use instead.
+      OpenQA.Selenium.Appium.ByIosUIAutomation are recommended to use instead.
       Server flags were added:
-	     - GeneralOptionList.AsyncTrace
-	     - IOSOptionList.WebkitDebugProxyPort
+      - GeneralOptionList.AsyncTrace
+      - IOSOptionList.WebkitDebugProxyPort
+      The SessionDetails property was added.  This property returns a dictionary of the current session data.
+      FIX of the pinch/zoom issue. This change is supposed to be the temporary workaround. We are searching for a more convenient solution.
+      It seems it requires some changes on the server side.
       FIX of the swiping issue (iOS, server version >= 1.5.0). Now the swiping is implemented differently by AndroidDriver and IOSDriver.
-      the ability to start an activity using Android intent actions, intent categories, flags and arguments was added to OpenQA.Selenium.Appium.Android.AndroidDriver. 
-        The StartActivityWithIntent method.
+      the ability to start an activity using Android intent actions, intent categories, flags and arguments was added to OpenQA.Selenium.Appium.Android.AndroidDriver.
+      The StartActivityWithIntent method.
       [Android] ability to push a common string as a file to the remote mobile device. The method was redesigned.
       [Android] ability to push base64 encoded bytes as a file to the remote mobile device. The method was added.
       [Android] ability to push a file as the file to the remote mobile device. The method was added.
-      Constructors like AppiumDriver(ICommandExecutor commandExecutor, ICapabilities desiredCapabilities) were added to OpenQA.Selenium.Appium.Android.AndroidDriver and OpenQA.Selenium.Appium.iOS.IOSDriver. Also 
-        OpenQA.Selenium.Appium.AppiumCommand became public. The binding of these features may allow to use realated solutions of other vendors/modified Appium server builds which support JSONWP commands 
-        that default Appium/Selenium do not support.      
+      Constructors like AppiumDriver(ICommandExecutor commandExecutor, ICapabilities desiredCapabilities) were added to OpenQA.Selenium.Appium.Android.AndroidDriver and OpenQA.Selenium.Appium.iOS.IOSDriver. Also
+      OpenQA.Selenium.Appium.AppiumCommand became public. The binding of these features may allow to use realated solutions of other vendors/modified Appium server builds which support JSONWP commands
+      that default Appium/Selenium do not support.
       1.5.1.1
       Update to Selenium.Webdriver v2.53.0 and Selenium.Support v2.53.0
       Update to Newtonsoft.Json v8.0.2
@@ -92,7 +95,7 @@
       TouchAction + multiActions rewriting,
       Project structure overhaul.
     </releaseNotes>
-    <copyright>Copyright 2014</copyright>
+    <copyright>Copyright 2016</copyright>
     <tags>Appium Webdriver device automation</tags>
     <dependencies>
       <dependency id="Newtonsoft.Json" version="9.0.1"/>
@@ -102,7 +105,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="bin/Release/appium-dotnet-driver.dll" target="lib/net40/appium-dotnet-driver.dll" />
-    <file src="bin/Release/appium-dotnet-driver.XML" target="lib/net40/appium-dotnet-driver.XML" />
+    <file src="bin/Release/appium-dotnet-driver.dll" target="lib/net45/appium-dotnet-driver.dll" />
+    <file src="bin/Release/appium-dotnet-driver.XML" target="lib/net45/appium-dotnet-driver.XML" />
   </files>
 </package>

--- a/integration_tests/Android/AndroidSessionTest.cs
+++ b/integration_tests/Android/AndroidSessionTest.cs
@@ -1,0 +1,64 @@
+﻿using Appium.Integration.Tests.Helpers;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Remote;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Appium.Integration.Tests.Android
+{
+    class AndroidSessionTest
+    {
+        private AppiumDriver<IWebElement> driver;
+
+        [TestFixtureSetUp]
+        public void BeforeAll()
+        {
+            DesiredCapabilities capabilities = Env.isSauce() ?
+                Caps.getAndroid501Caps(Apps.get("androidApiDemos")) :
+                Caps.getAndroid19Caps(Apps.get("androidApiDemos"));
+            if (Env.isSauce())
+            {
+                capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+                capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+                capabilities.SetCapability("name", "android - complex");
+                capabilities.SetCapability("tags", new string[] { "sample" });
+            }
+            Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.LocalServiceURIAndroid;
+            driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+            driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
+        }
+
+        [TestFixtureTearDown]
+        public void AfterAll()
+        {
+            if (driver != null)
+            {
+                driver.Quit();
+            }
+            if (!Env.isSauce())
+            {
+                AppiumServers.StopLocalService();
+            }
+        }
+
+        [Test]
+        public void GetDeviceUDIDTest()
+        {
+            string deviceUIID = driver.SessionDetails["deviceUDID"].ToString();
+            Assert.NotNull(deviceUIID);
+        }
+
+        [Test]
+        public void GetDeviceDictionaryData()
+        {
+            Dictionary<string, object> dictionary = (Dictionary<string, object>) driver.SessionDetails["desired"];
+            Assert.AreNotEqual(dictionary.Count, 0);
+        }
+    }
+}

--- a/integration_tests/integration_tests.csproj
+++ b/integration_tests/integration_tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Android\AndroidConnectionTest.cs" />
     <Compile Include="Android\AndroidElementTest.cs" />
     <Compile Include="Android\AndroidGestureTest.cs" />
+    <Compile Include="Android\AndroidSessionTest.cs" />
     <Compile Include="Android\FileInteractionTest.cs" />
     <Compile Include="Android\HideKeyboardTestCase.cs" />
     <Compile Include="Android\AndroidLocationTest.cs" />


### PR DESCRIPTION
## Change list

- #153 fix 

- #152 fix

These changes (#153 fix & #152 fix) are supposed to be the temporary workaround. I'm and  @SrinivasanTarget are searching for a more consistent solution. It seems it requires some changes on the server side.

- The `SessionDetails` property was added.  This property returns a dictionary of the current session data.

- updated release notes.

 
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)