### PR TITLE
Adds functionality that allows redirecting the AppiumLocalService process output to Console to allow easier debugging

### DIFF
--- a/test/integration/ServerTests/AppiumLocalServerLaunchingTest.cs
+++ b/test/integration/ServerTests/AppiumLocalServerLaunchingTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Threading;
@@ -64,6 +65,7 @@ namespace Appium.Net.Integration.Tests.ServerTests
         public void CheckAbilityToBuildDefaultService()
         {
             var service = AppiumLocalService.BuildDefaultService();
+
             try
             {
                 service.Start();
@@ -73,6 +75,27 @@ namespace Appium.Net.Integration.Tests.ServerTests
             {
                 service.Dispose();
             }
+        }
+
+        [Test]
+        public void CheckAbilityToLogServiceOutputToConsole()
+        {
+            var service = AppiumLocalService.BuildDefaultService();
+            var lines = new List<string>();
+
+            service.OutputDataReceived += (sender, e) => { lines.Add(e.Data); Console.Out.WriteLine(e.Data); };
+
+            try
+            {
+                service.Start();
+                Assert.AreEqual(true, service.IsRunning);
+            }
+            finally
+            {
+                service.Dispose();
+            }
+
+            Assert.IsNotEmpty(lines);
         }
 
         [Test]


### PR DESCRIPTION
## Change list

Added capability to redirect the Appium Local Service output similar to the way Java client does this - https://github.com/appium/java-client/blob/98daabe3943b606c5416818b73add493d889cc94/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java#L212
 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Integration tests
- [x] Have you provided integration tests to pass against the latest version of appium? (for Bugfix or New feature)

## Details

Even though the name of the branch suggests that we're redirecting the Error as well, it doesn't really make sense to do so (this was my initial intention - hence the name of the branch).

As a difference between the .NET client and the Java client, I have chosen not to redirect to `Console.Out` by default (see https://github.com/appium/java-client/blob/98daabe3943b606c5416818b73add493d889cc94/src/main/java/io/appium/java_client/service/local/AppiumDriverLocalService.java#L64) since there are issues in the way some xUnit frameworks (such as `NUnit` handle `Console.Out` see https://github.com/nunit/nunit/issues/2182#issuecomment-445453915)

Also, the output contains some "strange" characters, probably used by some other smarter consoles to color some ranges of the text:

`\u001b[35m[Appium]\u001b[39m Welcome to Appium v1.9.1`

Any recommendation on how we could sanitize this output, would be really appreciated.

Here you can also find a screenshot of out the output looks in VS 2017 - https://imgur.com/a/O8SMk52
