### PR TITLE
BackgroundApp update

### DIFF
--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -23,6 +23,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Runtime.ConstrainedExecution;
 using Castle.Core.Internal;
 using OpenQA.Selenium.Appium.ScreenRecording;
 
@@ -192,22 +193,22 @@ namespace OpenQA.Selenium.Appium
         }
 
         public void InstallApp(string appPath) =>
-            Execute(AppiumDriverCommand.InstallApp, new Dictionary<string, object>() {["appPath"] = appPath});
+            Execute(AppiumDriverCommand.InstallApp, PrepareArgument("appPath", appPath));
 
         public void RemoveApp(string appId) =>
-            Execute(AppiumDriverCommand.RemoveApp, new Dictionary<string, object>() {["appId"] = appId});
+            Execute(AppiumDriverCommand.RemoveApp, PrepareArgument("appId", appId));
 
         public bool IsAppInstalled(string bundleId) =>
             Convert.ToBoolean(Execute(AppiumDriverCommand.IsAppInstalled,
-                new Dictionary<string, object>() {["bundleId"] = bundleId}).Value.ToString());
+                PrepareArgument("bundleId", bundleId)).Value.ToString());
 
         public byte[] PullFile(string pathOnDevice) =>
             Convert.FromBase64String(Execute(AppiumDriverCommand.PullFile,
-                new Dictionary<string, object>() {["path"] = pathOnDevice}).Value.ToString());
+                PrepareArgument("path", pathOnDevice)).Value.ToString());
 
         public byte[] PullFolder(string remotePath) =>
             Convert.FromBase64String(Execute(AppiumDriverCommand.PullFolder,
-                new Dictionary<string, object>() {["path"] = remotePath}).Value.ToString());
+                PrepareArgument("path", remotePath)).Value.ToString());
 
         public void LaunchApp() => ((IExecuteMethod) this).Execute(AppiumDriverCommand.LaunchApp);
 
@@ -215,9 +216,9 @@ namespace OpenQA.Selenium.Appium
 
         public void ResetApp() => ((IExecuteMethod) this).Execute(AppiumDriverCommand.ResetApp);
 
-        public void BackgroundApp(int seconds) =>
-            Execute(AppiumDriverCommand.BackgroundApp,
-                new Dictionary<string, object>() {["seconds"] = seconds});
+        public void BackgroundApp(int? seconds) =>
+            Execute(AppiumDriverCommand.BackgroundApp, 
+                PrepareArgument("seconds", PrepareArgument("timeout", seconds)));
 
         /// <summary>
         /// Get all defined Strings from an app for the specified language and
@@ -276,8 +277,7 @@ namespace OpenQA.Selenium.Appium
             }
             set
             {
-                var parameters = new Dictionary<string, object>();
-                parameters.Add("name", value);
+                var parameters = PrepareArgument("name", value);
                 Execute(AppiumDriverCommand.SetContext, parameters);
             }
         }
@@ -312,8 +312,7 @@ namespace OpenQA.Selenium.Appium
             }
             set
             {
-                var parameters = new Dictionary<string, object>();
-                parameters.Add("orientation", value.JSONWireProtocolString());
+                var parameters = PrepareArgument("orientation", value.JSONWireProtocolString());
                 Execute(AppiumDriverCommand.SetOrientation, parameters);
             }
         }
@@ -357,7 +356,7 @@ namespace OpenQA.Selenium.Appium
         /// </summary>
         /// <param name="imeEngine">IME to activate</param>
         public void ActivateIMEEngine(string imeEngine) =>
-            Execute(AppiumDriverCommand.ActivateEngine, new Dictionary<string, object>() {["engine"] = imeEngine});
+            Execute(AppiumDriverCommand.ActivateEngine, PrepareArgument("engine", imeEngine));
 
         /// <summary>
         /// Deactivate the currently Active IME Engine on device
@@ -379,8 +378,7 @@ namespace OpenQA.Selenium.Appium
         public void PerformTouchAction(ITouchAction touchAction)
         {
             if (touchAction == null) return;
-            var parameters = new Dictionary<string, object>();
-            parameters.Add("actions", touchAction.GetParameters());
+            var parameters = PrepareArgument("actions", touchAction.GetParameters());
             Execute(AppiumDriverCommand.PerformTouchAction, parameters);
         }
 
@@ -437,7 +435,7 @@ namespace OpenQA.Selenium.Appium
 
         public string StartRecordingScreen(IScreenRecordingOptions options)
         {
-            var parameters = new Dictionary<string, object> {{"options", options.GetParameters()} };
+            var parameters = PrepareArgument("options", options.GetParameters());
             return Execute(AppiumDriverCommand.StartRecordingScreen, parameters).Value.ToString();
         }
 
@@ -445,7 +443,7 @@ namespace OpenQA.Selenium.Appium
 
         public string StopRecordingScreen(IScreenRecordingOptions options)
         {
-            var parameters = new Dictionary<string, object> { { "options", options.GetParameters() } };
+            var parameters = PrepareArgument("options", options.GetParameters());
             return Execute(AppiumDriverCommand.StopRecordingScreen, parameters).Value.ToString();
         }
 
@@ -471,6 +469,11 @@ namespace OpenQA.Selenium.Appium
                 result.Add((T) element);
             }
             return result.AsReadOnly();
+        }
+
+        protected static Dictionary<string, object> PrepareArgument(string param, object value)
+        {
+            return new Dictionary<string, object> { { param, value } };
         }
 
         #endregion

--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -23,9 +23,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Runtime.ConstrainedExecution;
-using Castle.Core.Internal;
-using OpenQA.Selenium.Appium.ScreenRecording;
 
 namespace OpenQA.Selenium.Appium
 {

--- a/src/Appium.Net/Appium/Interfaces/IInteractsWithApps.cs
+++ b/src/Appium.Net/Appium/Interfaces/IInteractsWithApps.cs
@@ -40,10 +40,10 @@ namespace OpenQA.Selenium.Appium.Interfaces
         void ResetApp();
 
         /// <summary>
-        /// Backgrounds the current app for the given number of seconds.
+        /// Backgrounds the current app for the given number of seconds or deactivates app completely if negative number or null is given. 
         /// </summary>
-        /// <param name="seconds">a string containing the number of seconds.</param>
-        void BackgroundApp(int seconds);
+        /// <param name="seconds">a integer number containing the number of seconds or null.</param>
+        void BackgroundApp(int? seconds);
 
 
         /// <summary>


### PR DESCRIPTION
## Change list
Update of BackgroundApp method
New helper method PrepareArgument introduced
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Integration tests
- [ ] Have you provided integration tests to pass against the latest version of appium? (for Bugfix or New feature)

## Details
Update of BackgroundApp method due to change in Appium, which introduced new way of handling parameters passed to BackgroundApp method and marked old approach as deprecated (see [documentation](https://appium.readthedocs.io/en/latest/en/commands/device/app/background-app/ "Background app")). 
Current Appium requires object containing {["timeout"]: seconds} to be passed as value of "seconds" argument. Passed value can be null/negative number to deactivate app or positive integer designating how long, in seconds, to background app for. 
To achieve it with more readability new method PrepareArgument (parallel to method used in Java client) was introduced for preparing JSON objects. Existing methods was adjusted to use it as well. 

Updated BackgroundApp method allows to:
- put app into the background for n seconds by:
`driver.BackgroundApp(n) `
- deactivate app (aka Home button) by:
`driver.BackgroundApp(-1)`
or 
`driver.BackgroundApp(null)`

Newly introduced helper method PrepareArguments allows to:
- prepare simple JSON objects:
  `PrepareArgument("appPath", pathToApp) ` 
is equivalent for: 
`  "appPath": pathToApp`
 - build complex JSON objects by recursive calls:
`PrepareArgument("seconds", PrepareArgument("timeout", seconds))`
is equivalent for : 
```
  "seconds": {
     "timeout": seconds
   }
```
