### PR TITLE
Pseudo-implemnenting IDisposable on AppiumCommandExecutor

### DIFF
--- a/appium-dotnet-driver/Appium/Service/AppiumCommandExecutor.cs
+++ b/appium-dotnet-driver/Appium/Service/AppiumCommandExecutor.cs
@@ -23,6 +23,7 @@ namespace OpenQA.Selenium.Appium.Service
         private readonly AppiumLocalService Service;
         private readonly Uri URL;
         private readonly ICommandExecutor RealExecutor;
+        private bool isDisposed;
 
         private static ICommandExecutor CreateRealExecutor(Uri remoteAddress, TimeSpan commandTimeout)
         {
@@ -87,15 +88,36 @@ namespace OpenQA.Selenium.Appium.Service
             finally
             {
                 if (result != null && result.Status != WebDriverResult.Success &&
-                    commandToExecute.Name == DriverCommand.NewSession && Service != null)
+                    commandToExecute.Name == DriverCommand.NewSession)
                 {
-                    Service.Dispose();
+                    Dispose();
                 }
 
-                if (commandToExecute.Name == DriverCommand.Quit && Service != null)
+                if (commandToExecute.Name == DriverCommand.Quit)
                 {
-                    Service.Dispose();
+                    Dispose();
                 }
+            }
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+        }
+
+        protected void Dispose(bool disposing)
+        {
+            if (!isDisposed)
+            {
+                if (disposing)
+                {
+                    if (Service != null)
+                    {
+                        Service.Dispose();
+                    }
+                }
+
+                isDisposed = true;
             }
         }
     }


### PR DESCRIPTION
## Change list

This commit implements the disposable pattern on AppiumCommandExecutor,
doing everything except actually declaring that the class implements
IDisposable. The upstream Selenium project will be changing the
ICommandExecutor interface to extend IDisposable in the near future, and
this change is required to prevent errors when that change is made.

## Types of changes

What types of changes are you proposing/introducing to .NET client?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

This PR implements the Disposable pattern as recommended by Microsoft for .NET code. The implementation includes a public `Dispose()` method and a protected `Dispose(bool)` method. As an added code cleanup, it also moves disposal of the service object into the Dispose method for the command executor class. If that change is deemed too risky, that portion of it may be easily reverted.