### PR TITLE
feat: Espresso's Data Matcher locator strategy

### DIFF
--- a/src/Appium.Net/Appium/Android/AndroidDriver.cs
+++ b/src/Appium.Net/Appium/Android/AndroidDriver.cs
@@ -25,7 +25,7 @@ using OpenQA.Selenium.Appium.Android.Enums;
 
 namespace OpenQA.Selenium.Appium.Android
 {
-    public class AndroidDriver<W> : AppiumDriver<W>, IFindByAndroidUIAutomator<W>, IStartsActivity,
+    public class AndroidDriver<W> : AppiumDriver<W>, IFindByAndroidUIAutomator<W>, IFindByAndroidDataMatcher<W>, IStartsActivity,
         IHasNetworkConnection, IHasClipboard,
         ISendsKeyEvents,
         IPushesFiles, IHasSettings where W : IWebElement
@@ -136,6 +136,16 @@ namespace OpenQA.Selenium.Appium.Android
             ConvertToExtendedWebElementCollection<W>(FindElements(MobileSelector.AndroidUIAutomator, selector));
 
         #endregion IFindByAndroidUIAutomator Members
+
+        #region IFindByAndroidDataMatcher Members
+
+        public W FindElementByAndroidDataMatcher(string selector) =>
+            FindElement(MobileSelector.AndroidDataMatcher, selector);
+
+        public IReadOnlyCollection<W> FindElementsByAndroidDataMatcher(string selector) =>
+            ConvertToExtendedWebElementCollection<W>(FindElements(MobileSelector.AndroidDataMatcher, selector));
+
+        #endregion IFindByAndroidDataMatcher Members
 
         public void StartActivity(string appPackage, string appActivity, string appWaitPackage = "",
             string appWaitActivity = "", bool stopApp = true) =>

--- a/src/Appium.Net/Appium/Android/AndroidElement.cs
+++ b/src/Appium.Net/Appium/Android/AndroidElement.cs
@@ -20,7 +20,7 @@ using System.Collections.ObjectModel;
 
 namespace OpenQA.Selenium.Appium.Android
 {
-    public class AndroidElement : AppiumWebElement, IFindByAndroidUIAutomator<AppiumWebElement>
+    public class AndroidElement : AppiumWebElement, IFindByAndroidUIAutomator<AppiumWebElement>, IFindByAndroidDataMatcher<AppiumWebElement>
     {
         /// <summary>
         /// Initializes a new instance of the AndroidElement class.
@@ -41,6 +41,16 @@ namespace OpenQA.Selenium.Appium.Android
             FindElements(MobileSelector.AndroidUIAutomator, selector);
 
         #endregion IFindByAndroidUIAutomator Members
+
+        #region IFindByAndroidDataMatcher Members
+
+        public AppiumWebElement FindElementByAndroidDataMatcher(string selector) =>
+            FindElement(MobileSelector.AndroidDataMatcher, selector);
+
+        public IReadOnlyCollection<AppiumWebElement> FindElementsByAndroidDataMatcher(string selector) =>
+            FindElements(MobileSelector.AndroidDataMatcher, selector);
+
+        #endregion IFindByAndroidDataMatcher Members
 
         public void ReplaceValue(string value) => AndroidCommandExecutionHelper.ReplaceValue(this, Id, value);
     }

--- a/src/Appium.Net/Appium/Enums/AutomationName.cs
+++ b/src/Appium.Net/Appium/Enums/AutomationName.cs
@@ -23,6 +23,7 @@ namespace OpenQA.Selenium.Appium.Enums
         public static readonly string Selendroid = "Selendroid";
         public static readonly string iOSXcuiTest = "XCuiTest";
         public static readonly string AndroidUIAutomator2 = "UIAutomator2";
+        public static readonly string AndroidEspresso = "Espresso";
         public static readonly string YouiEngine = "youiengine";
     }
 }

--- a/src/Appium.Net/Appium/Enums/MobileSelector.cs
+++ b/src/Appium.Net/Appium/Enums/MobileSelector.cs
@@ -23,6 +23,7 @@ namespace OpenQA.Selenium.Appium.Enums
         public static readonly string TagName = "tag name";
         public static readonly string Accessibility = "accessibility id";
         public static readonly string AndroidUIAutomator = "-android uiautomator";
+        public static readonly string AndroidDataMatcher = "-android datamatcher";
         public static readonly string iOSAutomatoion = "-ios uiautomation";
         public static readonly string iOSPredicateString = "-ios predicate string";
         public static readonly string iOSClassChain = "-ios class chain";

--- a/src/Appium.Net/Appium/Interfaces/IFindByAndroidDataMatcher.cs
+++ b/src/Appium.Net/Appium/Interfaces/IFindByAndroidDataMatcher.cs
@@ -1,0 +1,47 @@
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+using System.Collections.Generic;
+
+namespace OpenQA.Selenium.Appium.Interfaces
+{
+    public interface IFindByAndroidDataMatcher<out W> : IFindsByFluentSelector<W> where W : IWebElement
+    {
+        /// <summary>
+        /// Finds the first element in the page that matches the Android Espresso's Data Matcher selector supplied
+        /// </summary>
+        /// <param name="selector">Selector for the element.</param>
+        /// <returns>IWebElement object so that you can interact that object</returns>
+        /// <example>
+        /// <code>
+        /// IWebDriver driver = new RemoteWebDriver(new DriverOptions());
+        /// IWebElement elem = driver.FindElementByAndroidDataMatcher('elements()'))
+        /// </code>
+        /// </example>
+        W FindElementByAndroidDataMatcher(string selector);
+
+        /// <summary>
+        /// Finds a list of elements that match the Android Espresso's Data Matcher selector supplied
+        /// </summary>
+        /// <param name="selector">Selector for the elements.</param>
+        /// <returns>ReadOnlyCollection of IWebElement object so that you can interact with those objects</returns>
+        /// <example>
+        /// <code>
+        /// IWebDriver driver = new RemoteWebDriver(new FirefoxOptions());
+        /// ReadOnlyCollection<![CDATA[<IWebElement>]]> elem = driver.FindElementsByAndroidDataMatcher(elements())
+        /// </code>
+        /// </example>
+        IReadOnlyCollection<W> FindElementsByAndroidDataMatcher(string selector);
+    }
+}

--- a/src/Appium.Net/Appium/MobileBy.cs
+++ b/src/Appium.Net/Appium/MobileBy.cs
@@ -87,6 +87,15 @@ namespace OpenQA.Selenium.Appium
         public static By AndroidUIAutomator(string selector) => new ByAndroidUIAutomator(selector);
 
         /// <summary>
+        /// This method creates a <see cref="OpenQA.Selenium.By"/> strategy
+        /// that searches for elements using Espresso's Data Matcher.
+        /// <see cref="http://appium.io/docs/en/writing-running-appium/android/espresso-datamatcher-selector"/>
+        /// </summary>
+        /// <param name="selector">The selector to use in finding the element.</param>
+        /// <returns></returns>
+        public static By AndroidDataMatcher(string selector) => new ByAndroidDataMatcher(selector);
+
+        /// <summary>
         /// This method creates a <see cref="OpenQA.Selenium.By"/> strategy 
         /// that searches for elements using iOS UI automation.
         /// <see cref="https://developer.apple.com/library/tvos/documentation/DeveloperTools/Conceptual/InstrumentsUserGuide/UIAutomation.html"/>
@@ -173,6 +182,38 @@ namespace OpenQA.Selenium.Appium
 
         public override string ToString() =>
             $"ByAndroidUIAutomator({selector})";
+    }
+
+    /// <summary>
+    /// Finds element when the Espresso's Data Matcher selector has the specified value.
+    /// <see cref="http://appium.io/docs/en/writing-running-appium/android/espresso-datamatcher-selector"/>
+    /// </summary>
+    public class ByAndroidDataMatcher : MobileBy
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ByAndroidDataMatcher"/> class.
+        /// </summary>
+        /// <param name="selector">The selector to use in finding the element.</param>
+        public ByAndroidDataMatcher(string selector) : base(selector, MobileSelector.AndroidDataMatcher)
+        {
+        }
+
+        public override IWebElement FindElement(ISearchContext context)
+        {
+            if (context is IFindByAndroidDataMatcher<IWebElement> finder)
+                return finder.FindElementByAndroidDataMatcher(selector);
+            return base.FindElement(context);
+        }
+
+        public override ReadOnlyCollection<IWebElement> FindElements(ISearchContext context)
+        {
+            if (context is IFindByAndroidDataMatcher<IWebElement> finder)
+                return finder.FindElementsByAndroidDataMatcher(selector).ToList().AsReadOnly();
+            return base.FindElements(context);
+        }
+
+        public override string ToString() =>
+            $"ByAndroidDataMatcher({selector})";
     }
 
     /// <summary>

--- a/test/integration/Android/ActivityTest.cs
+++ b/test/integration/Android/ActivityTest.cs
@@ -14,8 +14,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
 
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);

--- a/test/integration/Android/AppStringsTest.cs
+++ b/test/integration/Android/AppStringsTest.cs
@@ -15,8 +15,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.ImplicitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/ClipboardTest.cs
+++ b/test/integration/Android/ClipboardTest.cs
@@ -19,8 +19,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             capabilities.AddAdditionalCapability(MobileCapabilityType.FullReset, true);
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.InitTimeoutSec);

--- a/test/integration/Android/ConnectionTest.cs
+++ b/test/integration/Android/ConnectionTest.cs
@@ -15,8 +15,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/CurrentPackageTest.cs
+++ b/test/integration/Android/CurrentPackageTest.cs
@@ -14,7 +14,7 @@ namespace Appium.Net.Integration.Tests.Android
         [OneTimeSetUp]
         public void BeforeAll()
         {
-            var capabilities = Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+            var capabilities = Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
 
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.InitTimeoutSec);

--- a/test/integration/Android/Device/AppTests.cs
+++ b/test/integration/Android/Device/AppTests.cs
@@ -19,7 +19,7 @@ namespace Appium.Net.Integration.Tests.Android.Device.App
         [OneTimeSetUp]
         public void SetUp()
         {
-            _androidOptions = Caps.GetAndroidCaps(Apps.Get(Apps.androidApiDemos));
+            _androidOptions = Caps.GetAndroidUIAutomatorCaps(Apps.Get(Apps.androidApiDemos));
             _driver = new AndroidDriver<IWebElement>(
                 Env.ServerIsLocal() ? AppiumServers.LocalServiceUri : AppiumServers.RemoteServerUri,
                 _androidOptions);

--- a/test/integration/Android/DeviceTest.cs
+++ b/test/integration/Android/DeviceTest.cs
@@ -18,7 +18,7 @@ namespace Appium.Net.Integration.Tests.Android
         [OneTimeSetUp]
         public void BeforeAll()
         {
-            var capabilities = Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+            var capabilities = Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             capabilities.AddAdditionalCapability(MobileCapabilityType.FullReset, true);
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.InitTimeoutSec);

--- a/test/integration/Android/ElementTest.cs
+++ b/test/integration/Android/ElementTest.cs
@@ -14,8 +14,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AndroidElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/ElementTestEspresso.cs
+++ b/test/integration/Android/ElementTestEspresso.cs
@@ -1,0 +1,56 @@
+﻿using Appium.Net.Integration.Tests.helpers;
+using NUnit.Framework;
+using OpenQA.Selenium;
+using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Appium.Android;
+
+namespace Appium.Net.Integration.Tests.Android
+{
+    public class ElementTestEspresso
+    {
+        private AndroidDriver<AndroidElement> _driver;
+
+        [OneTimeSetUp]
+        public void BeforeAll()
+        {
+            var capabilities = Caps.GetAndroidEspressoCaps(Apps.Get("androidApiDemos"));
+            var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
+            _driver = new AndroidDriver<AndroidElement>(serverUri, capabilities, Env.InitTimeoutSec);
+            _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _driver.StartActivity("io.appium.android.apis", ".ApiDemos");
+        }
+
+        [Test]
+        public void FindByAndroidDataMatcherTest()
+        {
+            const string selectorData = @"{
+                'name':'hasEntry',
+                'args':['title','Graphics']
+                }";
+
+            By byAndroidDataMatcher = new ByAndroidDataMatcher(selectorData);
+
+            Assert.AreNotEqual(
+                _driver.FindElementById("android:id/list").FindElement(byAndroidDataMatcher).Text,
+                null);
+            Assert.GreaterOrEqual(
+                _driver.FindElementById("android:id/list").FindElements(byAndroidDataMatcher).Count,
+                1);
+        }
+
+        [OneTimeTearDown]
+        public void AfterAll()
+        {
+            _driver?.Quit();
+            if (!Env.ServerIsRemote())
+            {
+                AppiumServers.StopLocalService();
+            }
+        }
+    }
+}

--- a/test/integration/Android/EmulatorDeviceTime.cs
+++ b/test/integration/Android/EmulatorDeviceTime.cs
@@ -14,8 +14,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AndroidElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/FileInteractionTest.cs
+++ b/test/integration/Android/FileInteractionTest.cs
@@ -16,8 +16,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/HideKeyboardTestCase.cs
+++ b/test/integration/Android/HideKeyboardTestCase.cs
@@ -14,8 +14,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/IntentAndroidTest.cs
+++ b/test/integration/Android/IntentAndroidTest.cs
@@ -13,8 +13,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("intentApp"))
-                : Caps.GetAndroidCaps(Apps.Get("intentApp"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("intentApp"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("intentApp"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/KeyPressTest.cs
+++ b/test/integration/Android/KeyPressTest.cs
@@ -13,8 +13,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AndroidElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/LockDeviceTest.cs
+++ b/test/integration/Android/LockDeviceTest.cs
@@ -12,8 +12,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AndroidElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/OrientationTest.cs
+++ b/test/integration/Android/OrientationTest.cs
@@ -14,8 +14,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/ScreenRecordingTest.cs
+++ b/test/integration/Android/ScreenRecordingTest.cs
@@ -15,7 +15,7 @@ namespace Appium.Net.Integration.Tests.Android
         [OneTimeSetUp]
         public void BeforeAll()
         {
-            var capabilities = Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+            var capabilities = Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AndroidElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/SearchingTest.cs
+++ b/test/integration/Android/SearchingTest.cs
@@ -15,8 +15,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AndroidElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/Session/GeolocationTests.cs
+++ b/test/integration/Android/Session/GeolocationTests.cs
@@ -14,8 +14,8 @@ namespace Appium.Net.Integration.Tests.Android.Session.Geolocation
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AndroidElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/Session/LogTests.cs
+++ b/test/integration/Android/Session/LogTests.cs
@@ -20,7 +20,7 @@ namespace Appium.Net.Integration.Tests.Android.Session.Logs
         [OneTimeSetUp]
         public void SetUp()
         {
-            _androidOptions = Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+            _androidOptions = Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             _driver = new AndroidDriver<IWebElement>(
                 Env.ServerIsLocal() ? AppiumServers.LocalServiceUri : AppiumServers.RemoteServerUri,
                 _androidOptions);

--- a/test/integration/Android/SessionDetailTest.cs
+++ b/test/integration/Android/SessionDetailTest.cs
@@ -17,8 +17,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("selendroidTestApp"))
-                : Caps.GetAndroidCaps(Apps.Get("selendroidTestApp"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("selendroidTestApp"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("selendroidTestApp"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/SessionTest.cs
+++ b/test/integration/Android/SessionTest.cs
@@ -15,8 +15,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<IWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/SettingTest.cs
+++ b/test/integration/Android/SettingTest.cs
@@ -15,8 +15,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/TouchActionTest.cs
+++ b/test/integration/Android/TouchActionTest.cs
@@ -17,8 +17,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/WebviewTest.cs
+++ b/test/integration/Android/WebviewTest.cs
@@ -18,8 +18,8 @@ namespace Appium.Net.Integration.Tests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("selendroidTestApp"))
-                : Caps.GetAndroidCaps(Apps.Get("selendroidTestApp"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("selendroidTestApp"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("selendroidTestApp"));
             capabilities.AddAdditionalCapability(AndroidMobileCapabilityType.AppPackage, "io.selendroid.testapp");
             capabilities.AddAdditionalCapability(AndroidMobileCapabilityType.AppActivity, ".WebViewActivity");
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;

--- a/test/integration/PageObjectTests/Android/NativeAppAttributesTest.cs
+++ b/test/integration/PageObjectTests/Android/NativeAppAttributesTest.cs
@@ -19,8 +19,8 @@ namespace Appium.Net.Integration.Tests.PageObjectTests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             var timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));

--- a/test/integration/PageObjectTests/Android/SeleniumAttributesCompatibilityTest.cs
+++ b/test/integration/PageObjectTests/Android/SeleniumAttributesCompatibilityTest.cs
@@ -19,8 +19,8 @@ namespace Appium.Net.Integration.Tests.PageObjectTests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             var timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));

--- a/test/integration/PageObjectTests/Android/TestThatChecksAttributeMix1.cs
+++ b/test/integration/PageObjectTests/Android/TestThatChecksAttributeMix1.cs
@@ -19,8 +19,8 @@ namespace Appium.Net.Integration.Tests.PageObjectTests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             var timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));

--- a/test/integration/PageObjectTests/Android/TestThatChecksAttributeMix2.cs
+++ b/test/integration/PageObjectTests/Android/TestThatChecksAttributeMix2.cs
@@ -19,8 +19,8 @@ namespace Appium.Net.Integration.Tests.PageObjectTests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             var timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));

--- a/test/integration/PageObjectTests/Android/WebViewTest.cs
+++ b/test/integration/PageObjectTests/Android/WebViewTest.cs
@@ -19,8 +19,8 @@ namespace Appium.Net.Integration.Tests.PageObjectTests.Android
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("selendroidTestApp"))
-                : Caps.GetAndroidCaps(Apps.Get("selendroidTestApp"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("selendroidTestApp"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("selendroidTestApp"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             var timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));

--- a/test/integration/PageObjectTests/NegativeTests/NoSuchElementTestOnAndroid.cs
+++ b/test/integration/PageObjectTests/NegativeTests/NoSuchElementTestOnAndroid.cs
@@ -31,8 +31,8 @@ namespace Appium.Net.Integration.Tests.PageObjectTests.NegativeTests
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             var timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));

--- a/test/integration/PageObjectTests/Other/AndroidJSWebViewTest.cs
+++ b/test/integration/PageObjectTests/Other/AndroidJSWebViewTest.cs
@@ -17,8 +17,8 @@ namespace Appium.Net.Integration.Tests.PageObjectTests.Other
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("selendroidTestApp"))
-                : Caps.GetAndroidCaps(Apps.Get("selendroidTestApp"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("selendroidTestApp"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("selendroidTestApp"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             _pageObject = new AndroidJavaScriptTestPageObject(_driver);

--- a/test/integration/PageObjectTests/Other/AndroidTouchActionTest.cs
+++ b/test/integration/PageObjectTests/Other/AndroidTouchActionTest.cs
@@ -19,8 +19,8 @@ namespace Appium.Net.Integration.Tests.PageObjectTests.Other
         public void BeforeAll()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver<AppiumWebElement>(serverUri, capabilities, Env.InitTimeoutSec);
             var timeSpan = new TimeOutDuration(new TimeSpan(0, 0, 0, 5, 0));

--- a/test/integration/ServerTests/StartingAppLocallyTest.cs
+++ b/test/integration/ServerTests/StartingAppLocallyTest.cs
@@ -17,7 +17,7 @@ namespace Appium.Net.Integration.Tests.ServerTests
         {
             var app = Apps.Get("androidApiDemos");
             var capabilities =
-                Caps.GetAndroidCaps(app);
+                Caps.GetAndroidUIAutomatorCaps(app);
 
             AndroidDriver<AppiumWebElement> driver = null;
             try
@@ -35,8 +35,8 @@ namespace Appium.Net.Integration.Tests.ServerTests
         public void StartingAndroidAppWithCapabilitiesAndServiceTest()
         {
             var capabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
 
 
             var argCollector = new OptionCollector()
@@ -62,8 +62,8 @@ namespace Appium.Net.Integration.Tests.ServerTests
             var app = Apps.Get("androidApiDemos");
 
             var serverCapabilities = Env.ServerIsRemote()
-                ? Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                ? Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
 
             var clientCapabilities = new AppiumOptions();
             clientCapabilities.AddAdditionalCapability(AndroidMobileCapabilityType.AppPackage, "io.appium.android.apis");
@@ -131,8 +131,8 @@ namespace Appium.Net.Integration.Tests.ServerTests
         {
             var capabilities = Env.ServerIsRemote()
                 ? //it will be a cause of error
-                Caps.GetAndroidCaps(Apps.Get("androidApiDemos"))
-                : Caps.GetAndroidCaps(Apps.Get("androidApiDemos"));
+                Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"))
+                : Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             capabilities.AddAdditionalCapability(MobileCapabilityType.DeviceName, "iPhone Simulator");
             capabilities.AddAdditionalCapability(MobileCapabilityType.PlatformName, MobilePlatform.IOS);
 

--- a/test/integration/helpers/Caps.cs
+++ b/test/integration/helpers/Caps.cs
@@ -17,10 +17,19 @@ namespace Appium.Net.Integration.Tests.helpers
             return capabilities;
         }
 
-        public static AppiumOptions GetAndroidCaps(string app)
+        public static AppiumOptions GetAndroidUIAutomatorCaps(string app)
         {
             var capabilities = new AppiumOptions();
             capabilities.AddAdditionalCapability(MobileCapabilityType.AutomationName, AutomationName.AndroidUIAutomator2);
+            capabilities.AddAdditionalCapability(MobileCapabilityType.DeviceName, "Android Emulator");
+            capabilities.AddAdditionalCapability(MobileCapabilityType.App, app);
+            return capabilities;
+        }
+
+        public static AppiumOptions GetAndroidEspressoCaps(string app)
+        {
+            var capabilities = new AppiumOptions();
+            capabilities.AddAdditionalCapability(MobileCapabilityType.AutomationName, AutomationName.AndroidEspresso);
             capabilities.AddAdditionalCapability(MobileCapabilityType.DeviceName, "Android Emulator");
             capabilities.AddAdditionalCapability(MobileCapabilityType.App, app);
             return capabilities;


### PR DESCRIPTION
## Change list
* Added Data Matcher locator strategy
* Added Espresso as available Automation name
* Added Integration test for Data Matcher locator strategy
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Implementation of Espresso's data matcher strategy. 
All elements outside of the screen are not rendered in android, but AdapterViews have metadata with all elements inside of them. This makes it possible to find and navigate to an element that is not visible.
The internal are using Hamcrest matchers for finding the elements - http://hamcrest.org/JavaHamcrest/javadoc/1.3/org/hamcrest/Matchers.html#hasEntry(K,%20V)

