### PR TITLE
CSS selector fix for findElementsFromElement()

### DIFF
--- a/src/Appium.Net/Appium/AppiumWebElement.cs
+++ b/src/Appium.Net/Appium/AppiumWebElement.cs
@@ -13,6 +13,7 @@
 //limitations under the License.
 
 using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium.Internal;
 using OpenQA.Selenium.Remote;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -40,7 +41,8 @@ namespace OpenQA.Selenium.Appium
     /// </code>
     /// </example>
     public abstract class AppiumWebElement : RemoteWebElement,
-        IMobileElement<AppiumWebElement>, IWebElementCached
+        IMobileElement<AppiumWebElement>, IWebElementCached,
+        IFindsById, IFindsByClassName, IFindsByName, IFindsByTagName
     {
         /// <summary>
         /// Initializes a new instance of the AppiumWebElement class.
@@ -201,7 +203,37 @@ namespace OpenQA.Selenium.Appium
 
         #endregion
 
+
+
         #region FindMethods
+
+        #region Overrides to fix "css selector" issue
+
+        IWebElement IFindsByClassName.FindElementByClassName(string className) =>
+            base.FindElement(MobileSelector.ClassName, className);
+
+        ReadOnlyCollection<IWebElement> IFindsByClassName.FindElementsByClassName(string className) =>
+            base.FindElements(MobileSelector.ClassName, className);
+
+        IWebElement IFindsById.FindElementById(string id) => 
+            base.FindElement(MobileSelector.Id, id);
+
+        ReadOnlyCollection<IWebElement> IFindsById.FindElementsById(string id) =>
+            base.FindElements(MobileSelector.Id, id);
+
+        IWebElement IFindsByName.FindElementByName(string name) =>
+            base.FindElement(MobileSelector.Name, name);
+
+        ReadOnlyCollection<IWebElement> IFindsByName.FindElementsByName(string name) =>
+            base.FindElements(MobileSelector.Name, name);
+
+        IWebElement IFindsByTagName.FindElementByTagName(string tagName) =>
+            base.FindElement(MobileSelector.TagName, tagName);
+
+        ReadOnlyCollection<IWebElement> IFindsByTagName.FindElementsByTagName(string tagName) =>
+            base.FindElements(MobileSelector.TagName, tagName);
+
+        #endregion Overrides to fix "css selector" issue
 
         #region IFindByAccessibilityId Members
 


### PR DESCRIPTION
## Change list

Fixes https://github.com/appium/appium-dotnet-driver/issues/328
Contains overrides for `AppiumWebDriver` methods:
FindElementByClassName
FindElementByName
FindElementById
FindElementByTagName
the commands get translated to a CSS selector which does not work.
 
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Integration tests
- [ ] Have you provided integration tests to pass against the latest version of appium? (for Bugfix or New feature)

## Details

Changes are the same as in https://github.com/appium/appium-dotnet-driver/pull/302