### PR TITLE
resolve (#390) and (#389)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,8 +1,10 @@
 ##
+- IHidesKeyboard is now exposes "key" and "strategy" overloads; Resolve (#390)
+- IHidesKeyboard no longer implement (inherit) IExecuteMethod - inheritance redundancy and a cleaner interface; Resolve (#389)
 - Add MacDriver to support [mac driver](https://github.com/appium/appium-mac-driver) (#383)
 - Add support for retrieving log type and server side logs (#376) resolves #280
 - Resolved #306 by updating the way appium's Location endpoint response is mapped to the client's Location model
-- Location property under AppiumDriver is now exposable by IHasLocation interface (#386)
+- Location property under AppiumDriver is now exposable by IHasLocation interface; Resolve (#386)
 
 ## 4.1.1
 - Resolved #372 by fixing the endpoint for Activating an App

--- a/src/Appium.Net/Appium/AppiumDriver.cs
+++ b/src/Appium.Net/Appium/AppiumDriver.cs
@@ -323,7 +323,26 @@ namespace OpenQA.Selenium.Appium
             return (Dictionary<string, object>) Execute(AppiumDriverCommand.GetAppStrings, parameters).Value;
         }
 
-        public void HideKeyboard() => AppiumCommandExecutionHelper.HideKeyboard(this, null, null);
+        /// <summary>
+        /// Hides the device keyboard.
+        /// </summary>
+        public void HideKeyboard()
+            => AppiumCommandExecutionHelper.HideKeyboard(this, null, null);
+
+        /// <summary>
+        /// Hides the device keyboard.
+        /// </summary>
+        /// <param name="key">The button pressed by the mobile driver to attempt hiding the keyboard.</param>
+        public void HideKeyboard(string key)
+            => AppiumCommandExecutionHelper.HideKeyboard(executeMethod: this, key: key);
+
+        /// <summary>
+        /// Hides the device keyboard.
+        /// </summary>
+        /// <param name="strategy">Hide keyboard strategy (optional, UIAutomation only). Available strategies - 'press', 'pressKey', 'swipeDown', 'tapOut', 'tapOutside', 'default'.</param>
+        /// <param name="key">The button pressed by the mobile driver to attempt hiding the keyboard.</param>
+        public void HideKeyboard(string strategy, string key)
+            => AppiumCommandExecutionHelper.HideKeyboard(executeMethod: this, strategy: strategy, key: key);
 
         /// <summary>
         /// GPS Location
@@ -669,7 +688,6 @@ namespace OpenQA.Selenium.Appium
         {
             return collection.Cast<T>().ToList().AsReadOnly();
         }
-
         #endregion
     }
 }

--- a/src/Appium.Net/Appium/Interfaces/IHidesKeyboard.cs
+++ b/src/Appium.Net/Appium/Interfaces/IHidesKeyboard.cs
@@ -1,25 +1,39 @@
-﻿//Licensed under the Apache License, Version 2.0 (the "License");
-//you may not use this file except in compliance with the License.
-//See the NOTICE file distributed with this work for additional
-//information regarding copyright ownership.
-//You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-//Unless required by applicable law or agreed to in writing, software
-//distributed under the License is distributed on an "AS IS" BASIS,
-//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//See the License for the specific language governing permissions and
-//limitations under the License.
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 namespace OpenQA.Selenium.Appium.Interfaces
 {
-    public interface IHidesKeyboard : IExecuteMethod
+    public interface IHidesKeyboard
     {
         /// <summary>
         /// Hides the device keyboard.
         /// </summary>
-        /// <param name="keyName">The button pressed by the mobile driver to attempt hiding the keyboard.</param>
         void HideKeyboard();
+
+        /// <summary>
+        /// Hides the device keyboard.
+        /// </summary>
+        /// <param name="key">The button pressed by the mobile driver to attempt hiding the keyboard.</param>
+        void HideKeyboard(string key);
+
+        /// <summary>
+        /// Hides the device keyboard.
+        /// </summary>
+        /// <param name="strategy">Hide keyboard strategy (optional, UIAutomation only). Available strategies - 'press', 'pressKey', 'swipeDown', 'tapOut', 'tapOutside', 'default'.</param>
+        /// <param name="key">The button pressed by the mobile driver to attempt hiding the keyboard.</param>
+        void HideKeyboard(string strategy, string key);
     }
 }


### PR DESCRIPTION
## Change list
- IHidesKeyboard is now exposes "key" and "strategy" overloads; Resolve (#390)
- IHidesKeyboard no longer implement (inherit) IExecuteMethod - inheritance redundancy and a cleaner interface; Resolve (#389) 

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
