### PR TITLE
Moving page object classes to be based on relocated repo

### DIFF
--- a/appium-dotnet-driver/Appium/PageObjects/AppiumPageObjectMemberDecorator.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/AppiumPageObjectMemberDecorator.cs
@@ -20,7 +20,7 @@ using OpenQA.Selenium.Appium.PageObjects.Interceptors;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
 using OpenQA.Selenium.Internal;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/appium-dotnet-driver/Appium/PageObjects/ByFactory.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/ByFactory.cs
@@ -18,7 +18,7 @@ using OpenQA.Selenium.Appium.iOS;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
 using OpenQA.Selenium.Appium.PageObjects.Attributes.Abstract;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -30,8 +30,8 @@ namespace OpenQA.Selenium.Appium.PageObjects
     {
         private static By From(FindsByAttribute attribute)
         {
-            Assembly assembly = Assembly.LoadFrom("WebDriver.Support.dll");
-            Type seleniumByFactory = assembly.GetType("OpenQA.Selenium.Support.PageObjects.ByFactory");
+            Assembly assembly = Assembly.LoadFrom("SeleniumExtras.PageObjects.dll");
+            Type seleniumByFactory = assembly.GetType("SeleniumExtras.PageObjects.ByFactory");
             MethodInfo m = seleniumByFactory.GetMethod("From", new Type[] {typeof(FindsByAttribute)});
             return (By) m.Invoke(seleniumByFactory, new object[] {attribute});
         }

--- a/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementInterceptor.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementInterceptor.cs
@@ -14,7 +14,7 @@
 
 using Castle.DynamicProxy;
 using OpenQA.Selenium.Internal;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementListInterceptor.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Interceptors/ElementListInterceptor.cs
@@ -13,7 +13,7 @@
 //limitations under the License.
 
 using Castle.DynamicProxy;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/appium-dotnet-driver/Appium/PageObjects/Interceptors/SearchingInterceptor.cs
+++ b/appium-dotnet-driver/Appium/PageObjects/Interceptors/SearchingInterceptor.cs
@@ -13,8 +13,8 @@
 //limitations under the License.
 
 using Castle.DynamicProxy;
-using OpenQA.Selenium.Support.PageObjects;
 using OpenQA.Selenium.Support.UI;
+using SeleniumExtras.PageObjects;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/appium-dotnet-driver/appium-dotnet-driver.csproj
+++ b/appium-dotnet-driver/appium-dotnet-driver.csproj
@@ -41,13 +41,16 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="SeleniumExtras.PageObjects, Version=3.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetSeleniumExtras.PageObjects.3.11.0\lib\net45\SeleniumExtras.PageObjects.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
-    <Reference Include="WebDriver, Version=3.8.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Selenium.WebDriver.3.8.0\lib\net45\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.11.0\lib\net45\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=3.8.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Selenium.Support.3.8.0\lib\net45\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.11.0\lib\net45\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/appium-dotnet-driver/packages.config
+++ b/appium-dotnet-driver/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net45" />
+  <package id="DotNetSeleniumExtras.PageObjects" version="3.11.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
-  <package id="Selenium.Support" version="3.8.0" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="3.8.0" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.11.0" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.11.0" targetFramework="net45" />
 </packages>

--- a/integration_tests/PageObjectTests/Android/AndroidNativeAppAttributesTest.cs
+++ b/integration_tests/PageObjectTests/Android/AndroidNativeAppAttributesTest.cs
@@ -6,7 +6,7 @@ using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 
 namespace Appium.Integration.Tests.PageObjectTests.Android

--- a/integration_tests/PageObjectTests/Android/AndroidTestThatChecksAttributeMix1.cs
+++ b/integration_tests/PageObjectTests/Android/AndroidTestThatChecksAttributeMix1.cs
@@ -6,7 +6,7 @@ using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 
 namespace Appium.Integration.Tests.PageObjectTests.Android

--- a/integration_tests/PageObjectTests/Android/AndroidTestThatChecksAttributeMix2.cs
+++ b/integration_tests/PageObjectTests/Android/AndroidTestThatChecksAttributeMix2.cs
@@ -6,7 +6,7 @@ using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 
 namespace Appium.Integration.Tests.PageObjectTests.Android

--- a/integration_tests/PageObjectTests/Android/AndroidTestThatChecksAttributeMix3SelendroidMode.cs
+++ b/integration_tests/PageObjectTests/Android/AndroidTestThatChecksAttributeMix3SelendroidMode.cs
@@ -6,7 +6,7 @@ using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 
 namespace Appium.Integration.Tests.PageObjectTests.Android

--- a/integration_tests/PageObjectTests/Android/AndroidWebViewTest.cs
+++ b/integration_tests/PageObjectTests/Android/AndroidWebViewTest.cs
@@ -6,7 +6,7 @@ using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 using System.Threading;
 

--- a/integration_tests/PageObjectTests/Android/SeleniumAttributesCompatipilityTest.cs
+++ b/integration_tests/PageObjectTests/Android/SeleniumAttributesCompatipilityTest.cs
@@ -5,7 +5,7 @@ using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 
 namespace Appium.Integration.Tests.PageObjectTests.Android

--- a/integration_tests/PageObjectTests/DesktopBrowserCompatibility/DesctopBrowserCompatibilityTest.cs
+++ b/integration_tests/PageObjectTests/DesktopBrowserCompatibility/DesctopBrowserCompatibilityTest.cs
@@ -5,7 +5,7 @@ using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
 using OpenQA.Selenium.Firefox;
 using OpenQA.Selenium.Internal;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 using System.Collections.Generic;
 

--- a/integration_tests/PageObjectTests/IOS/IOSNativeAppAttributesTest.cs
+++ b/integration_tests/PageObjectTests/IOS/IOSNativeAppAttributesTest.cs
@@ -5,7 +5,7 @@ using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.iOS;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 
 namespace Appium.Integration.Tests.PageObjectTests.IOS

--- a/integration_tests/PageObjectTests/IOS/IOSTestThatChecksAttributeMix.cs
+++ b/integration_tests/PageObjectTests/IOS/IOSTestThatChecksAttributeMix.cs
@@ -6,7 +6,7 @@ using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.iOS;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 
 namespace Appium.Integration.Tests.PageObjectTests.IOS

--- a/integration_tests/PageObjectTests/NegativeTests/NoSuchElementTestOnAndroid.cs
+++ b/integration_tests/PageObjectTests/NegativeTests/NoSuchElementTestOnAndroid.cs
@@ -6,7 +6,7 @@ using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 using System.Collections.Generic;
 

--- a/integration_tests/PageObjectTests/Other/AndroidTouchActionTest.cs
+++ b/integration_tests/PageObjectTests/Other/AndroidTouchActionTest.cs
@@ -5,7 +5,7 @@ using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Remote;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 
 namespace Appium.Integration.Tests.PageObjectTests.Other

--- a/integration_tests/PageObjectTests/TimeOutManagement/TimeOutManagementTest.cs
+++ b/integration_tests/PageObjectTests/TimeOutManagement/TimeOutManagementTest.cs
@@ -4,7 +4,7 @@ using OpenQA.Selenium;
 using OpenQA.Selenium.Appium.PageObjects;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
 using OpenQA.Selenium.Firefox;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 using System.Collections.Generic;
 

--- a/integration_tests/PageObjects/AndroidJavaScriptTestPageObject.cs
+++ b/integration_tests/PageObjects/AndroidJavaScriptTestPageObject.cs
@@ -1,6 +1,6 @@
 ﻿using OpenQA.Selenium;
 using OpenQA.Selenium.Appium.PageObjects;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System;
 using System.Threading;
 

--- a/integration_tests/PageObjects/AndroidPageObjectChecksAttributeMixOnNativeApp1.cs
+++ b/integration_tests/PageObjects/AndroidPageObjectChecksAttributeMixOnNativeApp1.cs
@@ -1,7 +1,7 @@
 ﻿using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System.Collections.Generic;
 
 namespace Appium.Integration.Tests.PageObjects

--- a/integration_tests/PageObjects/AndroidPageObjectChecksAttributeMixOnNativeApp2.cs
+++ b/integration_tests/PageObjects/AndroidPageObjectChecksAttributeMixOnNativeApp2.cs
@@ -1,7 +1,7 @@
 ﻿using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System.Collections.Generic;
 
 namespace Appium.Integration.Tests.PageObjects

--- a/integration_tests/PageObjects/AndroidPageObjectChecksSeleniumFindsByCompatibility.cs
+++ b/integration_tests/PageObjects/AndroidPageObjectChecksSeleniumFindsByCompatibility.cs
@@ -1,7 +1,7 @@
 ﻿using OpenQA.Selenium;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.Interfaces;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System.Collections.Generic;
 
 namespace Appium.Integration.Tests.PageObjects

--- a/integration_tests/PageObjects/AndroidWebView.cs
+++ b/integration_tests/PageObjects/AndroidWebView.cs
@@ -1,6 +1,6 @@
 ﻿using OpenQA.Selenium;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using OpenQA.Selenium.Support.UI;
 using System;
 

--- a/integration_tests/PageObjects/IOSPageObjectChecksAttributeMixOnNativeApp.cs
+++ b/integration_tests/PageObjects/IOSPageObjectChecksAttributeMixOnNativeApp.cs
@@ -1,7 +1,7 @@
 ﻿using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.iOS;
 using OpenQA.Selenium.Appium.PageObjects.Attributes;
-using OpenQA.Selenium.Support.PageObjects;
+using SeleniumExtras.PageObjects;
 using System.Collections.Generic;
 
 namespace Appium.Integration.Tests.PageObjects

--- a/integration_tests/integration_tests.csproj
+++ b/integration_tests/integration_tests.csproj
@@ -38,14 +38,17 @@
     <Reference Include="nunit.framework">
       <HintPath>$(SolutionDir)\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="SeleniumExtras.PageObjects, Version=3.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetSeleniumExtras.PageObjects.3.11.0\lib\net45\SeleniumExtras.PageObjects.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="WebDriver, Version=3.8.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Selenium.WebDriver.3.8.0\lib\net45\WebDriver.dll</HintPath>
+    <Reference Include="WebDriver, Version=3.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.WebDriver.3.11.0\lib\net45\WebDriver.dll</HintPath>
     </Reference>
-    <Reference Include="WebDriver.Support, Version=3.8.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\Selenium.Support.3.8.0\lib\net45\WebDriver.Support.dll</HintPath>
+    <Reference Include="WebDriver.Support, Version=3.11.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Selenium.Support.3.11.0\lib\net45\WebDriver.Support.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -150,5 +153,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
 </Project>

--- a/integration_tests/packages.config
+++ b/integration_tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="DotNetSeleniumExtras.PageObjects" version="3.11.0" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Selenium.Support" version="3.8.0" targetFramework="net45" />
-  <package id="Selenium.WebDriver" version="3.8.0" targetFramework="net45" />
+  <package id="Selenium.Support" version="3.11.0" targetFramework="net45" />
+  <package id="Selenium.WebDriver" version="3.11.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
## Change list

The upstream Selenium project has marked the `PageFactory` and its
supporting classes deprecated. The code for these classes has been moved
to a [new repository](https://github.com/DotNetSeleniumTools/DotNetSeleniumExtras).
This commit updates the NuGet dependencies for these projects and updates
the namespaces in the source code to refer to the proper objects.
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

If this PR is not merged, compilation of this code will fail when the implementation of `PageFactory` and its supporting classes has been removed from the Selenium project.