### PR TITLE
Adds pointer input device extension

### DIFF
--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -250,9 +250,9 @@
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="DotNetSeleniumExtras.PageObjects" Version="3.11.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="Selenium.Support" Version="3.14.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="3.14.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Selenium.Support" Version="3.141.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -4,8 +4,8 @@
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <RootNamespace>OpenQA.Selenium</RootNamespace>
-    <AssemblyVersion>4.0.0.5</AssemblyVersion>
-    <Version>4.0.0.5-beta</Version>
+    <AssemblyVersion>4.0.0.6</AssemblyVersion>
+    <Version>4.0.0.6-beta</Version>
     <Company>Appium Commiters</Company>
     <Product>Appium-Dotnet-Driver</Product>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -20,6 +20,8 @@
     <Description>Selenium Webdriver extension for Appium.</Description>
     <PackageTags>Appium Webdriver device automation</PackageTags>
     <PackageReleaseNotes>
+      4.0.0.6-beta
+      [Enhancement] Adds pointer input device extension (#315) - with help from Timotius Margo
       4.0.0.5-beta
       [Enhancement] Add screen recording mechanism (#277)
       [Enhancement] Add setting/getting clipboard mechanism (#278)
@@ -233,11 +235,12 @@
             1.0.0
             TouchAction + multiActions rewriting,
             Project structure overhaul.
-    </PackageReleaseNotes>
+</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
+    <FileVersion>4.0.0.6</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Appium.Net/Appium/AppiumCommand.cs
+++ b/src/Appium.Net/Appium/AppiumCommand.cs
@@ -111,6 +111,14 @@ namespace OpenQA.Selenium.Appium
 
             #endregion Touch Commands
 
+            // Enable W3C Actions on AppiumWebDriver
+            #region W3C Actions
+
+            new AppiumCommand(CommandInfo.PostCommand, AppiumDriverCommand.Actions,
+                "/session/{sessionId}/actions"),
+
+            #endregion W3C Actions
+
             #region JSON Wire Protocol Commands
 
             new AppiumCommand(CommandInfo.GetCommand, AppiumDriverCommand.GetOrientation,

--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -18,6 +18,7 @@ using OpenQA.Selenium.Appium.Enums;
 using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Appium.Service;
 using OpenQA.Selenium.Internal;
+using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Remote;
 using System;
 using System.Collections;
@@ -424,6 +425,30 @@ namespace OpenQA.Selenium.Appium
         }
 
         #endregion Multi Actions
+
+        #region W3C Actions
+
+        // Replace or hide the original RemoteWebElement.PerformActions base method so that it does not require
+        // AppiumDriver to be fully compliant with W3CWireProtocol specification to execute W3C actions command.
+        public new void PerformActions(IList<ActionSequence> actionSequenceList)
+        {
+            if (actionSequenceList == null)
+            {
+                throw new ArgumentNullException("actionSequenceList", "List of action sequences must not be null");
+            }
+
+            List<object> objectList = new List<object>();
+            foreach (ActionSequence sequence in actionSequenceList)
+            {
+                objectList.Add(sequence.ToDictionary());
+            }
+
+            Dictionary<string, object> parameters = new Dictionary<string, object>();
+            parameters["actions"] = objectList;
+            this.Execute(DriverCommand.Actions, parameters);
+        }
+
+        #endregion W3C Actions
 
         #region Device Time
 

--- a/src/Appium.Net/Appium/AppiumDriverCommand.cs
+++ b/src/Appium.Net/Appium/AppiumDriverCommand.cs
@@ -46,7 +46,7 @@ namespace OpenQA.Selenium.Appium
         public const string ToggleAirplaneMode = "toggleAirplaneMode";
 
         /// <summary>
-        /// Press key code 
+        /// Press key code
         /// </summary>
         public const string PressKeyCode = "pressKeyCode";
 
@@ -179,6 +179,15 @@ namespace OpenQA.Selenium.Appium
         public const string PerformMultiAction = "performMultiTouch";
 
         #endregion MultiTouchActions
+
+        #region W3C Actions
+
+        /// <summary>
+        /// Perform multi purpose W3C actions
+        /// </summary>
+        public const string Actions = "actions";
+
+        #endregion W3C Actions
 
         #region Context Commands
 

--- a/src/Appium.Net/Appium/Interactions/InteractionInfo.cs
+++ b/src/Appium.Net/Appium/Interactions/InteractionInfo.cs
@@ -1,0 +1,138 @@
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+using System.Collections.Generic;
+
+namespace OpenQA.Selenium.Appium.Interactions
+{
+    /// <summary>
+    /// Provides a method by which optional attributes can be added to an Interactions.
+    /// </summary>
+    public interface IInteractionInfo
+    {
+        /// <summary>
+        /// Returns optional values that are set to extend the default interaction values.
+        /// </summary>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}"/> representing the values that are set.</returns>
+        Dictionary<string, object> ToDictionary();
+    }
+
+    /// <summary>
+    /// Represents a collection of optional attributes for pen pointer interaction.
+    /// </summary>
+    public class PenInfo : IInteractionInfo
+    {
+        /// <summary>
+        /// The normalized pressure of the pointer input in the range of [0,1]
+        /// </summary>
+        public float? Pressure { get; set; }
+
+        /// <summary>
+        /// The clockwise rotation (in degrees, in the range of [0,359]) of a transducer (e.g. pen stylus) around its own major axis
+        /// </summary>
+        public int? Twist { get; set; }
+
+        /// <summary>
+        /// The plane angle (in degrees, in the range of [-90,90]) between the Y-Z plane and the plane containing both the transducer (e.g. pen stylus) axis and the Y axis
+        /// </summary>
+        public int? TiltX { get; set; }
+
+        /// <summary>
+        /// The plane angle (in degrees, in the range of [-90,90]) between the X-Z plane and the plane containing both the transducer (e.g. pen stylus) axis and the X axis
+        /// </summary>
+        public int? TiltY { get; set; }
+
+        /// <summary>
+        /// Returns optional values that are set to extend the default pen pointer interaction values.
+        /// </summary>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}"/> representing the values that are set.</returns>
+        public Dictionary<string, object> ToDictionary()
+        {
+            Dictionary<string, object> toReturn = new Dictionary<string, object>();
+
+            if (Pressure.HasValue)
+            {
+                toReturn["pressure"] = Pressure;
+            }
+            if (Twist.HasValue)
+            {
+                toReturn["twist"] = Twist;
+            }
+            if (TiltX.HasValue)
+            {
+                toReturn["tiltX"] = TiltX;
+            }
+            if (TiltY.HasValue)
+            {
+                toReturn["tiltY"] = TiltY;
+            }
+
+            return toReturn;
+        }
+    }
+
+    /// <summary>
+    /// Represents a collection of optional attributes for touch pointer interaction.
+    /// </summary>
+    public class TouchInfo : IInteractionInfo
+    {
+        /// <summary>
+        /// The normalized pressure of the pointer input in the range of [0,1]
+        /// </summary>
+        public float? Pressure { get; set; }
+
+        /// <summary>
+        /// The clockwise rotation (in degrees, in the range of [0,359]) of a transducer (e.g. pen stylus) around its own major axis
+        /// </summary>
+        public int? Twist { get; set; }
+
+        /// <summary>
+        /// The width (magnitude on the X axis), in pixels of the contact geometry of the pointer
+        /// </summary>
+        public double? Width { get; set; }
+
+        /// <summary>
+        /// The height (magnitude on the Y axis), in pixels of the contact geometry of the pointer
+        /// </summary>
+        public double? Height { get; set; }
+
+        /// <summary>
+        /// Returns optional values that are set to extend the default touch pointer interaction values.
+        /// </summary>
+        /// <returns>A <see cref="Dictionary{TKey, TValue}"/> representing the values that are set.</returns>
+        public Dictionary<string, object> ToDictionary()
+        {
+            Dictionary<string, object> toReturn = new Dictionary<string, object>();
+
+            if (Pressure.HasValue)
+            {
+                toReturn["pressure"] = Pressure;
+            }
+            if (Twist.HasValue)
+            {
+                toReturn["twist"] = Twist;
+            }
+            if (Width.HasValue)
+            {
+                toReturn["width"] = Width;
+            }
+            if (Height.HasValue)
+            {
+                toReturn["height"] = Height;
+            }
+
+            return toReturn;
+        }
+    }
+}

--- a/src/Appium.Net/Appium/Interactions/PointerInputDevice.cs
+++ b/src/Appium.Net/Appium/Interactions/PointerInputDevice.cs
@@ -1,0 +1,215 @@
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+using OpenQA.Selenium.Interactions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OpenQA.Selenium.Appium.Interactions
+{
+    /// <summary>
+    /// Specifies the button used during a pointer down or up action.
+    /// </summary>
+    public enum PointerButton
+    {
+        /// <summary>
+        /// Neither buttons nor touch/pen contact changed since last event
+        /// </summary>
+        None = -1,
+
+        /// <summary>
+        /// Mouse left button
+        /// </summary>
+        LeftMouse = 0,
+
+        /// <summary>
+        /// Default touch contact
+        /// </summary>
+        TouchContact = 0,
+
+        /// <summary>
+        /// The pen tip
+        /// </summary>
+        PenContact = 0,
+
+        /// <summary>
+        /// Mouse middle button
+        /// </summary>
+        MiddleMouse = 1,
+
+        /// <summary>
+        /// Mouse right button
+        /// </summary>
+        RightMouse = 2,
+
+        /// <summary>
+        /// Pen barrel button
+        /// </summary>
+        PenBarrel = 2,
+
+        /// <summary>
+        /// Mouse X1 (back) button
+        /// </summary>
+        X1Mouse = 3,
+
+        /// <summary>
+        /// Mouse X1 (forward) button
+        /// </summary>
+        X2Mouse = 4,
+
+        /// <summary>
+        /// The pen eraser button
+        /// </summary>
+        PenEraser = 5
+    }
+
+    /// <summary>
+    /// Represents a pointer input device such as pen, touch, and mouse. This class extends
+    /// OpenQA.Selenium.Interactions.PointerUInputDevice to add optional interaction values
+    /// such as pressure, rotation, tilt angle, etc.
+    /// </summary>
+    public class PointerInputDevice : Selenium.Interactions.PointerInputDevice
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PointerInputDevice"/> class.
+        /// </summary>
+        /// <param name="pointerKind">The kind of pointer represented by this input device.</param>
+        public PointerInputDevice(PointerKind pointerKind)
+            : base(pointerKind)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PointerInputDevice"/> class.
+        /// </summary>
+        /// <param name="pointerKind">The kind of pointer represented by this input device.</param>
+        /// <param name="deviceName">The unique name for this input device.</param>
+        public PointerInputDevice(PointerKind pointerKind, string deviceName)
+            : base(pointerKind, deviceName)
+        {
+        }
+
+        /// <summary>
+        /// Creates a pointer down action.
+        /// </summary>
+        /// <param name="button">The button of the pointer that should be pressed.</param>
+        /// <returns>The action representing the pointer down gesture.</returns>
+        public Interaction CreatePointerDown(PointerButton button)
+        {
+            return CreatePointerDown((MouseButton)button);
+        }
+
+        /// <summary>
+        /// Creates a pointer up action.
+        /// </summary>
+        /// <param name="button">The button of the pointer that should be released.</param>
+        /// <returns>The action representing the pointer up gesture.</returns>
+        public Interaction CreatePointerUp(PointerButton button)
+        {
+
+            return CreatePointerUp((MouseButton)button);
+        }
+
+        /// <summary>
+        /// Creates a pointer down action.
+        /// </summary>
+        /// <param name="button">The button of the pointer that should be pressed.</param>
+        /// <param name="pointerExtraAttributes">Additional pointer attributes.</param>
+        /// <returns>The action representing the pointer down gesture.</returns>
+        public Interaction CreatePointerDown(PointerButton button, IInteractionInfo pointerExtraAttributes)
+        {
+            return new ExtendedPointerInteraction(CreatePointerDown((MouseButton)button), pointerExtraAttributes);
+        }
+
+        /// <summary>
+        /// Creates a pointer up action.
+        /// </summary>
+        /// <param name="button">The button of the pointer that should be released.</param>
+        /// <param name="pointerExtraAttributes">Additional pointer attributes.</param>
+        /// <returns>The action representing the pointer up gesture.</returns>
+        public Interaction CreatePointerUp(PointerButton button, IInteractionInfo pointerExtraAttributes)
+        {
+            return new ExtendedPointerInteraction(CreatePointerUp((MouseButton)button), pointerExtraAttributes);
+        }
+
+        /// <summary>
+        /// Creates a pointer move action to a specific element.
+        /// </summary>
+        /// <param name="target">The <see cref="IWebElement"/> used as the target for the move.</param>
+        /// <param name="xOffset">The horizontal offset from the origin of the move.</param>
+        /// <param name="yOffset">The vertical offset from the origin of the move.</param>
+        /// <param name="duration">The length of time the move gesture takes to complete.</param>
+        /// <param name="pointerExtraAttributes">Additional pointer attributes.</param>
+        /// <returns>The action representing the pointer move gesture.</returns>
+        public Interaction CreatePointerMove(IWebElement target, int xOffset, int yOffset, TimeSpan duration, IInteractionInfo pointerExtraAttributes)
+        {
+            return new ExtendedPointerInteraction(CreatePointerMove(target, xOffset, yOffset, duration), pointerExtraAttributes);
+        }
+
+        /// <summary>
+        /// Creates a pointer move action to an absolute coordinate.
+        /// </summary>
+        /// <param name="origin">The origin of coordinates for the move. Values can be relative to
+        /// the view port origin, or the most recent pointer position.</param>
+        /// <param name="xOffset">The horizontal offset from the origin of the move.</param>
+        /// <param name="yOffset">The vertical offset from the origin of the move.</param>
+        /// <param name="duration">The length of time the move gesture takes to complete.</param>
+        /// <param name="pointerExtraAttributes">Additional pointer attributes.</param>
+        /// <returns>The action representing the pointer move gesture.</returns>
+        /// <exception cref="ArgumentException">Thrown when passing CoordinateOrigin.Element into origin.
+        /// Users should use the other CreatePointerMove overload to move to a specific element.</exception>
+        public Interaction CreatePointerMove(CoordinateOrigin origin, int xOffset, int yOffset, TimeSpan duration, IInteractionInfo pointerExtraAttributes)
+        {
+            return new ExtendedPointerInteraction(CreatePointerMove(origin, xOffset, yOffset, duration), pointerExtraAttributes);
+        }
+
+        // This class appended the original Interaction defined in OpenQA.Selenium.Interaction with additional
+        // extra attributes of the pointer interaction. This can be removed when the standard interaction objects
+        // in OpenQA.Selenium.Interaction namespace are enhanced to support these additional attributes.
+        private class ExtendedPointerInteraction : Interaction
+        {
+            private Interaction wrappedInteraction;
+            private Dictionary<string, object> pointerInputExtraAttributes;
+
+            public ExtendedPointerInteraction(Interaction pointerInteraction, IInteractionInfo pointerAttributes)
+                : base(pointerInteraction.SourceDevice)
+            {
+                if (pointerInteraction == null)
+                {
+                    throw new ArgumentException("Pointer interaction provided is invalid");
+                }
+
+                if (pointerAttributes == null)
+                {
+                    throw new ArgumentException("Pointer attributes provided is invalid");
+                }
+
+                wrappedInteraction = pointerInteraction;
+                pointerInputExtraAttributes = pointerAttributes.ToDictionary();
+            }
+
+            public override Dictionary<string, object> ToDictionary()
+            {
+                // Get the original payload from the wrapped Interaction
+                Dictionary<string, object> toReturn = wrappedInteraction.ToDictionary();
+
+                // Append the original payload with the given pointer input extra attributes
+                pointerInputExtraAttributes.ToList().ForEach(x => toReturn[x.Key] = x.Value);
+
+                return toReturn;
+            }
+        }
+    }
+}

--- a/test/integration/Appium.Net.Integration.Tests.csproj
+++ b/test/integration/Appium.Net.Integration.Tests.csproj
@@ -11,11 +11,11 @@
     <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="DotNetSeleniumExtras.PageObjects" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
-    <PackageReference Include="Selenium.Support" Version="3.14.0" />
-    <PackageReference Include="Selenium.WebDriver" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+    <PackageReference Include="Selenium.Support" Version="3.141.0" />
+    <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Appium.Net\Appium.Net.csproj" />

--- a/test/integration/Windows/PentTest.cs
+++ b/test/integration/Windows/PentTest.cs
@@ -1,0 +1,277 @@
+﻿//******************************************************************************
+//
+// Copyright (c) 2018 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+using System;
+using System.Drawing;
+using System.Threading;
+using System.Collections.Generic;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Remote;
+using OpenQA.Selenium.Interactions;
+using OpenQA.Selenium.Appium.Interactions;
+using OpenQA.Selenium.Appium.Windows;
+
+// Define an alias to OpenQA.Selenium.Appium.Interactions.PointerInputDevice to hide
+// inherited OpenQA.Selenium.Interactions.PointerInputDevice that causes ambiguity.
+// In the future, all functions of OpenQA.Selenium.Appium.Interactions should be moved
+// up to OpenQA.Selenium.Interactions and this alias can simply be removed.
+using PointerInputDevice = OpenQA.Selenium.Appium.Interactions.PointerInputDevice;
+using NUnit.Framework;
+using OpenQA.Selenium.Appium;
+using Appium.Net.Integration.Tests.helpers;
+
+namespace Appium.Net.Integration.Tests.Windows
+{
+    public class PenTest : StickyNotesTest
+    {
+        private WindowsDriver<WindowsElement> newStickyNoteSession;
+        private WindowsElement inkCanvas;
+
+        [Test]
+        public void DrawBasicSquare()
+        {
+            Point canvasCoordinate = inkCanvas.Coordinates.LocationInViewport;
+            Size squareSize = new Size(inkCanvas.Size.Width * 3 / 5, inkCanvas.Size.Height * 3 / 5);
+            Point A = new Point(canvasCoordinate.X + inkCanvas.Size.Width / 5, canvasCoordinate.Y + inkCanvas.Size.Height / 5);
+
+            // A        B
+            //  ┌──────┐   Draw a basic ABCD square using Pen through the Actions API
+            //  │      │   in viewport(default) origin mode:
+            //  │      │   - X is absolute horizontal position in the session window
+            //  └──────┘   - Y is absolute vertical position in the session window
+            // D        C
+            PointerInputDevice penDevice = new PointerInputDevice(PointerKind.Pen);
+            ActionSequence sequence = new ActionSequence(penDevice, 0);
+
+            // Draw line AB from point A to B
+            sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Viewport, A.X, A.Y, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
+            sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Viewport, A.X + squareSize.Width, A.Y, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            // Draw line BC from point B to C
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
+            sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Viewport, A.X + squareSize.Width, A.Y + squareSize.Height, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            // Draw line CD from point C to D
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
+            sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Viewport, A.X, A.Y + squareSize.Height, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            // Draw line DA from point D to A
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
+            sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Viewport, A.X, A.Y, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            newStickyNoteSession.PerformActions(new List<ActionSequence> { sequence });
+
+            try
+            {
+                var result = newStickyNoteSession.FindElementByAccessibilityId("RichEditBox");
+                Assert.Fail("RichEditBox should not be defined anymore after a pen input is successfully performed.");
+            }
+            catch { }
+        }
+
+        [Test]
+        public void DrawBasicSquareWithExtraAttributes()
+        {
+            Point canvasCoordinate = inkCanvas.Coordinates.LocationInViewport;
+            Size squareSize = new Size(inkCanvas.Size.Width * 3 / 5, inkCanvas.Size.Height * 3 / 5);
+            Point A = new Point(canvasCoordinate.X + inkCanvas.Size.Width / 5, canvasCoordinate.Y + inkCanvas.Size.Height / 5);
+
+            // A        B
+            //  ┌──────┐   Draw a basic ABCD square using Pen through the Actions API
+            //  │      │   in pointer origin mode:
+            //  │      │   - X is relative to the previous X position in this session
+            //  └──────┘   - Y is relative to the previous Y position in this session
+            // D        C
+            PointerInputDevice penDevice = new PointerInputDevice(PointerKind.Pen);
+            ActionSequence sequence = new ActionSequence(penDevice, 0);
+            PenInfo penExtraAttributes = new PenInfo { TiltX = 45, TiltY = 45, Twist = 45 };
+
+            // Draw line AB from point A to B with attributes defined in penExtraAttributes
+            sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Pointer, A.X, A.Y, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact, penExtraAttributes));
+            sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Pointer, squareSize.Width, 0, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            // Draw line BC from point B to C and apply maximum (0.9f) pressure as the pen draw between the points
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
+            sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Pointer, 0, squareSize.Height, TimeSpan.Zero, new PenInfo { Pressure = 0.9f }));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            // Draw line CD from point C to D and keep the maximum pressure by not changing the pressure attribute
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
+            sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Pointer, -squareSize.Width, 0, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            // Draw line DA from point D to A and reduce the pressure to minimum (0.1f) as the pen draw between the points
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
+            sequence.AddAction(penDevice.CreatePointerMove(CoordinateOrigin.Pointer, 0, -squareSize.Height, TimeSpan.Zero, new PenInfo { Pressure = 0.1f }));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            newStickyNoteSession.PerformActions(new List<ActionSequence> { sequence });
+
+            try
+            {
+                var result = newStickyNoteSession.FindElementByAccessibilityId("RichEditBox");
+                Assert.Fail("RichEditBox should not be defined anymore after a pen input is successfully performed.");
+            }
+            catch { }
+        }
+
+        [Test]
+        public void DrawSquareAndDeleteStrokes()
+        {
+            int offset = 400;
+            // A        B
+            //  ┌──────┐   Draw a basic ABCD square using Pen through the Actions API
+            //  │      │   in pointer element mode:
+            //  │      │   - X is relative to the horizontal element center point
+            //  └──────┘   - Y is relative to the vertical element center point
+            // D        C
+            PointerInputDevice penDevice = new PointerInputDevice(PointerKind.Pen);
+            ActionSequence sequence = new ActionSequence(penDevice, 0);
+
+            // Draw line CD from point C to D and apply 30% pen pressure
+            sequence.AddAction(penDevice.CreatePointerMove(inkCanvas, offset, offset, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact, new PenInfo { Pressure = 0.3f }));
+            sequence.AddAction(penDevice.CreatePointerMove(inkCanvas, -offset, offset, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            // Draw line DA from point D to A
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
+            sequence.AddAction(penDevice.CreatePointerMove(inkCanvas, -offset, -offset, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            // Draw line AB from point A to B
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
+            sequence.AddAction(penDevice.CreatePointerMove(inkCanvas, offset, -offset, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            // Draw line BC from point B to C
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
+            sequence.AddAction(penDevice.CreatePointerMove(inkCanvas, offset, offset, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            // Draw diagonal line CA from point C straight to A
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
+            sequence.AddAction(penDevice.CreatePointerMove(inkCanvas, -offset, -offset, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            // Draw diagonal line DB from point D straight to B
+            sequence.AddAction(penDevice.CreatePointerMove(inkCanvas, -offset, offset, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenContact));
+            sequence.AddAction(penDevice.CreatePointerMove(inkCanvas, offset, -offset, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenContact));
+
+            // Erase line AB by pressing PenEraser (Pen tail end/eraser button) on the line AB from right to left
+            sequence.AddAction(penDevice.CreatePointerMove(inkCanvas, offset / 2, -offset, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenEraser));
+            sequence.AddAction(penDevice.CreatePointerMove(inkCanvas, -offset / 2, -offset, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenEraser));
+
+            // Erase line CD by pressing PenEraser (Pen tail end/eraser button) on the line CD from left to right
+            sequence.AddAction(penDevice.CreatePointerMove(inkCanvas, -offset / 2, offset, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerDown(PointerButton.PenEraser));
+            sequence.AddAction(penDevice.CreatePointerMove(inkCanvas, offset / 2, offset, TimeSpan.Zero));
+            sequence.AddAction(penDevice.CreatePointerUp(PointerButton.PenEraser));
+
+            newStickyNoteSession.PerformActions(new List<ActionSequence> { sequence });
+
+            try
+            {
+                var result = newStickyNoteSession.FindElementByAccessibilityId("RichEditBox");
+                Assert.Fail("RichEditBox should not be defined anymore after a pen input is successfully performed.");
+            }
+            catch { }
+        }
+
+        [SetUp]
+        public void CreateNewStickyNote()
+        {
+            var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
+
+            const int stickyNoteWidth = 1000;
+            const int stickyNoteHeight = 1000;
+            const int stickyNotePositionX = 100;
+            const int stickyNotePositionY = 100;
+
+            // Preserve existing or previously opened Sticky Notes by keeping track of them on initialize
+            var openedStickyNotesWindowsBefore = session.FindElementsByClassName("ApplicationFrameWindow");
+            Assert.IsNotNull(openedStickyNotesWindowsBefore);
+            Assert.IsTrue(openedStickyNotesWindowsBefore.Count > 0);
+
+            // Create a new Sticky Note by pressing Ctrl + N
+            openedStickyNotesWindowsBefore[0].SendKeys(Keys.Control + "n" + Keys.Control);
+            Thread.Sleep(TimeSpan.FromSeconds(2));
+
+            var openedStickyNotesWindowsAfter = session.FindElementsByClassName("ApplicationFrameWindow");
+            Assert.IsNotNull(openedStickyNotesWindowsAfter);
+            Assert.AreEqual(openedStickyNotesWindowsBefore.Count + 1, openedStickyNotesWindowsAfter.Count);
+
+            // Identify the newly opened Sticky Note by removing the previously opened ones from the list
+            List<WindowsElement> openedStickyNotes = new List<WindowsElement>(openedStickyNotesWindowsAfter);
+            foreach (var preExistingStickyNote in openedStickyNotesWindowsBefore)
+            {
+                openedStickyNotes.Remove(preExistingStickyNote);
+            }
+            Assert.AreEqual(1, openedStickyNotes.Count);
+
+            // Create a new session based from the newly opened Sticky Notes window
+            var newStickyNoteWindowHandle = openedStickyNotes[0].GetAttribute("NativeWindowHandle");
+            newStickyNoteWindowHandle = (int.Parse(newStickyNoteWindowHandle)).ToString("x"); // Convert to Hex
+            AppiumOptions appCapabilities = new AppiumOptions();
+            appCapabilities.AddAdditionalCapability("appTopLevelWindow", newStickyNoteWindowHandle);
+            appCapabilities.AddAdditionalCapability("deviceName", "WindowsPC");
+            newStickyNoteSession = new WindowsDriver<WindowsElement>(serverUri, appCapabilities);
+            Assert.IsNotNull(newStickyNoteSession);
+
+            // Resize and re-position the Sticky Notes window we are working with
+            newStickyNoteSession.Manage().Window.Size = new Size(stickyNoteWidth, stickyNoteHeight);
+            newStickyNoteSession.Manage().Window.Position = new Point(stickyNotePositionX, stickyNotePositionY);
+
+            // Verify that this Sticky Notes is indeed new. Newly created Sticky Notes has both
+            // RichEditBox and InkCanvas in the UI tree. Once modified by a pen or key input,
+            // it will only contain one or the other.
+            Assert.IsNotNull(newStickyNoteSession.FindElementByAccessibilityId("RichEditBox"));
+            inkCanvas = newStickyNoteSession.FindElementByAccessibilityId("InkCanvas");
+            Assert.IsNotNull(inkCanvas);
+        }
+
+        [TearDown]
+        public void DeleteStickyNote()
+        {
+            if (newStickyNoteSession != null)
+            {
+                // Create a new Sticky Note by pressing Ctrl + N
+                newStickyNoteSession.Keyboard.SendKeys(Keys.Control + "d" + Keys.Control);
+                Thread.Sleep(TimeSpan.FromSeconds(2));
+
+                try
+                {
+                    // If a delete confirmation dialog is displayed, press Delete to proceed
+                    newStickyNoteSession.FindElementByAccessibilityId("YesButton").Click();
+                }
+                catch { }
+            }
+
+            inkCanvas = null;
+        }
+    }
+}

--- a/test/integration/Windows/StickyNotesTest.cs
+++ b/test/integration/Windows/StickyNotesTest.cs
@@ -1,0 +1,106 @@
+﻿//******************************************************************************
+//
+// Copyright (c) 2018 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//******************************************************************************
+
+using Appium.Net.Integration.Tests.helpers;
+using NUnit.Framework;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Windows;
+using System;
+
+namespace Appium.Net.Integration.Tests.Windows
+{
+    public class StickyNotesTest
+    {
+        private const string StickyNotesAppId = @"Microsoft.MicrosoftStickyNotes_8wekyb3d8bbwe!App";
+
+        protected WindowsDriver<WindowsElement> session;
+
+        [OneTimeSetUp]
+        public void BeforeAll()
+        {
+            // Launch StickyNotes application if it is not yet launched
+            if (session == null)
+            {
+                var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
+
+                try
+                {
+                    // Create a new session to launch or bring up Sticky Notes application
+                    // Note: All sticky note windows are parented to Modern_Sticky_Top_Window pane
+                    AppiumOptions appCapabilities = new AppiumOptions();
+                    appCapabilities.AddAdditionalCapability("app", StickyNotesAppId);
+                    appCapabilities.AddAdditionalCapability("deviceName", "WindowsPC");
+                    session = new WindowsDriver<WindowsElement>(serverUri, appCapabilities);
+                }
+                catch
+                {
+                    // When Sticky Notes application was previously launched, the creation above may fail.
+                    // In such failure, simply look for the Modern_Sticky_Top_Window pane using the Desktop
+                    // session and create a new session based on the located top window pane.
+                    AppiumOptions desktopCapabilities = new AppiumOptions();
+                    desktopCapabilities.AddAdditionalCapability("app", "Root");
+                    desktopCapabilities.AddAdditionalCapability("deviceName", "WindowsPC");
+                    var desktopSession = new WindowsDriver<WindowsElement>(serverUri, desktopCapabilities);
+
+                    var StickyNotesTopLevelWindow = desktopSession.FindElementByClassName("Modern_Sticky_Top_Window");
+                    var StickyNotesTopLevelWindowHandle = StickyNotesTopLevelWindow.GetAttribute("NativeWindowHandle");
+                    StickyNotesTopLevelWindowHandle = (int.Parse(StickyNotesTopLevelWindowHandle)).ToString("x"); // Convert to Hex
+
+                    AppiumOptions appCapabilities = new AppiumOptions();
+                    appCapabilities.AddAdditionalCapability("appTopLevelWindow", StickyNotesTopLevelWindowHandle);
+                    appCapabilities.AddAdditionalCapability("deviceName", "WindowsPC");
+                    session = new WindowsDriver<WindowsElement>(serverUri, appCapabilities);
+                }
+                Assert.IsNotNull(session);
+
+                // Set implicit timeout to 1.5 seconds to make element search to retry every 500 ms for at most three times
+                session.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(1.5);
+            }
+        }
+
+        [OneTimeTearDown]
+        public void AfterAll()
+        {
+            // Close the application and delete the session
+            if (session != null)
+            {
+                var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
+
+                try
+                {
+                    // Sticky Notes applciation can be closed by explicitly closing any of the opened Sticky Notes window.
+                    // Create a new session based on any of opened Sticky Notes window and close it to close the application.
+                    var openedStickyNotes = session.FindElementsByClassName("ApplicationFrameWindow");
+                    if (openedStickyNotes.Count > 0)
+                    {
+                        var newStickyNoteWindowHandle = openedStickyNotes[0].GetAttribute("NativeWindowHandle");
+                        newStickyNoteWindowHandle = (int.Parse(newStickyNoteWindowHandle)).ToString("x"); // Convert to Hex
+
+                        AppiumOptions appCapabilities = new AppiumOptions();
+                        appCapabilities.AddAdditionalCapability("appTopLevelWindow", newStickyNoteWindowHandle);
+                        appCapabilities.AddAdditionalCapability("deviceName", "WindowsPC");
+                        var stickyNoteSession = new WindowsDriver<WindowsElement>(serverUri, appCapabilities);
+                        stickyNoteSession.Close();
+                    }
+                }
+                catch { }
+
+                session.Quit();
+                session = null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Change list

Enable AppiumDriver to perform W3CWebDriver Actions and implement support for additional pointer interaction attributes such as pressure, twist, tilt etc.
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Integration tests
- [x] Have you provided integration tests to pass against the latest version of appium? (for Bugfix or New feature)

## Details

I've brought these changes from https://github.com/timotiusmargo/appium-dotnet-driver/pull/1.
Also the integration tests were brought from https://github.com/Microsoft/WinAppDriver/tree/master/Samples/C%23/StickyNotesTest

We needed these changes in order to tap on a specific coordinate in our test for our UWP application.
More details can be found here - https://github.com/Microsoft/WinAppDriver/issues/229

I admit I'm not too familiar with the overall design of this feature, so probably it makes sense to reach out to the guys at Microsoft, for any further information.

I'd like to bring this into the main repository, so we can get rid of our own fork and local .dll.
