### PR TITLE
Adding handling of locking and unlocking ios devices.

### DIFF
--- a/appium-dotnet-driver/Appium/iOS/IOSCommandExecutionHelper.cs
+++ b/appium-dotnet-driver/Appium/iOS/IOSCommandExecutionHelper.cs
@@ -24,6 +24,16 @@ namespace OpenQA.Selenium.Appium.iOS
 
         public static void PerformTouchID(IExecuteMethod executeMethod, bool match) =>
             executeMethod.Execute(AppiumDriverCommand.TouchID,
-                new Dictionary<string, object>() {["match"] = match});
+                new Dictionary<string, object> {["match"] = match});
+
+        public static bool IsLocked(IExecuteMethod executeMethod) =>
+            (bool)executeMethod.Execute(AppiumDriverCommand.IsLocked).Value;
+
+        public static void Unlock(IExecuteMethod executeMethod) =>
+            executeMethod.Execute(AppiumDriverCommand.UnlockDevice);
+
+        public static void Lock(IExecuteMethod executeMethod) =>
+            executeMethod.Execute(AppiumDriverCommand.LockDevice);
+
     }
 }

--- a/appium-dotnet-driver/Appium/iOS/IOSDriver.cs
+++ b/appium-dotnet-driver/Appium/iOS/IOSDriver.cs
@@ -162,5 +162,12 @@ namespace OpenQA.Selenium.Appium.iOS
         public void Lock(int seconds) => AppiumCommandExecutionHelper.Lock(this, seconds);
 
         public void PerformTouchID(bool match) => IOSCommandExecutionHelper.PerformTouchID(this, match);
+
+        public bool IsLocked() => IOSCommandExecutionHelper.IsLocked(this);
+
+        public void Unlock() => IOSCommandExecutionHelper.Unlock(this);
+
+        public void Lock() => IOSCommandExecutionHelper.Lock(this);
+
     }
 }

--- a/integration_tests/helpers/Caps.cs
+++ b/integration_tests/helpers/Caps.cs
@@ -16,6 +16,15 @@ namespace Appium.Integration.Tests.Helpers
             return capabilities;
         }
 
+        public static DesiredCapabilities getIos112Caps(string app)
+        {
+            DesiredCapabilities capabilities = new DesiredCapabilities();
+            capabilities.SetCapability(MobileCapabilityType.PlatformVersion, "11.2");
+            capabilities.SetCapability(MobileCapabilityType.DeviceName, "iPad Air 2");
+            capabilities.SetCapability(MobileCapabilityType.App, app);
+            return capabilities;
+        }
+
         public static DesiredCapabilities getIos92Caps(string app)
         {
             DesiredCapabilities capabilities = new DesiredCapabilities();

--- a/integration_tests/iOS/iOSLockDeviceTest.cs
+++ b/integration_tests/iOS/iOSLockDeviceTest.cs
@@ -14,10 +14,10 @@ namespace Appium.Integration.Tests.iOS
     {
         private IOSDriver<IWebElement> driver;
 
-        [TestFixtureSetUp]
-        public void BeforeAll()
+        [SetUp]
+        public void TestSetup()
         {
-            DesiredCapabilities capabilities = Caps.getIos92Caps(Apps.get("iosWebviewApp"));
+            DesiredCapabilities capabilities = Caps.getIos112Caps(Apps.get("iosWebviewApp"));
             if (Env.isSauce())
             {
                 capabilities.SetCapability("username", Env.getEnvVar("SAUCE_USERNAME"));
@@ -25,13 +25,17 @@ namespace Appium.Integration.Tests.iOS
                 capabilities.SetCapability("tags", new string[] {"sample"});
             }
             Uri serverUri = Env.isSauce() ? AppiumServers.sauceURI : AppiumServers.LocalServiceURIForIOS;
+            
+
             driver = new IOSDriver<IWebElement>(serverUri, capabilities, Env.INIT_TIMEOUT_SEC);
             driver.Manage().Timeouts().ImplicitWait = Env.IMPLICIT_TIMEOUT_SEC;
         }
 
-        [TestFixtureTearDown]
-        public void AfterAll()
+        [TearDown]
+        public void Cleanup()
         {
+            if(driver.IsLocked())
+                driver.Unlock();
             if (driver != null)
             {
                 driver.Quit();
@@ -42,10 +46,38 @@ namespace Appium.Integration.Tests.iOS
             }
         }
 
-        [Test()]
+        [Test]
+        public void IsLockedTest()
+        {
+            Assert.AreEqual(driver.IsLocked(), false);
+        }
+
+        [Test]
         public void LockTest()
         {
-            driver.Lock(20);
+            Assert.AreEqual(driver.IsLocked(),false);
+            driver.Lock();
+            Assert.AreEqual(driver.IsLocked(), true);
         }
+
+        [Test]
+        public void LockTestWithSeconds()
+        {
+            Assert.AreEqual(driver.IsLocked(), false);
+            driver.Lock(5);
+            Assert.AreEqual(driver.IsLocked(), false);
+        }
+
+        [Test]
+        public void UnlockTest()
+        {
+            Assert.AreEqual(driver.IsLocked(), false);
+            driver.Lock();
+            Assert.AreEqual(driver.IsLocked(), true);
+            driver.Unlock();
+            Assert.AreEqual(driver.IsLocked(), false);
+        }
+
     }
 }
+ 


### PR DESCRIPTION
## Change list

Allowing using locking/unlocking mechanism for .Net client. It's related to:
https://github.com/appium/WebDriverAgent/pull/21
https://github.com/appium/appium-xcuitest-driver/pull/595
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

Change was determined to use functionality used already in java-client: 
https://github.com/appium/java-client/pull/799