### PR TITLE
Fixed spelling error for AppState Enum

### DIFF
--- a/src/Appium.Net/Appium/Enums/AppState.cs
+++ b/src/Appium.Net/Appium/Enums/AppState.cs
@@ -11,7 +11,7 @@ namespace OpenQA.Selenium.Appium.Enums
         NotInstalled,
         NotRunning,
         RunningInBackgroundOrSuspended,
-        RunningInBackgroud,
+        RunningInBackground,
         RunningInForeground
     }
 }


### PR DESCRIPTION
## Change list

Changed `RunningInBackgroud` to `RunningInBackground`
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details
This could be potentially breaking when someone already used the wrongly spelled enum.
