### PR TITLE
Remove Visual studio version binding from solution file

### DIFF
--- a/src/Appium.Net.sln
+++ b/src/Appium.Net.sln
@@ -1,8 +1,5 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2026
-MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DD79BA21-B485-411E-B132-0C1A462FFABF}"
 	ProjectSection(SolutionItems) = preProject
 		..\.travis.yml = ..\.travis.yml


### PR DESCRIPTION
What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details
Removed VisualStudioVersion binding that prevents users from loading the project on the latest versions/update of Visual Studio on Windows 