### PR TITLE
Added toggleTouchIdEnrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#appium-dotnet-driver
+# appium-dotnet-driver
 
 This driver is an extension of the [Selenium](http://docs.seleniumhq.org/) C# client. It has 
 all the functionalities of the regular driver, but add Appium specific methods on top of this.

--- a/appium-dotnet-driver/Appium/AppiumCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumCommand.cs
@@ -58,7 +58,8 @@ namespace OpenQA.Selenium.Appium
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.StartActivity, "/session/{sessionId}/appium/device/start_activity"),
                 new AppiumCommand(CommandInfo.GetCommand,  AppiumDriverCommand.GetSettings, "/session/{sessionId}/appium/settings"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.UpdateSettings, "/session/{sessionId}/appium/settings"),
-                new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.TouchID, "/session/{sessionId}/appium/simulator/touch_id"),
+				new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.TouchID, "/session/{sessionId}/appium/simulator/touch_id"),
+				new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.ToggleTouchIdEnrollment, "/session/{sessionId}/appium/simulator/toggle_touch_id_enrollment"),
                 #endregion Appium Commands
                 #region Touch Commands
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.PerformMultiAction, "/session/{sessionId}/touch/multi/perform"),

--- a/appium-dotnet-driver/Appium/AppiumCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumCommand.cs
@@ -58,8 +58,8 @@ namespace OpenQA.Selenium.Appium
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.StartActivity, "/session/{sessionId}/appium/device/start_activity"),
                 new AppiumCommand(CommandInfo.GetCommand,  AppiumDriverCommand.GetSettings, "/session/{sessionId}/appium/settings"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.UpdateSettings, "/session/{sessionId}/appium/settings"),
-		new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.TouchID, "/session/{sessionId}/appium/simulator/touch_id"),
-		new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.ToggleTouchIdEnrollment, "/session/{sessionId}/appium/simulator/toggle_touch_id_enrollment"),
+                new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.TouchID, "/session/{sessionId}/appium/simulator/touch_id"),
+                new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.ToggleTouchIdEnrollment, "/session/{sessionId}/appium/simulator/toggle_touch_id_enrollment"),
                 #endregion Appium Commands
                 #region Touch Commands
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.PerformMultiAction, "/session/{sessionId}/touch/multi/perform"),

--- a/appium-dotnet-driver/Appium/AppiumCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumCommand.cs
@@ -58,8 +58,8 @@ namespace OpenQA.Selenium.Appium
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.StartActivity, "/session/{sessionId}/appium/device/start_activity"),
                 new AppiumCommand(CommandInfo.GetCommand,  AppiumDriverCommand.GetSettings, "/session/{sessionId}/appium/settings"),
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.UpdateSettings, "/session/{sessionId}/appium/settings"),
-				new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.TouchID, "/session/{sessionId}/appium/simulator/touch_id"),
-				new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.ToggleTouchIdEnrollment, "/session/{sessionId}/appium/simulator/toggle_touch_id_enrollment"),
+		new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.TouchID, "/session/{sessionId}/appium/simulator/touch_id"),
+		new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.ToggleTouchIdEnrollment, "/session/{sessionId}/appium/simulator/toggle_touch_id_enrollment"),
                 #endregion Appium Commands
                 #region Touch Commands
                 new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.PerformMultiAction, "/session/{sessionId}/touch/multi/perform"),

--- a/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
@@ -256,10 +256,10 @@ namespace OpenQA.Selenium.Appium
 	/// </summary>
 	public const string TouchID = "touchId";
 
-		/// <summary>
-		/// Represents the ToggleTouchIdEnrollment Command
-		/// </summary>
-		public const string ToggleTouchIdEnrollment = "toggleTouchIdEnrollment";
+	/// <summary>
+	/// Represents the ToggleTouchIdEnrollment Command
+	/// </summary>
+	public const string ToggleTouchIdEnrollment = "toggleTouchIdEnrollment";
 
         public const string ReplaceValue = "replaceValue";
 

--- a/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriverCommand.cs
@@ -256,6 +256,11 @@ namespace OpenQA.Selenium.Appium
 	/// </summary>
 	public const string TouchID = "touchId";
 
+		/// <summary>
+		/// Represents the ToggleTouchIdEnrollment Command
+		/// </summary>
+		public const string ToggleTouchIdEnrollment = "toggleTouchIdEnrollment";
+
         public const string ReplaceValue = "replaceValue";
 
         public const string SetValue = "setValue";

--- a/appium-dotnet-driver/Appium/iOS/IOSCommandExecutionHelper.cs
+++ b/appium-dotnet-driver/Appium/iOS/IOSCommandExecutionHelper.cs
@@ -25,5 +25,8 @@ namespace OpenQA.Selenium.Appium.iOS
         public static void PerformTouchID(IExecuteMethod executeMethod, bool match) =>
             executeMethod.Execute(AppiumDriverCommand.TouchID, 
                 new Dictionary<string, object>() { ["match"] = match });
+
+        public static void ToggleTouchIdEnrollment(IExecuteMethod executeMethod) =>
+           executeMethod.Execute(AppiumDriverCommand.ToggleTouchIdEnrollment);
     }
 }

--- a/appium-dotnet-driver/Appium/iOS/IOSDriver.cs
+++ b/appium-dotnet-driver/Appium/iOS/IOSDriver.cs
@@ -174,5 +174,7 @@ namespace OpenQA.Selenium.Appium.iOS
         }
 
         public void PerformTouchID(bool match) => IOSCommandExecutionHelper.PerformTouchID(this, match);
+
+        public void ToggleTouchIdEnrollment() => IOSCommandExecutionHelper.ToggleTouchIdEnrollment(this);
     }
 }

--- a/appium-dotnet-driver/Appium/iOS/Interfaces/IPerformsTouchID.cs
+++ b/appium-dotnet-driver/Appium/iOS/Interfaces/IPerformsTouchID.cs
@@ -22,5 +22,10 @@ namespace OpenQA.Selenium.Appium.iOS.Interfaces
         /// <param name="match">If true, simulates a successful fingerprint scan. 
         /// If false, simulates a failed fingerprint scan.</param>
         void PerformTouchID(bool match);
+
+        ///<summary>
+        /// Toggle Simulator's enabled state for touch id
+        /// </summary>
+        void ToggleTouchIdEnrollment();
     }
 }


### PR DESCRIPTION
## Proposed changes

The Appium team added an endpoint that toggles touchId enrollment (/session/:session_id/simulator/toggle_touch_id_enrollment). This PR adds a new method that hits this endpoint.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected