### PR TITLE
Add AutoGrantPermissions key name to AndroidMobileCapabilityType

### DIFF
--- a/src/Appium.Net/Appium/Enums/AndroidMobileCapabilityType.cs
+++ b/src/Appium.Net/Appium/Enums/AndroidMobileCapabilityType.cs
@@ -226,5 +226,11 @@ namespace OpenQA.Selenium.Appium.Enums
         /// Timeout in seconds while waiting for device to become ready.
         /// </summary>
         public static readonly string AppWaitDuration = "appWaitDuration";
+
+        /// <summary>
+        /// Have Appium automatically determine which permissions your app requires and grant them to the app on install.
+        /// Defaults to false. If noReset is true, this capability doesn't work.
+        /// </summary>
+        public static readonly string AutoGrantPermissions = "autoGrantPermissions";
     }
 }


### PR DESCRIPTION
## Change list

Add AutoGrantPermissions key name to AndroidMobileCapabilityType.
 
## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

The _autoGrantPermissions_ specified in the docs but absents like const.
Description was taken from [Appium Desired Capabilities](http://appium.io/docs/en/writing-running-appium/caps/index.html#appium-desired-capabilities)