### PR TITLE
Use const for values of MobilePlatform

### DIFF
--- a/appium-dotnet-driver/Appium/Enums/MobilePlatform.cs
+++ b/appium-dotnet-driver/Appium/Enums/MobilePlatform.cs
@@ -15,11 +15,11 @@ namespace OpenQA.Selenium.Appium.Enums
 {
     public sealed class MobilePlatform
     {
-        public static readonly string Android = "Android";
+        public const string Android = "Android";
 
-        public static readonly string IOS = "iOS";
+        public const string IOS = "iOS";
 
-        public static readonly string Windows = "Windows";
+        public const string Windows = "Windows";
 
         //FireFoxOS and WinPhone will be added when there will be the supporting of appropriate mobile OS.
     }


### PR DESCRIPTION
Makes them usable for attributes (e.g. as a parameter for a platform specific ignore attribute)
 
## Types of changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)

## Details

I'd like to be able to use MobilePlatform in attributes of tests where const values are required.