### PR TITLE
Get rid of converting selector to css, stop sending JS commands to get attributes

### DIFF
--- a/appium-dotnet-driver/Appium/AppiumWebElement.cs
+++ b/appium-dotnet-driver/Appium/AppiumWebElement.cs
@@ -240,7 +240,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="className">CSS class name on the element</param>
         /// <returns>first element found</returns
         public new AppiumWebElement FindElementByClassName(string className) =>
-            (AppiumWebElement) base.FindElement("class name", className);
+            (AppiumWebElement) base.FindElement(MobileSelector.ClassName, className);
 
         /// <summary>
         /// Finds a list of elements that match the class name supplied
@@ -248,7 +248,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="className">CSS class name on the element</param>
         /// <returns>ReadOnlyCollection of elements found</returns
         public new ReadOnlyCollection<AppiumWebElement> FindElementsByClassName(string className) =>
-            ConvertToExtendedWebElementCollection(base.FindElements("class name", className));
+            ConvertToExtendedWebElementCollection(base.FindElements(MobileSelector.ClassName, className));
 
         /// <summary>
         /// Finds the first element in the page that matches the ID supplied
@@ -256,7 +256,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="id">ID of the element</param>
         /// <returns>First element found</returns>
         public new AppiumWebElement FindElementById(string id) =>
-             (AppiumWebElement) base.FindElement("id", id);
+            (AppiumWebElement) base.FindElement(MobileSelector.Id, id);
 
         /// <summary>
         /// Finds a list of elements that match the ID supplied
@@ -264,7 +264,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="id">ID of the element</param>
         /// <returns>ReadOnlyCollection of elements found</returns>
         public new ReadOnlyCollection<AppiumWebElement> FindElementsById(string id) =>
-            ConvertToExtendedWebElementCollection(base.FindElements("id", id));
+            ConvertToExtendedWebElementCollection(base.FindElements(MobileSelector.Id, id));
 
         /// <summary>
         /// Finds the first element matching the specified CSS selector
@@ -304,7 +304,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="name">Name of the element on the page</param>
         /// <returns>First element found</returns>
         public new AppiumWebElement FindElementByName(string name) =>
-            (AppiumWebElement) base.FindElement("name", name);
+            (AppiumWebElement) base.FindElement(MobileSelector.Name, name);
 
         /// <summary>
         /// Finds a list of elements that match the name supplied
@@ -312,7 +312,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="name">Name of the element on the page</param>
         /// <returns>ReadOnlyCollection of elements found</returns>
         public new ReadOnlyCollection<AppiumWebElement> FindElementsByName(string name) =>
-            ConvertToExtendedWebElementCollection(base.FindElements("name", name));
+            ConvertToExtendedWebElementCollection(base.FindElements(MobileSelector.Name, name));
 
         /// <summary>
         /// Finds the first of elements that match the part of the link text supplied
@@ -336,7 +336,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="tagName">DOM tag name of the element being searched</param>
         /// <returns>First element found</returns>
         public new AppiumWebElement FindElementByTagName(string tagName) =>
-            (AppiumWebElement) base.FindElement("tag name", tagName);
+            (AppiumWebElement) base.FindElement(MobileSelector.TagName, tagName);
 
         /// <summary>
         /// Finds a list of elements that match the DOM Tag supplied
@@ -344,7 +344,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="tagName">DOM tag name of the element being searched</param>
         /// <returns>ReadOnlyCollection of elements found</returns>
         public new ReadOnlyCollection<AppiumWebElement> FindElementsByTagName(string tagName) =>
-            ConvertToExtendedWebElementCollection(FindElements("tag name", tagName));
+            ConvertToExtendedWebElementCollection(FindElements(MobileSelector.TagName, tagName));
 
         /// <summary>
         /// Finds the first of elements that match the XPath supplied

--- a/appium-dotnet-driver/Appium/AppiumWebElement.cs
+++ b/appium-dotnet-driver/Appium/AppiumWebElement.cs
@@ -123,8 +123,34 @@ namespace OpenQA.Selenium.Appium
 
         public override string GetAttribute(string attributeName) => CacheValue(
                 "attribute/" + attributeName,
-                () => base.GetAttribute(attributeName)
+                () => _GetAttribute(attributeName)
             )?.ToString();
+
+        private string _GetAttribute(string attributeName)
+        {
+            Response commandResponse = null;
+            string attributeValue = string.Empty;
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+
+            parameters.Add("id", Id);
+            parameters.Add("name", attributeName);
+            commandResponse = Execute(DriverCommand.GetElementAttribute, parameters);
+
+            if (commandResponse.Value == null)
+            {
+                return null;
+            }
+
+            attributeValue = commandResponse.Value.ToString();
+
+            // Normalize string values of boolean results as lowercase.
+            if (commandResponse.Value is bool)
+            {
+                attributeValue = attributeValue.ToLowerInvariant();
+            }
+
+            return attributeValue;
+        }
 
         public override string GetCssValue(string propertyName) => CacheValue(
                 "css/" + propertyName,

--- a/appium-dotnet-driver/Appium/AppiumWebElement.cs
+++ b/appium-dotnet-driver/Appium/AppiumWebElement.cs
@@ -240,7 +240,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="className">CSS class name on the element</param>
         /// <returns>first element found</returns
         public new AppiumWebElement FindElementByClassName(string className) =>
-            (AppiumWebElement) base.FindElementByClassName(className);
+            (AppiumWebElement) base.FindElement("class name", className);
 
         /// <summary>
         /// Finds a list of elements that match the class name supplied
@@ -248,7 +248,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="className">CSS class name on the element</param>
         /// <returns>ReadOnlyCollection of elements found</returns
         public new ReadOnlyCollection<AppiumWebElement> FindElementsByClassName(string className) =>
-            ConvertToExtendedWebElementCollection(base.FindElementsByClassName(className));
+            ConvertToExtendedWebElementCollection(base.FindElements("class name", className));
 
         /// <summary>
         /// Finds the first element in the page that matches the ID supplied
@@ -256,7 +256,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="id">ID of the element</param>
         /// <returns>First element found</returns>
         public new AppiumWebElement FindElementById(string id) =>
-            (AppiumWebElement) base.FindElementById(id);
+             (AppiumWebElement) base.FindElement("id", id);
 
         /// <summary>
         /// Finds a list of elements that match the ID supplied
@@ -264,7 +264,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="id">ID of the element</param>
         /// <returns>ReadOnlyCollection of elements found</returns>
         public new ReadOnlyCollection<AppiumWebElement> FindElementsById(string id) =>
-            ConvertToExtendedWebElementCollection(base.FindElementsById(id));
+            ConvertToExtendedWebElementCollection(base.FindElements("id", id));
 
         /// <summary>
         /// Finds the first element matching the specified CSS selector
@@ -304,7 +304,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="name">Name of the element on the page</param>
         /// <returns>First element found</returns>
         public new AppiumWebElement FindElementByName(string name) =>
-            (AppiumWebElement) base.FindElementByName(name);
+            (AppiumWebElement) base.FindElement("name", name);
 
         /// <summary>
         /// Finds a list of elements that match the name supplied
@@ -312,7 +312,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="name">Name of the element on the page</param>
         /// <returns>ReadOnlyCollection of elements found</returns>
         public new ReadOnlyCollection<AppiumWebElement> FindElementsByName(string name) =>
-            ConvertToExtendedWebElementCollection(base.FindElementsByName(name));
+            ConvertToExtendedWebElementCollection(base.FindElements("name", name));
 
         /// <summary>
         /// Finds the first of elements that match the part of the link text supplied
@@ -336,7 +336,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="tagName">DOM tag name of the element being searched</param>
         /// <returns>First element found</returns>
         public new AppiumWebElement FindElementByTagName(string tagName) =>
-            (AppiumWebElement) base.FindElementByTagName(tagName);
+            (AppiumWebElement) base.FindElement("tag name", tagName);
 
         /// <summary>
         /// Finds a list of elements that match the DOM Tag supplied
@@ -344,7 +344,7 @@ namespace OpenQA.Selenium.Appium
         /// <param name="tagName">DOM tag name of the element being searched</param>
         /// <returns>ReadOnlyCollection of elements found</returns>
         public new ReadOnlyCollection<AppiumWebElement> FindElementsByTagName(string tagName) =>
-            ConvertToExtendedWebElementCollection(base.FindElementsByTagName(tagName));
+            ConvertToExtendedWebElementCollection(FindElements("tag name", tagName));
 
         /// <summary>
         /// Finds the first of elements that match the XPath supplied

--- a/appium-dotnet-driver/Appium/Enums/MobileSelector.cs
+++ b/appium-dotnet-driver/Appium/Enums/MobileSelector.cs
@@ -16,6 +16,13 @@ namespace OpenQA.Selenium.Appium.Enums
 {
     public class MobileSelector
     {
+
+        public static readonly string Id = "id";
+        public static readonly string ClassName = "class name";
+        public static readonly string Name = "name";
+        public static readonly string TagName = "tag name";
+
+
         public static readonly string Accessibility = "accessibility id";
         public static readonly string AndroidUIAutomator = "-android uiautomator";
         public static readonly string iOSAutomatoion = "-ios uiautomation";

--- a/appium-dotnet-driver/Appium/Enums/MobileSelector.cs
+++ b/appium-dotnet-driver/Appium/Enums/MobileSelector.cs
@@ -21,8 +21,6 @@ namespace OpenQA.Selenium.Appium.Enums
         public static readonly string ClassName = "class name";
         public static readonly string Name = "name";
         public static readonly string TagName = "tag name";
-
-
         public static readonly string Accessibility = "accessibility id";
         public static readonly string AndroidUIAutomator = "-android uiautomator";
         public static readonly string iOSAutomatoion = "-ios uiautomation";


### PR DESCRIPTION
## Change list

- Some methods which haven't defined by W3C spec convert selector from them to `css selector`
    - In this PR, I've changed to use id, name, class name and tag name directly.
- `GetAttribute` calls JS-command instead of calling `DriverCommand.GetElementAttribute` in W3C spec. In this PR, I've changed to call the command directly.

- related selenium client code: https://github.com/SeleniumHQ/selenium/blob/25d2e542d39768816a83931a4f43e4a006c9e78d/dotnet/src/webdriver/Remote/RemoteWebElement.cs
 
closes https://github.com/appium/appium-dotnet-driver/issues/266 and https://github.com/appium/appium-dotnet-driver/issues/265

## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 