### PR TITLE
Adjusted editorconfig - spaces in cs files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,6 @@ root = true
 indent_style = space
 indent_size = 4
 
+[*.cs]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
## Change list

Extended the 4-space indent style to include .cs files in the editorconfig
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Meta change (only affects library contributors)

## Integration tests
- [ ] Have you provided integration tests to pass against the latest version of appium? (for Bugfix or New feature)

## Details
This should reduce a simple form of re-work needed by contributors and reviewers. This was added as a new section within the editorconfig to preserve the existing settings for other file types. If 4-space indentation is desirable across all project files, this could be simplified to a single section of `[*]`.