### PR TITLE
Fix for #338 - StackOverflowException in AppiumOptions.ToDictionary()

### DIFF
--- a/src/Appium.Net/Appium/AppiumCapabilities.cs
+++ b/src/Appium.Net/Appium/AppiumCapabilities.cs
@@ -1,6 +1,6 @@
-﻿using OpenQA.Selenium.Remote;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Reflection;
+using OpenQA.Selenium.Remote;
 
 namespace OpenQA.Selenium.Appium
 {
@@ -11,11 +11,18 @@ namespace OpenQA.Selenium.Appium
     {
         /// <summary>
         /// Get the capabilities back as a dictionary
+        ///
+        /// This method uses Reflection and should be removed once
+        /// AppiumOptions class is avalaible for each driver
         /// </summary>
         /// <returns></returns>
         public Dictionary<string, object> ToDictionary()
         {
-            return this.ToDictionary();
+            var bindingFlags = BindingFlags.Instance | BindingFlags.NonPublic;
+            FieldInfo capsField = typeof(DesiredCapabilities)
+                    .GetField("capabilities", bindingFlags);
+
+            return capsField?.GetValue(this) as Dictionary<string, object>;
         }
     }
 }


### PR DESCRIPTION
## Change list

ToDictionary() called itself so it caused StackOverflowException.

Added reflection mechanism to get internal capabilities dictionary in
DesiredCapabilities class.
Reordered `usages` block.
 
## Types of changes

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Integration tests
- [ ] Have you provided integration tests to pass against the latest version of appium? (for Bugfix or New feature)

Tested with code from issue:
````C#
AppiumOptions options = new AppiumOptions();
options.AddAdditionalCapability(MobileCapabilityType.PlatformName, "Android");
options.AddAdditionalCapability(MobileCapabilityType.DeviceName, "9886785356548358");
options.AddAdditionalCapability(MobileCapabilityType.AutomationName, "UiAutomator2");
options.AddAdditionalCapability("appPackage", "com.test.acc");
options.AddAdditionalCapability("appActivity", "com.test.acc.MainActivity");
options.AddAdditionalCapability("chromedriverExecutableDir", Environment.CurrentDirectory);
var caps = options.ToDictionary();
````

## Details

Probably this change will be removed once AppiumOptions are ready to use with each
driver - see issue conversation.