### PR TITLE
feat: Add MacDriver

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,5 @@
 ##
+- Add MacDriver to support [mac driver](https://github.com/appium/appium-mac-driver) (#383)
 - Add support for retrieving log type and server side logs (#376) resolves #280
 - Resolved #306 by updating the way appium's Location endpoint response is mapped to the client's Location model
 

--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -44,11 +44,11 @@
 
   <ItemGroup>
     <Folder Include="Properties\" />
+    <Folder Include="Appium\Mac\" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Drawing.Common">
-      <Version>4.5.1</Version>
+    <PackageReference Include="System.Drawing.Common" Version="4.5.1">
     </PackageReference>
   </ItemGroup>
 

--- a/src/Appium.Net/Appium/Mac/MacDriver.cs
+++ b/src/Appium.Net/Appium/Mac/MacDriver.cs
@@ -1,0 +1,121 @@
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+using OpenQA.Selenium.Appium.Enums;
+using OpenQA.Selenium.Appium.Service;
+using OpenQA.Selenium.Remote;
+using System;
+
+namespace OpenQA.Selenium.Appium.Mac
+{
+    public class MacDriver<W> : AppiumDriver<W> where W : IWebElement
+    {
+        private static readonly string Platform = MobilePlatform.MacOS;
+
+        /// <summary>
+        /// Initializes a new instance of the MacDriver class
+        /// </summary>
+        /// <param name="commandExecutor">An <see cref="ICommandExecutor"/> object which executes commands for the driver.</param>
+        /// <param name="AppiumOptions">An <see cref="ICapabilities"/> object containing the Appium options.</param>
+        public MacDriver(ICommandExecutor commandExecutor, AppiumOptions AppiumOptions)
+            : base(commandExecutor, SetPlatformToCapabilities(AppiumOptions, Platform))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the MacDriver class using Appium options
+        /// </summary>
+        /// <param name="AppiumOptions">An <see cref="AppiumOptions"/> object containing the Appium options of the browser.</param>
+        public MacDriver(AppiumOptions AppiumOptions)
+            : base(SetPlatformToCapabilities(AppiumOptions, Platform))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the MacDriver class using Appium options and command timeout
+        /// </summary>
+        /// <param name="AppiumOptions">An <see cref="ICapabilities"/> object containing the Appium options.</param>
+        /// <param name="commandTimeout">The maximum amount of time to wait for each command.</param>
+        public MacDriver(AppiumOptions AppiumOptions, TimeSpan commandTimeout)
+            : base(SetPlatformToCapabilities(AppiumOptions, Platform), commandTimeout)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the MacDriver class using the AppiumServiceBuilder instance and Appium options
+        /// </summary>
+        /// <param name="builder"> object containing settings of the Appium local service which is going to be started</param>
+        /// <param name="AppiumOptions">An <see cref="ICapabilities"/> object containing the Appium options.</param>
+        public MacDriver(AppiumServiceBuilder builder, AppiumOptions AppiumOptions)
+            : base(builder, SetPlatformToCapabilities(AppiumOptions, Platform))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the MacDriver class using the AppiumServiceBuilder instance, Appium options and command timeout
+        /// </summary>
+        /// <param name="builder"> object containing settings of the Appium local service which is going to be started</param>
+        /// <param name="AppiumOptions">An <see cref="ICapabilities"/> object containing the Appium options.</param>
+        /// <param name="commandTimeout">The maximum amount of time to wait for each command.</param>
+        public MacDriver(AppiumServiceBuilder builder, AppiumOptions AppiumOptions, TimeSpan commandTimeout)
+            : base(builder, SetPlatformToCapabilities(AppiumOptions, Platform), commandTimeout)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the MacDriver class using the specified remote address and Appium options
+        /// </summary>
+        /// <param name="remoteAddress">URI containing the address of the WebDriver remote server (e.g. http://127.0.0.1:4723/wd/hub).</param>
+        /// <param name="AppiumOptions">An <see cref="AppiumOptions"/> object containing the Appium options.</param>
+        public MacDriver(Uri remoteAddress, AppiumOptions AppiumOptions)
+            : base(remoteAddress, SetPlatformToCapabilities(AppiumOptions, Platform))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the MacDriver class using the specified Appium local service and Appium options
+        /// </summary>
+        /// <param name="service">the specified Appium local service</param>
+        /// <param name="AppiumOptions">An <see cref="ICapabilities"/> object containing the Appium options of the browser.</param>
+        public MacDriver(AppiumLocalService service, AppiumOptions AppiumOptions)
+            : base(service, SetPlatformToCapabilities(AppiumOptions, Platform))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the MacDriver class using the specified remote address, Appium options, and command timeout.
+        /// </summary>
+        /// <param name="remoteAddress">URI containing the address of the WebDriver remote server (e.g. http://127.0.0.1:4723/wd/hub).</param>
+        /// <param name="AppiumOptions">An <see cref="AppiumOptions"/> object containing the Appium options.</param>
+        /// <param name="commandTimeout">The maximum amount of time to wait for each command.</param>
+        public MacDriver(Uri remoteAddress, AppiumOptions AppiumOptions, TimeSpan commandTimeout)
+            : base(remoteAddress, SetPlatformToCapabilities(AppiumOptions, Platform), commandTimeout)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the MacDriver class using the specified Appium local service, Appium options, and command timeout.
+        /// </summary>
+        /// <param name="service">the specified Appium local service</param>
+        /// <param name="AppiumOptions">An <see cref="ICapabilities"/> object containing the Appium options.</param>
+        /// <param name="commandTimeout">The maximum amount of time to wait for each command.</param>
+        public MacDriver(AppiumLocalService service, AppiumOptions AppiumOptions, TimeSpan commandTimeout)
+            : base(service, SetPlatformToCapabilities(AppiumOptions, Platform), commandTimeout)
+        {
+        }
+
+
+        protected override RemoteWebElementFactory CreateElementFactory() => new MacElementFactory(this);
+    }
+}

--- a/src/Appium.Net/Appium/Mac/MacElement.cs
+++ b/src/Appium.Net/Appium/Mac/MacElement.cs
@@ -11,20 +11,23 @@
 //WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //See the License for the specific language governing permissions and
 //limitations under the License.
-namespace OpenQA.Selenium.Appium.Enums
+using OpenQA.Selenium.Appium.Enums;
+using OpenQA.Selenium.Appium.Interfaces;
+using OpenQA.Selenium.Remote;
+using System.Collections.Generic;
+
+namespace OpenQA.Selenium.Appium.Mac
 {
-    public sealed class MobilePlatform
+    public class MacElement : AppiumWebElement
     {
-        public const string Android = "Android";
-
-        public const string IOS = "iOS";
-
-        public const string MacOS = "Mac";
-
-        public const string Windows = "Windows";
-
-        public const string Tizen = "Tizen";
-
-        //FireFoxOS and WinPhone will be added when there will be the supporting of appropriate mobile OS.
+        /// <summary>
+        /// Initializes a new instance of the MacElement class.
+        /// </summary>
+        /// <param name="parent">Driver in use.</param>
+        /// <param name="id">ID of the element.</param>
+        public MacElement(RemoteWebDriver parent, string id)
+            : base(parent, id)
+        {
+        }
     }
 }

--- a/src/Appium.Net/Appium/Mac/MacElementFactory.cs
+++ b/src/Appium.Net/Appium/Mac/MacElementFactory.cs
@@ -1,0 +1,16 @@
+﻿using OpenQA.Selenium.Remote;
+
+namespace OpenQA.Selenium.Appium.Mac
+{
+    public class MacElementFactory : CachedElementFactory<MacElement>
+    {
+        public MacElementFactory(RemoteWebDriver parentDriver) : base(parentDriver)
+        {
+        }
+
+        protected override MacElement CreateCachedElement(RemoteWebDriver parentDriver, string elementId)
+        {
+            return new MacElement(parentDriver, elementId);
+        }
+    }
+}

--- a/test/integration/Appium.Net.Integration.Tests.csproj
+++ b/test/integration/Appium.Net.Integration.Tests.csproj
@@ -38,4 +38,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Mac\" />
+  </ItemGroup>
 </Project>

--- a/test/integration/Mac/AlertTest.cs
+++ b/test/integration/Mac/AlertTest.cs
@@ -1,0 +1,40 @@
+﻿using Appium.Net.Integration.Tests.helpers;
+using NUnit.Framework;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Enums;
+using OpenQA.Selenium.Appium.Mac;
+
+namespace Appium.Net.Integration.Tests.Mac
+{
+    [Ignore("Ignore tests for macOS on CI")]
+    public class FindElementTest
+    {
+        private AppiumDriver<MacElement> _driver;
+
+        [OneTimeSetUp]
+        public void BeforeAll()
+        {
+            var capabilities = new AppiumOptions();
+            capabilities.AddAdditionalCapability(MobileCapabilityType.DeviceName, "Mac"); // Requires until Appium 1.15.1
+            var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
+            _driver = new MacDriver<MacElement>(serverUri, capabilities, Env.InitTimeoutSec);
+            _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;
+        }
+
+        [OneTimeTearDown]
+        public void AfterAll()
+        {
+            _driver?.Quit();
+            if (!Env.ServerIsRemote())
+            {
+                AppiumServers.StopLocalService();
+            }
+        }
+
+        [Test]
+        public void ClickFinderIconOnDoc()
+        {
+            _driver.FindElementByXPath("/AXApplication[@AXTitle='Dock']/AXList[0]/AXDockItem[@AXTitle='Finder']").Click();
+        }
+    }
+}

--- a/test/integration/Mac/AlertTest.cs
+++ b/test/integration/Mac/AlertTest.cs
@@ -6,7 +6,6 @@ using OpenQA.Selenium.Appium.Mac;
 
 namespace Appium.Net.Integration.Tests.Mac
 {
-    [Ignore("Ignore tests for macOS on CI")]
     public class FindElementTest
     {
         private AppiumDriver<MacElement> _driver;


### PR DESCRIPTION
## Change list

Add MacDriver for appium-mac-driver https://github.com/appium/appium-for-mac
I simply add MacDriver which has 'Mac' platform.
 
https://github.com/appium/appium-dotnet-driver/issues/382

## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Below is an example to run MacDriver. I've marked as ignore to functional test not to run it on CI.

```
[HTTP] --> POST /wd/hub/session
[HTTP] {"desiredCapabilities":{"deviceName":"Mac","platformName":"Mac"},"capabilities":{"firstMatch":[{"platformName":"Mac"}]}}
[debug] [W3C] Calling AppiumDriver.createSession() with args: [{"deviceName":"Mac","platformName":"Mac"},null,{"firstMatch":[{"platformName":"Mac"}]}]
[debug] [BaseDriver] Event 'newSessionRequested' logged at 1577026621045 (23:57:01 GMT+0900 (Japan Standard Time))
[Appium] Could not parse W3C capabilities: 'deviceName' can't be blank
[Appium] Trying to fix W3C capabilities by merging them with JSONWP caps
[BaseDriver] The capabilities ["deviceName"] are not standard capabilities and should have an extension prefix
[Appium] Appium v1.15.1 creating new MacDriver (v1.6.0) session
[debug] [BaseDriver] W3C capabilities and MJSONWP desired capabilities were provided
[debug] [BaseDriver] Creating session with W3C capabilities: {
[debug] [BaseDriver]   "alwaysMatch": {
[debug] [BaseDriver]     "appium:deviceName": "Mac",
[debug] [BaseDriver]     "platformName": "Mac"
[debug] [BaseDriver]   },
[debug] [BaseDriver]   "firstMatch": [
[debug] [BaseDriver]     {}
[debug] [BaseDriver]   ]
[debug] [BaseDriver] }
[BaseDriver] Session created with session id: 3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3
[MacDriver] Killing any old AppiumForMac
[MacDriver] Successfully cleaned up old Appium4Mac servers
[MacDriver] Spawning AppiumForMac with: undefined
[Appium4Mac] [STDERR] 2019-12-22 23:57:01:197 AppiumForMac[72615:307] HTTPServer: Started HTTP server on port 4622
[debug] [WD Proxy] Matched '/session' to command name 'createSession'
[debug] [WD Proxy] Proxying [POST /session] to [POST http://127.0.0.1:4622/wd/hub/session] with body: {"desiredCapabilities":{"platformName":"Mac","deviceName":"Mac"}}
[debug] [WD Proxy] Got response with status 200: {"status":0,"sessionId":"P3uafXCI","value":{"locationContextEnabled":false,"webStorageEnabled":false,"browserName":"Mac","platform":"Mac","databaseEnabled":false,"version":"10.14.6","javascriptEnabled":true,"takesScreenshot":true,"nativeEvents":true}}
[WD Proxy] Determined the downstream protocol as 'MJSONWP'
[Appium] New MacDriver session created successfully, session 3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3 added to master session list
[debug] [BaseDriver] Event 'newSessionStarted' logged at 1577026621431 (23:57:01 GMT+0900 (Japan Standard Time))
[debug] [W3C (3b5a5c3c)] Cached the protocol value 'W3C' for the new session 3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3
[debug] [W3C (3b5a5c3c)] Responding to client with driver.createSession() result: {"capabilities":{"platformName":"Mac","deviceName":"Mac"}}
[HTTP] <-- POST /wd/hub/session 200 387 ms - 119
[HTTP]
[HTTP] --> POST /wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3/timeouts
[HTTP] {"implicit":10000}
[W3C (3b5a5c3c)] Driver proxy active, passing request on via HTTP proxy
[debug] [WD Proxy] Matched '/wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3/timeouts' to command name 'timeouts'
[debug] [Protocol Converter] Will send the following request bodies to /timeouts: [{"type":"implicit","ms":10000}]
[debug] [WD Proxy] Proxying [POST /wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3/timeouts] to [POST http://127.0.0.1:4622/wd/hub/session/P3uafXCI/timeouts] with body: {"type":"implicit","ms":10000}
[debug] [WD Proxy] Got response with status 200: {"status":0,"sessionId":"P3uafXCI","value":"0"}
[WD Proxy] Replacing sessionId P3uafXCI with 3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3
[HTTP] <-- POST /wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3/timeouts 200 18 ms - 64
[HTTP]
[HTTP] --> POST /wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3/element
[HTTP] {"using":"xpath","value":"/AXApplication[@AXTitle='Dock']/AXList[0]/AXDockItem[@AXTitle='Finder']"}
[W3C (3b5a5c3c)] Driver proxy active, passing request on via HTTP proxy
[debug] [WD Proxy] Matched '/wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3/element' to command name 'findElement'
[debug] [WD Proxy] Proxying [POST /wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3/element] to [POST http://127.0.0.1:4622/wd/hub/session/P3uafXCI/element] with body: {"using":"xpath","value":"/AXApplication[@AXTitle='Dock']/AXList[0]/AXDockItem[@AXTitle='Finder']"}
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.483 AppiumForMac[72615:6294968]
[Appium4Mac] [STDERR]
[Appium4Mac] [STDERR]
[Appium4Mac] [STDERR] ************* findAllUsingAbsoluteAXPath: /AXApplication[@AXTitle='Dock']/AXList[0]/AXDockItem[@AXTitle='Finder']
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.483 AppiumForMac[72615:6294968] axPathComponents:(
[Appium4Mac] [STDERR] "AXApplication[@AXTitle='Dock']",
[Appium4Mac] [STDERR] "AXList[0]",
[Appium4Mac] [STDERR] "AXDockItem[@AXTitle='Finder']"
[Appium4Mac] [STDERR] )
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.512 AppiumForMac[72615:6294968] Dock Attributes: (
[Appium4Mac] [STDERR] AXRole,
[Appium4Mac] [STDERR] AXRoleDescription,
[Appium4Mac] [STDERR] AXTitle,
[Appium4Mac] [STDERR] AXChildren,
[Appium4Mac] [STDERR] AXFocusedUIElement,
[Appium4Mac] [STDERR] AXEnhancedUserInterface
[Appium4Mac] [STDERR] )
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.514 AppiumForMac[72615:6294968] Dock AXChildren (
[Appium4Mac] [STDERR] "<PFUIElement: 0x7ffb3b256d10> {\n    AXDescription = \"<null>\";\n    AXHelp = \"\";\n    AXRole = AXList;\n    AXRoleDescription = list;\n    AXSubrole = \"<null>\";\n    AXTitle = \"<null>\";\n}"
[Appium4Mac] [STDERR] )
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.514 AppiumForMac[72615:6294968] Dock AXFocusedUIElement (null)
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.514 AppiumForMac[72615:6294968] Dock AXEnhancedUserInterface 0
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.531 AppiumForMac[72615:6294968]
[Appium4Mac] [STDERR] ************* findAllUsingAbsoluteAXPath matchedNodes:(
[Appium4Mac] [STDERR] "<PFUIElement: 0x7ffaa9d01f70> {\n    AXDescription = \"<null>\";\n    AXHelp = \"\";\n    AXRole = AXDockItem;\n    AXRoleDescription = \"application dock item\";\n    AXSubrole = AXApplicationDockItem;\n    AXTitle = Finder;\n}"
[Appium4Mac] [STDERR] )
[Appium4Mac] [STDERR]
[Appium4Mac] [STDERR]
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.531 AppiumForMac[72615:6294968] AXDockItem: AXRole:AXDockItem
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.531 AppiumForMac[72615:6294968] AXDockItem: AXRoleDescription:application dock item
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.531 AppiumForMac[72615:6294968] AXDockItem: AXSubrole:AXApplicationDockItem
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.531 AppiumForMac[72615:6294968] AXDockItem: AXTitle:Finder
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.532 AppiumForMac[72615:6294968] AXDockItem: AXParent:<PFUIElement: 0x7ffb39c441a0> {
[Appium4Mac] [STDERR] AXDescription = "<null>";
[Appium4Mac] [STDERR] AXHelp = "";
[Appium4Mac] [STDERR] AXRole = AXList;
[Appium4Mac] [STDERR] AXRoleDescription = list;
[Appium4Mac] [STDERR] AXSubrole = "<null>";
[Appium4Mac] [STDERR] AXTitle = "<null>";
[Appium4Mac] [STDERR] }
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.532 AppiumForMac[72615:6294968] AXDockItem: AXChildren:(
[Appium4Mac] [STDERR] )
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.533 AppiumForMac[72615:6294968] AXDockItem: AXPosition:NSPoint: {182.99993896484375, 1200}
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.533 AppiumForMac[72615:6294968] AXDockItem: AXSize:NSSize: {60, 72}
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.533 AppiumForMac[72615:6294968] AXDockItem: AXFrame:NSRect: {{182.99993896484375, 1200}, {60, 72}}
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.534 AppiumForMac[72615:6294968] AXDockItem: AXTopLevelUIElement:<PFUIElement: 0x7ffb39c6e8f0> {
[Appium4Mac] [STDERR] AXDescription = "<null>";
[Appium4Mac] [STDERR] AXHelp = "";
[Appium4Mac] [STDERR] AXRole = AXList;
[Appium4Mac] [STDERR] AXRoleDescription = list;
[Appium4Mac] [STDERR] AXSubrole = "<null>";
[Appium4Mac] [STDERR] AXTitle = "<null>";
[Appium4Mac] [STDERR] }
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.534 AppiumForMac[72615:6294968] AXDockItem: AXSelected:0
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.534 AppiumForMac[72615:6294968] AXDockItem: AXShownMenuUIElement:(null)
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.534 AppiumForMac[72615:6294968] AXDockItem: AXStatusLabel:(null)
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.534 AppiumForMac[72615:6294968] AXDockItem: AXProgressValue:(null)
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.535 AppiumForMac[72615:6294968] AXDockItem: AXURL:file:///System/Library/CoreServices/Finder.app/
[Appium4Mac] [STDERR] 2019-12-22 23:57:01.535 AppiumForMac[72615:6294968] AXDockItem: AXIsApplicationRunning:1
[debug] [WD Proxy] Got response with status 200: {"status":0,"sessionId":"P3uafXCI","value":{"ELEMENT":"1"}}
[WD Proxy] Replacing sessionId P3uafXCI with 3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3
[HTTP] <-- POST /wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3/element 200 60 ms - 118
[HTTP]
[HTTP] --> POST /wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3/element/1/click
[HTTP] {}
[W3C (3b5a5c3c)] Driver proxy active, passing request on via HTTP proxy
[debug] [WD Proxy] Matched '/wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3/element/1/click' to command name 'click'
[debug] [WD Proxy] Proxying [POST /wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3/element/1/click] to [POST http://127.0.0.1:4622/wd/hub/session/P3uafXCI/element/1/click] with body: {}
[debug] [WD Proxy] Got response with status 200: {"status":0,"sessionId":"P3uafXCI"}
[WD Proxy] Replacing sessionId P3uafXCI with 3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3
[HTTP] <-- POST /wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3/element/1/click 200 21 ms - 65
[HTTP]
[HTTP] --> DELETE /wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3
[HTTP] {}
[debug] [W3C (3b5a5c3c)] Calling AppiumDriver.deleteSession() with args: ["3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3"]
[debug] [BaseDriver] Event 'quitSessionRequested' logged at 1577026621571 (23:57:01 GMT+0900 (Japan Standard Time))
[Appium] Removing session 3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3 from our master session list
[debug] [MacDriver] Deleting AppiumForMac session
[debug] [MacDriver] Deleting AppiumForMac server session
[debug] [WD Proxy] Matched '/' to command name 'deleteSession'
[debug] [WD Proxy] Proxying [DELETE /] to [DELETE http://127.0.0.1:4622/wd/hub/session/P3uafXCI] with no body
[debug] [WD Proxy] Got response with status 200: {
[debug] [WD Proxy]   "status" : 0,
[debug] [WD Proxy]   "sessionId" : "P3uafXCI"
[debug] [WD Proxy] }
[MacDriver] AppiumForMac exited unexpectedly with code null, signal SIGTERM
[debug] [BaseDriver] Event 'quitSessionFinished' logged at 1577026621591 (23:57:01 GMT+0900 (Japan Standard Time))
[debug] [W3C (3b5a5c3c)] Received response: null
[debug] [W3C (3b5a5c3c)] But deleting session, so not returning
[debug] [W3C (3b5a5c3c)] Responding to client with driver.deleteSession() result: null
[HTTP] <-- DELETE /wd/hub/session/3b5a5c3c-020d-46e3-ad13-0e5f352bf0d3 200 59 ms - 14
[HTTP]
[HTTP] --> GET /wd/hub/status
[HTTP] {}
[debug] [GENERIC] Calling AppiumDriver.getStatus() with args: []
[debug] [GENERIC] Responding to client with driver.getStatus() result: {"build":{"version":"1.15.1"}}
[HTTP] <-- GET /wd/hub/status 200 1 ms - 68
[HTTP]
```