### PR TITLE
Overwrite w3c related FIndBy methods to adapt to mobile driver

### DIFF
--- a/appium-dotnet-driver/Appium/AppiumDriver.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriver.cs
@@ -93,8 +93,6 @@ namespace OpenQA.Selenium.Appium
 
         public new W FindElement(By by) =>
             (W) base.FindElement(by);
-
-
         public new ReadOnlyCollection<W> FindElements(By by) =>
             ConvertToExtendedWebElementCollection<W>(base.FindElements(by));
 
@@ -104,16 +102,16 @@ namespace OpenQA.Selenium.Appium
             ConvertToExtendedWebElementCollection<W>(base.FindElements(selector, value));
 
         public new W FindElementByClassName(string className) =>
-            (W) base.FindElementByClassName(className);
+            (W) base.FindElement(MobileSelector.ClassName, className);
 
         public new ReadOnlyCollection<W> FindElementsByClassName(string className) =>
-            ConvertToExtendedWebElementCollection<W>(base.FindElementsByClassName(className));
+            ConvertToExtendedWebElementCollection<W>(base.FindElements(MobileSelector.ClassName, className));
 
         public new W FindElementById(string id) =>
-            (W) base.FindElementById(id);
+            (W) base.FindElement(MobileSelector.Id, id);
 
         public new ReadOnlyCollection<W> FindElementsById(string id) =>
-            ConvertToExtendedWebElementCollection<W>(base.FindElementsById(id));
+            ConvertToExtendedWebElementCollection<W>(base.FindElements(MobileSelector.Id, id));
 
         public new W FindElementByCssSelector(string cssSelector) =>
             (W) base.FindElementByCssSelector(cssSelector);
@@ -128,7 +126,7 @@ namespace OpenQA.Selenium.Appium
             ConvertToExtendedWebElementCollection<W>(base.FindElementsByLinkText(linkText));
 
         public new W FindElementByName(string name) =>
-            (W) base.FindElementByName(name);
+            (W) base.FindElement(MobileSelector.Name, name);
 
         public new ReadOnlyCollection<W> FindElementsByName(string name) =>
             ConvertToExtendedWebElementCollection<W>(base.FindElementsByName(name));
@@ -140,10 +138,10 @@ namespace OpenQA.Selenium.Appium
             ConvertToExtendedWebElementCollection<W>(base.FindElementsByPartialLinkText(partialLinkText));
 
         public new W FindElementByTagName(string tagName) =>
-            (W) base.FindElementByTagName(tagName);
+            (W) base.FindElement(MobileSelector.TagName, tagName);
 
         public new ReadOnlyCollection<W> FindElementsByTagName(string tagName) =>
-            ConvertToExtendedWebElementCollection<W>(base.FindElementsByTagName(tagName));
+            ConvertToExtendedWebElementCollection<W>(base.FindElements(MobileSelector.TagName, tagName));
 
         public new W FindElementByXPath(string xpath) =>
             (W) base.FindElementByXPath(xpath);

--- a/appium-dotnet-driver/Appium/AppiumDriver.cs
+++ b/appium-dotnet-driver/Appium/AppiumDriver.cs
@@ -129,7 +129,7 @@ namespace OpenQA.Selenium.Appium
             (W) base.FindElement(MobileSelector.Name, name);
 
         public new ReadOnlyCollection<W> FindElementsByName(string name) =>
-            ConvertToExtendedWebElementCollection<W>(base.FindElementsByName(name));
+            ConvertToExtendedWebElementCollection<W>(base.FindElements(MobileSelector.Name, name));
 
         public new W FindElementByPartialLinkText(string partialLinkText) =>
             (W) base.FindElementByPartialLinkText(partialLinkText);


### PR DESCRIPTION
## Change list

AppiumDriver.cs

## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details

Allow users to call the W3C related FindBy methods on mobile:
Class
TagName
Name
Id

Completes #268