### PR TITLE
Add Find by ios class chain

### DIFF
--- a/appium-dotnet-driver/Appium/Enums/MobileSelector.cs
+++ b/appium-dotnet-driver/Appium/Enums/MobileSelector.cs
@@ -20,6 +20,7 @@ namespace OpenQA.Selenium.Appium.Enums
         public static readonly string AndroidUIAutomator = "-android uiautomator";
         public static readonly string iOSAutomatoion = "-ios uiautomation";
         public static readonly string iOSPredicateString = "-ios predicate string";
-        public static readonly string WindowsUIAutomation = "-windows uiautomation";
+		public static readonly string iOSClassChain = "-ios class chain";
+		public static readonly string WindowsUIAutomation = "-windows uiautomation";
     }
 }

--- a/appium-dotnet-driver/Appium/Enums/MobileSelector.cs
+++ b/appium-dotnet-driver/Appium/Enums/MobileSelector.cs
@@ -20,7 +20,7 @@ namespace OpenQA.Selenium.Appium.Enums
         public static readonly string AndroidUIAutomator = "-android uiautomator";
         public static readonly string iOSAutomatoion = "-ios uiautomation";
         public static readonly string iOSPredicateString = "-ios predicate string";
-		public static readonly string iOSClassChain = "-ios class chain";
-		public static readonly string WindowsUIAutomation = "-windows uiautomation";
+        public static readonly string iOSClassChain = "-ios class chain";
+        public static readonly string WindowsUIAutomation = "-windows uiautomation";
     }
 }

--- a/appium-dotnet-driver/Appium/Interfaces/IFindsByIosClassChain.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/IFindsByIosClassChain.cs
@@ -15,10 +15,20 @@ using System.Collections.ObjectModel;
 
 namespace OpenQA.Selenium.Appium.Interfaces
 {
-	public interface IFindsByIosClassChain<W> : IFindsByFluentSelector<W> where W : IWebElement
-	{
-		W FindElementByIosClassChain(string selector);
+    public interface IFindsByIosClassChain<W> : IFindsByFluentSelector<W> where W : IWebElement
+    {
+        /// <summary>
+        /// Finds the first of elements that match the IosClassChain selector supplied
+        /// </summary>
+        /// <param name="selector">an IosClassChain selector</param>
+        /// <returns>IWebElement object so that you can interact that object</returns>
+        W FindElementByIosClassChain(string selector);
 
-		ReadOnlyCollection<W> FindElementsByIosClassChain(string selector);
-	}
+        /// <summary>
+        /// Finds a list of elements that match the IosClassChain selector supplied
+        /// </summary>
+        /// <param name="selector">an IosClassChain selector</param>
+        /// <returns>ReadOnlyCollection of IWebElement objects so that you can interact with those objects</returns>
+        ReadOnlyCollection<W> FindElementsByIosClassChain(string selector);
+    }
 }

--- a/appium-dotnet-driver/Appium/Interfaces/IFindsByIosClassChain.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/IFindsByIosClassChain.cs
@@ -1,0 +1,24 @@
+﻿//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+using System.Collections.ObjectModel;
+
+namespace OpenQA.Selenium.Appium.Interfaces
+{
+	public interface IFindsByIosClassChain<W> : IFindsByFluentSelector<W> where W : IWebElement
+	{
+		W FindElementByIosClassChain(string selector);
+
+		ReadOnlyCollection<W> FindElementsByIosClassChain(string selector);
+	}
+}

--- a/appium-dotnet-driver/Appium/Interfaces/IFindsByIosNSPredicate.cs
+++ b/appium-dotnet-driver/Appium/Interfaces/IFindsByIosNSPredicate.cs
@@ -18,8 +18,18 @@ namespace OpenQA.Selenium.Appium.Interfaces
 {
     public interface IFindsByIosNSPredicate<W> : IFindsByFluentSelector<W> where W : IWebElement
     {
+        /// <summary>
+        /// Finds the first of elements that match the IosNsPredicate selector supplied
+        /// </summary>
+        /// <param name="selector">an IosNsPredicate selector</param>
+        /// <returns>IWebElement object so that you can interact that object</returns>
         W FindElementByIosNsPredicate(string selector);
 
+        /// <summary>
+        /// Finds a list of elements that match the IosNsPredicate selector supplied
+        /// </summary>
+        /// <param name="selector">an IosNsPredicate selector</param>
+        /// <returns>ReadOnlyCollection of IWebElement objects so that you can interact with those objects</returns>
         ReadOnlyCollection<W> FindElementsByIosNsPredicate(string selector);
     }
 }

--- a/appium-dotnet-driver/Appium/MobileBy.cs
+++ b/appium-dotnet-driver/Appium/MobileBy.cs
@@ -151,6 +151,8 @@ namespace OpenQA.Selenium.Appium
         public static By WindowsAutomation(string selector) => new ByWindowsAutomation(selector);
 
         public static By IosNSPredicate(string selector) => new ByIosNSPredicate(selector);
+
+        public static By IosClassChain(string selector) => new ByIosClassChain(selector);
     }
 
     /// <summary>
@@ -244,4 +246,20 @@ namespace OpenQA.Selenium.Appium
         public override string ToString() =>
             $"ByIosNSPredicate({selector})";
     }
+
+	public class ByIosClassChain : MobileBy
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ByWindowsAutomation"/> class.
+		/// </summary>
+		/// <param name="selector">The selector to use in finding the element.</param>
+		public ByIosClassChain(string selector)
+            : base(selector, "IFindsByIosClassChain", "FindElementByIosClassChain", "FindElementsByIosClassChain", MobileSelector.iOSClassChain)
+		{
+		}
+
+		public override string ToString() =>
+			$"ByIosClassChain({selector})";
+	}
+
 }

--- a/appium-dotnet-driver/Appium/MobileBy.cs
+++ b/appium-dotnet-driver/Appium/MobileBy.cs
@@ -235,7 +235,7 @@ namespace OpenQA.Selenium.Appium
     public class ByIosNSPredicate : MobileBy
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ByWindowsAutomation"/> class.
+        /// Initializes a new instance of the <see cref="ByIosNSPredicate"/> class.
         /// </summary>
         /// <param name="selector">The selector to use in finding the element.</param>
         public ByIosNSPredicate(string selector)
@@ -247,19 +247,19 @@ namespace OpenQA.Selenium.Appium
             $"ByIosNSPredicate({selector})";
     }
 
-	public class ByIosClassChain : MobileBy
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="ByWindowsAutomation"/> class.
-		/// </summary>
-		/// <param name="selector">The selector to use in finding the element.</param>
-		public ByIosClassChain(string selector)
+    public class ByIosClassChain : MobileBy
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ByIosClassChain"/> class.
+        /// </summary>
+        /// <param name="selector">The selector to use in finding the element.</param>
+        public ByIosClassChain(string selector)
             : base(selector, "IFindsByIosClassChain", "FindElementByIosClassChain", "FindElementsByIosClassChain", MobileSelector.iOSClassChain)
-		{
-		}
+        {
+        }
 
-		public override string ToString() =>
-			$"ByIosClassChain({selector})";
-	}
+        public override string ToString() =>
+            $"ByIosClassChain({selector})";
+    }
 
 }

--- a/appium-dotnet-driver/Appium/iOS/IOSDriver.cs
+++ b/appium-dotnet-driver/Appium/iOS/IOSDriver.cs
@@ -23,7 +23,7 @@ using System.Collections.ObjectModel;
 
 namespace OpenQA.Selenium.Appium.iOS
 {
-    public class IOSDriver<W> : AppiumDriver<W>, IFindByIosUIAutomation<W>, IHidesKeyboardWithKeyName, 
+    public class IOSDriver<W> : AppiumDriver<W>, IFindByIosUIAutomation<W>, IFindsByIosClassChain<W>, IHidesKeyboardWithKeyName, 
         IShakesDevice, IPerformsTouchID where W : IWebElement
     {
         private static readonly string Platform = MobilePlatform.IOS;
@@ -121,6 +121,7 @@ namespace OpenQA.Selenium.Appium.iOS
         }
 
         #region IFindByIosUIAutomation Members
+
         /// <summary>
         /// Finds the first element that matches the iOS UIAutomation selector
         /// </summary>
@@ -134,7 +135,26 @@ namespace OpenQA.Selenium.Appium.iOS
         /// <param name="selector">UIAutomation selector</param>
         /// <returns>ReadOnlyCollection of elements found</returns>
         public ReadOnlyCollection<W> FindElementsByIosUIAutomation(string selector) => FindElements(MobileSelector.iOSAutomatoion, selector);
+
         #endregion IFindByIosUIAutomation Members
+
+        #region IFindsByIosClassChain Members
+
+        /// <summary>
+        /// Finds the first element that matches the iOS class chain selector
+        /// </summary>
+        /// <param name="selector">class chain selector</param>
+        /// <returns>First element found</returns>
+        public W FindElementByIosClassChain(string selector) => FindElement(MobileSelector.iOSClassChain, selector);
+
+        /// <summary>
+        /// Finds a list of elements that match the iOS class chain selector
+        /// </summary>
+        /// <param name="selector">class chain selector</param>
+        /// <returns>ReadOnlyCollection of elements found</returns>
+        public ReadOnlyCollection<W> FindElementsByIosClassChain(string selector) => FindElements(MobileSelector.iOSClassChain, selector);
+
+        #endregion IFindsByIosClassChain Members
 
         public void ShakeDevice() => IOSCommandExecutionHelper.ShakeDevice(this);
 

--- a/appium-dotnet-driver/Appium/iOS/IOSDriver.cs
+++ b/appium-dotnet-driver/Appium/iOS/IOSDriver.cs
@@ -23,7 +23,7 @@ using System.Collections.ObjectModel;
 
 namespace OpenQA.Selenium.Appium.iOS
 {
-    public class IOSDriver<W> : AppiumDriver<W>, IFindByIosUIAutomation<W>, IFindsByIosClassChain<W>, IHidesKeyboardWithKeyName, 
+    public class IOSDriver<W> : AppiumDriver<W>, IFindByIosUIAutomation<W>, IFindsByIosClassChain<W>, IFindsByIosNSPredicate<W>, IHidesKeyboardWithKeyName, 
         IShakesDevice, IPerformsTouchID where W : IWebElement
     {
         private static readonly string Platform = MobilePlatform.IOS;
@@ -155,6 +155,24 @@ namespace OpenQA.Selenium.Appium.iOS
         public ReadOnlyCollection<W> FindElementsByIosClassChain(string selector) => FindElements(MobileSelector.iOSClassChain, selector);
 
         #endregion IFindsByIosClassChain Members
+
+        #region IFindsByIosNSPredicate Members
+
+        /// <summary>
+        /// Finds the first element that matches the IosNSPredicate selector
+        /// </summary>
+        /// <param name="selector">IosNSPredicate selector</param>
+        /// <returns>First element found</returns>
+        public W FindElementByIosNsPredicate(string selector) => FindElement(MobileSelector.iOSPredicateString, selector);
+
+        /// <summary>
+        /// Finds a list of elements that match the IosNSPredicate selector
+        /// </summary>
+        /// <param name="selector">IosNSPredicate selector</param>
+        /// <returns>ReadOnlyCollection of elements found</returns>
+        public ReadOnlyCollection<W> FindElementsByIosNsPredicate(string selector) => FindElements(MobileSelector.iOSPredicateString, selector);
+
+        #endregion IFindsByIosNSPredicate Members
 
         public void ShakeDevice() => IOSCommandExecutionHelper.ShakeDevice(this);
 

--- a/appium-dotnet-driver/appium-dotnet-driver.csproj
+++ b/appium-dotnet-driver/appium-dotnet-driver.csproj
@@ -151,6 +151,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Appium\Interfaces\IFindsByIosClassChain.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="appium-dotnet-driver.licenseheader" />

--- a/integration_tests/helpers/Caps.cs
+++ b/integration_tests/helpers/Caps.cs
@@ -6,6 +6,15 @@ namespace Appium.Integration.Tests.Helpers
 {
 	public class Caps
 	{
+        public static DesiredCapabilities getIos102Caps (string app) {
+			DesiredCapabilities capabilities = new DesiredCapabilities();
+			capabilities.SetCapability(MobileCapabilityType.PlatformVersion, "10.2");
+			capabilities.SetCapability(MobileCapabilityType.DeviceName, "iPhone Simulator");
+            capabilities.SetCapability(MobileCapabilityType.AppiumVersion, "1.7.1");
+			capabilities.SetCapability(MobileCapabilityType.App, app);
+			return capabilities;
+        }
+
 		public static DesiredCapabilities getIos92Caps (string app) {
 			DesiredCapabilities capabilities = new DesiredCapabilities();
 			capabilities.SetCapability(MobileCapabilityType.PlatformVersion, "9.2");

--- a/integration_tests/iOS/iOSSearchingClassChainTest.cs
+++ b/integration_tests/iOS/iOSSearchingClassChainTest.cs
@@ -1,0 +1,60 @@
+﻿using Appium.Integration.Tests.Helpers;
+using NUnit.Framework;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.iOS;
+using OpenQA.Selenium.Remote;
+using System;
+using System.Collections.ObjectModel;
+
+namespace Appium.Integration.Tests.iOS
+{
+	public class IOSSearchingClassChainTest
+	{
+		private IOSDriver<AppiumWebElement> driver;
+
+		[TestFixtureSetUp]
+		public void beforeAll()
+		{
+            DesiredCapabilities capabilities = Caps.getIos102Caps(Apps.get("iosUICatalogApp"));
+			if (Env.isSauce())
+			{
+				capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
+				capabilities.SetCapability("accessKey", Env.getEnvVar("SAUCE_ACCESS_KEY"));
+				capabilities.SetCapability("name", "ios - complex");
+				capabilities.SetCapability("tags", new string[] { "sample" });
+
+			}
+			Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.LocalServiceURIForIOS;
+			driver = new IOSDriver<AppiumWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
+			driver.Manage().Timeouts().ImplicitlyWait(Env.IMPLICIT_TIMEOUT_SEC);
+		}
+
+		[TestFixtureTearDown]
+		public void AfterEach()
+		{
+			if (driver != null)
+			{
+				driver.Quit();
+			}
+			if (!Env.isSauce())
+			{
+				AppiumServers.StopLocalService();
+			}
+		}
+
+		[Test()]
+		public void FindByClassChainTest()
+		{
+            ReadOnlyCollection<AppiumWebElement> sliderCellStaticTextElements_1 = driver
+                .FindElements(new ByIosClassChain("**/XCUIElementTypeCell/XCUIElementTypeStaticText[`name == 'Sliders'`]"));
+            Assert.AreEqual(sliderCellStaticTextElements_1.Count, 1);
+            ReadOnlyCollection<AppiumWebElement> sliderCellStaticTextElements_2 = driver
+                .FindElementsByIosClassChain("**/XCUIElementTypeCell");
+            Assert.AreEqual(sliderCellStaticTextElements_2.Count, 18);
+
+            AppiumWebElement actionSheetsCell = driver.FindElement(new ByIosClassChain("**/XCUIElementTypeCell/XCUIElementTypeStaticText[`name == 'Action Sheets'`]"));
+            actionSheetsCell.Tap(1, 250);
+            driver.FindElementByIosClassChain("**/XCUIElementTypeNavigationBar/XCUIElementTypeButton").Click();
+		}
+	}
+}

--- a/integration_tests/integration_tests.csproj
+++ b/integration_tests/integration_tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="iOS\iOSAppStringsTest.cs" />
     <Compile Include="Windows\WindowsClickElementTest.cs" />
     <Compile Include="Windows\WindowsMultiSelectControlTest.cs" />
+    <Compile Include="iOS\iOSSearchingClassChainTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>


### PR DESCRIPTION
## Change list

This is to add capability to use class chain selectors for Finding elements.
 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

`            
AppiumWebElement lastSettingsCellItem = MobileAppMgr.CurrentAppDriver.FindElement(MobileBy.IosClassChain("**/XCUIElementTypeCell[-1]"));
string labelAttribute = lastSettingsCellItem.GetAttribute("label");
lastSettingsCellItem.Tap(1, 250);
`

Appium Logs for above code are available [here](https://gist.github.com/rajfidel/cdbe93f1b2ca1e33b6221752cc062c04)