### PR TITLE
Location property under AppiumDriver is now expose by IHasLoaction in…

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,7 @@
 - Add MacDriver to support [mac driver](https://github.com/appium/appium-mac-driver) (#383)
 - Add support for retrieving log type and server side logs (#376) resolves #280
 - Resolved #306 by updating the way appium's Location endpoint response is mapped to the client's Location model
+- Location property under AppiumDriver is now exposable by IHasLocation interface (#386)
 
 ## 4.1.1
 - Resolved #372 by fixing the endpoint for Activating an App

--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -33,6 +33,7 @@ namespace OpenQA.Selenium.Appium
     public abstract class AppiumDriver<W> : RemoteWebDriver, IFindsById, IFindsByClassName, IFindsByName,
         IFindsByTagName, IExecuteMethod, IFindsByFluentSelector<W>,
         IHasSessionDetails,
+        IHasLocation,
         IFindByAccessibilityId<W>,
         IHidesKeyboard, IInteractsWithFiles,
         IInteractsWithApps, IPerformsTouchActions, IRotatable, IContextAware, IGenericSearchContext<W>,

--- a/src/Appium.Net/Appium/Interfaces/IHasLocation.cs
+++ b/src/Appium.Net/Appium/Interfaces/IHasLocation.cs
@@ -1,0 +1,18 @@
+﻿/*
+ * CHANGE LOG - keep only last 5 threads
+ * 
+ * on-line resources
+ */
+namespace OpenQA.Selenium.Appium.Interfaces
+{
+    /// <summary>
+    /// Describes a contract by which you can get or set a GPS location on a mobile device.
+    /// </summary>
+    public interface IHasLocation
+    {
+        /// <summary>
+        /// Gets or sets the GPS location of this mobile device.
+        /// </summary>
+        Location Location { get; set; }
+    }
+}


### PR DESCRIPTION
…terface (similar as IHasSessionDetails interface)

## Change list
1. Create IHasLocation interface.
2. Implement IHasLocation interface under AppiumDriver to expose Location proerty. 
 
## Types of changes
What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details
It is now possible to get Location property from AppiumDriver class by extracting IHasLocation interface.

This implementation was designed to further SOLID AppiumDriver and allow a better class structure and flexibility

`
IHasLocation d = new AndroidDriver<IWebElement>(new AppiumOptions());
var lat = d.Location.Latitude;
`
