### PR TITLE
resolved (#392)

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,5 @@
 ##
+- IPerformsTouchActions no longer implement (inherit) IExecuteMethod - inheritance redundancy and a cleaner interface; Resolve (#389)
 - IHidesKeyboard is now exposes "key" and "strategy" overloads; Resolve (#390)
 - IHidesKeyboard no longer implement (inherit) IExecuteMethod - inheritance redundancy and a cleaner interface; Resolve (#389)
 - Add MacDriver to support [mac driver](https://github.com/appium/appium-mac-driver) (#383)

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,5 @@
 ##
-- IPerformsTouchActions no longer implement (inherit) IExecuteMethod - inheritance redundancy and a cleaner interface; Resolve (#389)
+- IPerformsTouchActions no longer implement (inherit) IExecuteMethod - inheritance redundancy and a cleaner interface; Resolve (#392)
 - IHidesKeyboard is now exposes "key" and "strategy" overloads; Resolve (#390)
 - IHidesKeyboard no longer implement (inherit) IExecuteMethod - inheritance redundancy and a cleaner interface; Resolve (#389)
 - Add MacDriver to support [mac driver](https://github.com/appium/appium-mac-driver) (#383)

--- a/src/Appium.Net/Appium/Interfaces/IPerformsTouchActions.cs
+++ b/src/Appium.Net/Appium/Interfaces/IPerformsTouchActions.cs
@@ -1,31 +1,33 @@
-﻿//Licensed under the Apache License, Version 2.0 (the "License");
-//you may not use this file except in compliance with the License.
-//See the NOTICE file distributed with this work for additional
-//information regarding copyright ownership.
-//You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-//Unless required by applicable law or agreed to in writing, software
-//distributed under the License is distributed on an "AS IS" BASIS,
-//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//See the License for the specific language governing permissions and
-//limitations under the License.
-
-using OpenQA.Selenium.Appium.MultiTouch;
-
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 namespace OpenQA.Selenium.Appium.Interfaces
 {
-    public interface IPerformsTouchActions : IExecuteMethod
+    /// <summary>
+    /// Provides a mechanism for building advanced interactions with the browser/application.
+    /// </summary>
+    public interface IPerformsTouchActions
     {
         /// <summary>
-        /// Perform the multi action
+        /// Performs the multi-action sequence.
         /// </summary>
-        /// <param name="multiAction">multi action to perform</param>
+        /// <param name="multiAction">Multi-action to perform.</param>
         void PerformMultiAction(IMultiAction multiAction);
 
         /// <summary>
-        /// Perform the touch action
+        /// Perform the touch-action sequence.
         /// </summary>
         /// <param name="touchAction">touch action to perform</param>
         void PerformTouchAction(ITouchAction touchAction);


### PR DESCRIPTION
## Change list
Interfaces cleanup.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Details
IPerformsTouchActions no longer implement (inherit) IExecuteMethod - inheritance redundancy and a cleaner interface.
