### PR TITLE
longPress action name fix

### DIFF
--- a/appium-dotnet-driver/Appium/MultiAction/TouchAction.cs
+++ b/appium-dotnet-driver/Appium/MultiAction/TouchAction.cs
@@ -103,7 +103,7 @@ namespace OpenQA.Selenium.Appium.MultiTouch
         /// <returns>A self-reference to this <see cref="ITouchAction"/>.</returns>
         public ITouchAction LongPress(IWebElement element, double? x = null, double? y = null)
         {
-            Step longPressStep = new Step("longpress");
+            Step longPressStep = new Step("longPress");
             longPressStep
                 .AddOpt("element", element)
                 .AddOpt("x", x)


### PR DESCRIPTION
## Change list

Change "longpress" to "longPress" in TouchAction class
 
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details
Created issue for this https://github.com/appium/appium-dotnet-driver/issues/180