### PR TITLE
Enable pushing files for both android and iOS

### DIFF
--- a/src/Appium.Net/Appium/Android/AndroidCommandExecutionHelper.cs
+++ b/src/Appium.Net/Appium/Android/AndroidCommandExecutionHelper.cs
@@ -13,10 +13,8 @@
 //limitations under the License.
 
 using OpenQA.Selenium.Appium.Interfaces;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using System.IO;
 
 namespace OpenQA.Selenium.Appium.Android
 {
@@ -103,27 +101,6 @@ namespace OpenQA.Selenium.Appium.Android
             executeMethod.Execute(AppiumDriverCommand.EndTestCoverage,
                 new Dictionary<string, object>()
                     {["intent"] = intent, ["path"] = path}).Value as string;
-
-        public static void PushFile(IExecuteMethod executeMethod, string pathOnDevice, byte[] base64Data) =>
-            executeMethod.Execute(AppiumDriverCommand.PushFile, new Dictionary<string, object>()
-                {["path"] = pathOnDevice, ["data"] = base64Data});
-
-        public static void PushFile(IExecuteMethod executeMethod, string pathOnDevice, FileInfo file)
-        {
-            if (file == null)
-            {
-                throw new ArgumentException("The file argument should not be null");
-            }
-
-            if (!file.Exists)
-            {
-                throw new ArgumentException("The file " + file.FullName + " doesn't exist");
-            }
-
-            byte[] bytes = File.ReadAllBytes(file.FullName);
-            string fileBase64Data = Convert.ToBase64String(bytes);
-            PushFile(executeMethod, pathOnDevice, Convert.FromBase64String(fileBase64Data));
-        }
 
         public static void OpenNotifications(IExecuteMethod executeMethod) =>
             executeMethod.Execute(AppiumDriverCommand.OpenNotifications);

--- a/src/Appium.Net/Appium/Android/AndroidDriver.cs
+++ b/src/Appium.Net/Appium/Android/AndroidDriver.cs
@@ -19,8 +19,6 @@ using OpenQA.Selenium.Appium.Service;
 using OpenQA.Selenium.Remote;
 using System;
 using System.Collections.ObjectModel;
-using System.Text;
-using System.IO;
 using System.Collections.Generic;
 using System.Drawing;
 using OpenQA.Selenium.Appium.Android.Enums;
@@ -185,15 +183,6 @@ namespace OpenQA.Selenium.Appium.Android
         /// <return>a base64 string containing the data</return> 
         public string EndTestCoverage(string intent, string path) =>
             AndroidCommandExecutionHelper.EndTestCoverage(this, intent, path);
-
-        public void PushFile(string pathOnDevice, string stringData) => AndroidCommandExecutionHelper.PushFile(this,
-            pathOnDevice, Convert.FromBase64String(Convert.ToBase64String(Encoding.UTF8.GetBytes(stringData))));
-
-        public void PushFile(string pathOnDevice, byte[] base64Data) =>
-            AndroidCommandExecutionHelper.PushFile(this, pathOnDevice, base64Data);
-
-        public void PushFile(string pathOnDevice, FileInfo file) =>
-            AndroidCommandExecutionHelper.PushFile(this, pathOnDevice, file);
 
         /// <summary>
         /// Open the notifications 

--- a/src/Appium.Net/Appium/AppiumCommandExecutionHelper.cs
+++ b/src/Appium.Net/Appium/AppiumCommandExecutionHelper.cs
@@ -15,6 +15,7 @@
 using System;
 using OpenQA.Selenium.Appium.Interfaces;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.Enums;
@@ -120,6 +121,27 @@ namespace OpenQA.Selenium.Appium
         {
             var encodedContentBytes = Convert.FromBase64String(GetClipboard(executeMethod, ClipboardContentType.PlainText));
             return Encoding.UTF8.GetString(encodedContentBytes);
+        }
+
+        public static void PushFile(IExecuteMethod executeMethod, string pathOnDevice, byte[] base64Data) =>
+            executeMethod.Execute(AppiumDriverCommand.PushFile, new Dictionary<string, object>()
+                { ["path"] = pathOnDevice, ["data"] = base64Data });
+
+        public static void PushFile(IExecuteMethod executeMethod, string pathOnDevice, FileInfo file)
+        {
+            if (file == null)
+            {
+                throw new ArgumentException("The file argument should not be null");
+            }
+
+            if (!file.Exists)
+            {
+                throw new ArgumentException("The file " + file.FullName + " doesn't exist");
+            }
+
+            byte[] bytes = File.ReadAllBytes(file.FullName);
+            string fileBase64Data = Convert.ToBase64String(bytes);
+            PushFile(executeMethod, pathOnDevice, Convert.FromBase64String(fileBase64Data));
         }
 
         #endregion Device Commands

--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -22,7 +22,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace OpenQA.Selenium.Appium
 {
@@ -206,6 +208,15 @@ namespace OpenQA.Selenium.Appium
         public byte[] PullFolder(string remotePath) =>
             Convert.FromBase64String(Execute(AppiumDriverCommand.PullFolder,
                 AppiumCommandExecutionHelper.PrepareArgument("path", remotePath)).Value.ToString());
+
+        public void PushFile(string pathOnDevice, string stringData) => AppiumCommandExecutionHelper.PushFile(this,
+            pathOnDevice, Convert.FromBase64String(Convert.ToBase64String(Encoding.UTF8.GetBytes(stringData))));
+
+        public void PushFile(string pathOnDevice, byte[] base64Data) =>
+            AppiumCommandExecutionHelper.PushFile(this, pathOnDevice, base64Data);
+
+        public void PushFile(string pathOnDevice, FileInfo file) =>
+            AppiumCommandExecutionHelper.PushFile(this, pathOnDevice, file);
 
         public void LaunchApp() => ((IExecuteMethod) this).Execute(AppiumDriverCommand.LaunchApp);
 


### PR DESCRIPTION
## Change list

Deleted android specific part of code about pushing file and moved it back to appium driver (same logic for iOS).
 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Integration tests
- [ ] Have you provided integration tests to pass against the latest version of appium? (for Bugfix or New feature)

