### PR TITLE
Fixes "css selector" issue when using id, name, class name and tag name strategies with Page Objects

### DIFF
--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 using OpenQA.Selenium.Appium.Enums;
 using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.Service;
+using OpenQA.Selenium.Internal;
 using OpenQA.Selenium.Remote;
 using System;
 using System.Collections;
@@ -26,7 +27,7 @@ using System.Linq;
 
 namespace OpenQA.Selenium.Appium
 {
-    public abstract class AppiumDriver<W> : RemoteWebDriver, IExecuteMethod, IFindsByFluentSelector<W>,
+    public abstract class AppiumDriver<W> : RemoteWebDriver, IFindsById, IFindsByClassName, IFindsByName, IFindsByTagName, IExecuteMethod, IFindsByFluentSelector<W>,
         IHasSessionDetails,
         IFindByAccessibilityId<W>,
         IHidesKeyboard, IInteractsWithFiles,
@@ -88,6 +89,34 @@ namespace OpenQA.Selenium.Appium
         }
 
         #endregion Constructors
+
+        #region Overrides to fix "css selector" issue
+
+        IWebElement IFindsByClassName.FindElementByClassName(string className) =>
+            base.FindElement(MobileSelector.ClassName, className);
+
+        ReadOnlyCollection<IWebElement> IFindsByClassName.FindElementsByClassName(string className) =>
+            base.FindElements(MobileSelector.ClassName, className);
+
+        IWebElement IFindsById.FindElementById(string id) => 
+            base.FindElement(MobileSelector.Id, id);
+
+        ReadOnlyCollection<IWebElement> IFindsById.FindElementsById(string id) =>
+            base.FindElements(MobileSelector.Id, id);
+
+        IWebElement IFindsByName.FindElementByName(string name) =>
+            base.FindElement(MobileSelector.Name, name);
+
+        ReadOnlyCollection<IWebElement> IFindsByName.FindElementsByName(string name) =>
+            base.FindElements(MobileSelector.Name, name);
+
+        IWebElement IFindsByTagName.FindElementByTagName(string tagName) =>
+            base.FindElement(MobileSelector.TagName, tagName);
+
+        ReadOnlyCollection<IWebElement> IFindsByTagName.FindElementsByTagName(string tagName) =>
+            base.FindElements(MobileSelector.TagName, tagName);
+
+        #endregion Overrides to fix "css selector" issue
 
         #region Generic FindMethods
 


### PR DESCRIPTION
## Change list

Fixes https://github.com/appium/appium-dotnet-driver/issues/265 for Page Objects as well.
 
## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Integration tests
- [ ] Have you provided integration tests to pass against the latest version of Appium? (for Bugfix or New feature)
