### PR TITLE
feat: Added builder pattern for creating valid ByAndroidUIAutomator statements

### DIFF
--- a/src/Appium.Net/Appium/Android/AndroidDriver.cs
+++ b/src/Appium.Net/Appium/Android/AndroidDriver.cs
@@ -132,8 +132,14 @@ namespace OpenQA.Selenium.Appium.Android
         public W FindElementByAndroidUIAutomator(string selector) =>
             FindElement(MobileSelector.AndroidUIAutomator, selector);
 
+        public W FindElementByAndroidUIAutomator(IUiAutomatorStatementBuilder selector) =>
+            FindElement(MobileSelector.AndroidUIAutomator, selector.Compile());
+
         public IReadOnlyCollection<W> FindElementsByAndroidUIAutomator(string selector) =>
             ConvertToExtendedWebElementCollection<W>(FindElements(MobileSelector.AndroidUIAutomator, selector));
+
+        public IReadOnlyCollection<W> FindElementsByAndroidUIAutomator(IUiAutomatorStatementBuilder selector) =>
+            ConvertToExtendedWebElementCollection<W>(FindElements(MobileSelector.AndroidUIAutomator, selector.Compile()));
 
         #endregion IFindByAndroidUIAutomator Members
 

--- a/src/Appium.Net/Appium/Android/AndroidDriver.cs
+++ b/src/Appium.Net/Appium/Android/AndroidDriver.cs
@@ -133,13 +133,13 @@ namespace OpenQA.Selenium.Appium.Android
             FindElement(MobileSelector.AndroidUIAutomator, selector);
 
         public W FindElementByAndroidUIAutomator(IUiAutomatorStatementBuilder selector) =>
-            FindElement(MobileSelector.AndroidUIAutomator, selector.Compile());
+            FindElement(MobileSelector.AndroidUIAutomator, selector.Build());
 
         public IReadOnlyCollection<W> FindElementsByAndroidUIAutomator(string selector) =>
             ConvertToExtendedWebElementCollection<W>(FindElements(MobileSelector.AndroidUIAutomator, selector));
 
         public IReadOnlyCollection<W> FindElementsByAndroidUIAutomator(IUiAutomatorStatementBuilder selector) =>
-            ConvertToExtendedWebElementCollection<W>(FindElements(MobileSelector.AndroidUIAutomator, selector.Compile()));
+            ConvertToExtendedWebElementCollection<W>(FindElements(MobileSelector.AndroidUIAutomator, selector.Build()));
 
         #endregion IFindByAndroidUIAutomator Members
 

--- a/src/Appium.Net/Appium/Android/AndroidElement.cs
+++ b/src/Appium.Net/Appium/Android/AndroidElement.cs
@@ -37,13 +37,13 @@ namespace OpenQA.Selenium.Appium.Android
             FindElement(MobileSelector.AndroidUIAutomator, selector);
 
         public AppiumWebElement FindElementByAndroidUIAutomator(IUiAutomatorStatementBuilder selector) =>
-            FindElement(MobileSelector.AndroidUIAutomator, selector.Compile());
+            FindElement(MobileSelector.AndroidUIAutomator, selector.Build());
 
         public IReadOnlyCollection<AppiumWebElement> FindElementsByAndroidUIAutomator(string selector) =>
             FindElements(MobileSelector.AndroidUIAutomator, selector);
 
         public IReadOnlyCollection<AppiumWebElement> FindElementsByAndroidUIAutomator(IUiAutomatorStatementBuilder selector) => 
-            FindElements(MobileSelector.AndroidUIAutomator, selector.Compile());
+            FindElements(MobileSelector.AndroidUIAutomator, selector.Build());
 
         #endregion IFindByAndroidUIAutomator Members
 

--- a/src/Appium.Net/Appium/Android/AndroidElement.cs
+++ b/src/Appium.Net/Appium/Android/AndroidElement.cs
@@ -16,7 +16,6 @@ using OpenQA.Selenium.Appium.Enums;
 using OpenQA.Selenium.Appium.Interfaces;
 using OpenQA.Selenium.Remote;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace OpenQA.Selenium.Appium.Android
 {
@@ -37,8 +36,14 @@ namespace OpenQA.Selenium.Appium.Android
         public AppiumWebElement FindElementByAndroidUIAutomator(string selector) =>
             FindElement(MobileSelector.AndroidUIAutomator, selector);
 
+        public AppiumWebElement FindElementByAndroidUIAutomator(IUiAutomatorStatementBuilder selector) =>
+            FindElement(MobileSelector.AndroidUIAutomator, selector.Compile());
+
         public IReadOnlyCollection<AppiumWebElement> FindElementsByAndroidUIAutomator(string selector) =>
             FindElements(MobileSelector.AndroidUIAutomator, selector);
+
+        public IReadOnlyCollection<AppiumWebElement> FindElementsByAndroidUIAutomator(IUiAutomatorStatementBuilder selector) => 
+            FindElements(MobileSelector.AndroidUIAutomator, selector.Compile());
 
         #endregion IFindByAndroidUIAutomator Members
 

--- a/src/Appium.Net/Appium/Android/Enums/ListDirection.cs
+++ b/src/Appium.Net/Appium/Android/Enums/ListDirection.cs
@@ -1,0 +1,8 @@
+﻿namespace OpenQA.Selenium.Appium.Android.Enums
+{
+    public enum ListDirection
+    {
+        Vertical,
+        Horizontal
+    }
+}

--- a/src/Appium.Net/Appium/Android/Enums/ListDirection.cs
+++ b/src/Appium.Net/Appium/Android/Enums/ListDirection.cs
@@ -1,4 +1,18 @@
-﻿namespace OpenQA.Selenium.Appium.Android.Enums
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+namespace OpenQA.Selenium.Appium.Android.Enums
 {
     public enum ListDirection
     {

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
@@ -1,0 +1,92 @@
+﻿using System.Text;
+using OpenQA.Selenium.Appium.Android.Enums;
+using OpenQA.Selenium.Appium.Interfaces;
+
+namespace OpenQA.Selenium.Appium.Android.UiAutomator
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <remarks>
+    /// Docs: https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable
+    /// </remarks>
+    public class AndroidUiScrollable : IUiAutomatorStatementBuilder
+    {
+        private readonly StringBuilder _builder;
+
+        /// <summary>
+        /// Creates a new scrollable searcher which will match the first scrollable widget
+        /// in the view.
+        /// </summary>
+        public AndroidUiScrollable()
+            : this(new AndroidUiSelector().IsScrollable(true))
+        {
+        }
+
+        /// <summary>
+        /// Creates a new scrollable searcher which will match the first widget
+        /// which matches the given UISelector.
+        /// </summary>
+        /// <param name="uiSelector"></param>
+        public AndroidUiScrollable(AndroidUiSelector uiSelector)
+        {
+            _builder = new StringBuilder().AppendFormat("new UiScrollable({0})", uiSelector.Compile());
+        }
+
+        /// <summary>
+        /// Sets the scrolling direction of the list.
+        /// </summary>
+        /// <param name="direction"></param>
+        /// <returns></returns>
+        public AndroidUiScrollable SetScrollDirection(ListDirection direction)
+        {
+            _builder.AppendFormat(".setAs{0}List()", direction);
+            return this;
+        }
+
+        /// <summary>
+        /// Perform a scroll forward action to move through the scrollable layout element until a visible item that matches the selector is found.
+        /// Maps to the UiScrollable.scrollIntoView(UiSelector) method.
+        /// </summary>
+        /// <param name="uiSelector"></param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollintoview</remarks>
+        public AndroidUiScrollable ScrollIntoView(AndroidUiSelector uiSelector)
+        {
+            _builder.AppendFormat(".scrollIntoView({0})", uiSelector.Compile());
+            return this;
+        }
+
+        /// <summary>
+        /// Append raw text to this <see cref="AndroidUiScrollable"/> instance. The target language is Java.
+        /// Text entered here will not be checked for validity. Use this at your own risk.
+        /// </summary>
+        /// <param name="text">
+        /// Text to be appended to the UiScrollable command builder.
+        /// </param>
+        public AndroidUiScrollable AddRawText(string text)
+        {
+            _builder.Append(text);
+            return this;
+        }
+
+        public string Compile()
+        {
+            return Compile(false);
+        }
+
+        /// <summary>
+        /// Compiles the current UiScrollable statements into a valid Java string which can be executed.
+        /// </summary>
+        /// <param name="terminateStatement">
+        /// Should the statement be returned with a semicolon terminator at the end. Defaults to false.
+        /// The terminator is only appended to the returned statement string - this <see cref="AndroidUiScrollable"/> is not affected.
+        /// </param>
+        public string Compile(bool terminateStatement)
+        {
+            if (terminateStatement)
+                return _builder + ";";
+
+            return _builder.ToString();
+        }
+    }
+}

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
@@ -19,7 +19,7 @@ using OpenQA.Selenium.Appium.Interfaces;
 namespace OpenQA.Selenium.Appium.Android.UiAutomator
 {
     /// <summary>
-    /// 
+    /// A convenience class to wrap Android UiScrollable method calls.
     /// </summary>
     /// <remarks>
     /// Docs: https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
@@ -12,6 +12,7 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
+using System;
 using System.Text;
 using OpenQA.Selenium.Appium.Android.Enums;
 using OpenQA.Selenium.Appium.Interfaces;
@@ -41,14 +42,265 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// Creates a new scrollable searcher which will match the first widget
         /// which matches the given UISelector.
         /// </summary>
-        /// <param name="uiSelector"></param>
+        /// <param name="uiSelector">
+        /// A UiSelector that will be used to find the scrollable container
+        /// </param>
         public AndroidUiScrollable(AndroidUiSelector uiSelector)
         {
             _builder = new StringBuilder().AppendFormat("new UiScrollable({0})", uiSelector.Build());
         }
 
         /// <summary>
+        /// Performs a backwards fling action with the default number of fling steps (5). If the swipe direction
+        /// is set to vertical, then the swipe will be performed from top to bottom. If the swipe direction is set
+        /// to horizontal, then the swipes will be performed from left to right. Make sure to take into account
+        /// devices configured with right-to-left languages like Arabic and Hebrew.
+        /// Maps to the UiScrollable.flingBackward() method.
+        /// </summary>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingbackward</remarks>
+        public TerminatedStatementBuilder FlingBackward()
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".flingBackward()");
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Performs a forward fling with the default number of fling steps (5). If the swipe direction is set
+        /// to vertical, then the swipes will be performed from bottom to top. If the swipe direction is set to
+        /// horizontal, then the swipes will be performed from right to left. Make sure to take into account
+        /// devices configured with right-to-left languages like Arabic and Hebrew.
+        /// Maps to the UiScrollable.flingForward() method.
+        /// </summary>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingforward</remarks>
+        public TerminatedStatementBuilder FlingForward()
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".flingForward()");
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Performs a fling gesture to reach the beginning of a scrollable layout element. The beginning can
+        /// be at the top-most edge in the case of vertical controls, or the left-most edge for horizontal
+        /// controls. Make sure to take into account devices configured with right-to-left languages like
+        /// Arabic and Hebrew.
+        /// Maps to the UiScrollable.flingToBeginning(int) method.
+        /// </summary>
+        /// <param name="maxSwipes"></param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingtobeginning</remarks>
+        public TerminatedStatementBuilder FlingToBeginning(int maxSwipes)
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".flingToBeginning({0})", maxSwipes);
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Performs a fling gesture to reach the end of a scrollable layout element. The end can be at the
+        /// bottom-most edge in the case of vertical controls, or the right-most edge for horizontal controls.
+        /// Make sure to take into account devices configured with right-to-left languages like Arabic and Hebrew.
+        /// Maps to the UiScrollable.flingToEnd() method.
+        /// </summary>
+        /// <param name="maxSwipes"></param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingtoend</remarks>
+        public TerminatedStatementBuilder FlingToEnd(int maxSwipes)
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".flingToEnd({0})", maxSwipes);
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Searches for a child element in the present scrollable container. The search first looks for a
+        /// child element that matches the selector you provided, then looks for the content-description in
+        /// its children elements. If both search conditions are fulfilled, the method returns a {@ link UiObject}
+        /// representing the element matching the selector (not the child element in its subhierarchy containing
+        /// the content-description). By default, this method performs a scroll search.
+        /// Maps to the UiScrollable.getChildByDescription(UiSelector, String, boolean) method.
+        /// </summary>
+        /// <param name="uiSelector">
+        /// UiSelector for a child in a scollable layout element
+        /// </param>
+        /// <param name="description">
+        /// Content-description to find in the children of the childPattern match (may be a partial match)
+        /// </param>
+        /// <param name="allowScrollSearch">
+        /// Set to true if scrolling is allowed
+        /// </param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbydescription_1</remarks>
+        public TerminatedStatementBuilder GetChildByDescription(AndroidUiSelector uiSelector, string description, bool allowScrollSearch = true)
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".getChildByDescription({0}, \"{1}\", {2})", 
+                uiSelector.Build(), 
+                description,
+                allowScrollSearch.ToString().ToLowerInvariant());
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Searches for a child element in the present scrollable container that matches the selector you provided.
+        /// The search is performed without scrolling and only on visible elements.
+        /// Maps to the UiScrollable.getChildByInstance(UiSelector, int) method.
+        /// </summary>
+        /// <param name="uiSelector"></param>
+        /// <param name="instance"></param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbyinstance</remarks>
+        public TerminatedStatementBuilder GetChildByInstance(AndroidUiSelector uiSelector, int instance)
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".getChildByInstance({0}, {1})", uiSelector.Build(), instance);
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Searches for a child element in the present scrollable container. The search first looks for
+        /// a child element that matches the selector you provided, then looks for the text in its children
+        /// elements. If both search conditions are fulfilled, the method returns a {@ link UiObject}
+        /// representing the element matching the selector (not the child element in its subhierarchy containing
+        /// the text). By default, this method performs a scroll search.
+        /// Maps to the UiScrollable.getChildByText(UiSelector, String, boolean) method.
+        /// </summary>
+        /// <param name="uiSelector"></param>
+        /// <param name="text"></param>
+        /// <param name="allowScrollSearch"></param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbytext</remarks>
+        public TerminatedStatementBuilder GetChildByText(AndroidUiSelector uiSelector, string text,
+            bool allowScrollSearch = true)
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".getChildByText({0}, \"{1}\", {2})", 
+                uiSelector.Build(), 
+                text, 
+                allowScrollSearch.ToString().ToLowerInvariant());
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Performs a backward scroll. If the swipe direction is set to vertical, then the swipes will be performed
+        /// from top to bottom. If the swipe direction is set to horizontal, then the swipes will be performed
+        /// from left to right. Make sure to take into account devices configured with right-to-left languages
+        /// like Arabic and Hebrew.
+        /// Maps to the UiScrollable.scrollBackward(int) method.
+        /// </summary>
+        /// <param name="steps">
+        /// Number of steps. Use this to control the speed of the scroll action.
+        /// </param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollbackward</remarks>
+        public TerminatedStatementBuilder ScrollBackward(int steps = 55)
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".scrollBackward({0})", steps);
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Performs a forward scroll action on the scrollable layout element until the content-description
+        /// is found, or until swipe attempts have been exhausted. See <see cref="SetMaxSearchSwipes"/>
+        /// Maps to the UiScrollable.scrollDescriptionIntoView(String) method.
+        /// </summary>
+        /// <param name="description"></param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolldescriptionintoview</remarks>
+        public TerminatedStatementBuilder ScrollDescriptionIntoView(string description)
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".scrollDescriptionIntoView(\"{0}\")", description);
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Performs a forward scroll. If the swipe direction is set to vertical, then the swipes will be performed
+        /// from bottom to top. If the swipe direction is set to horizontal, then the swipes will be performed
+        /// from right to left. Make sure to take into account devices configured with right-to-left languages
+        /// like Arabic and Hebrew.
+        /// Maps to the UiScrollable.scrollForward(int) method.
+        /// </summary>
+        /// <param name="steps">
+        /// Number of steps. Use this to control the speed of the scroll action.
+        /// </param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollforward</remarks>
+        public TerminatedStatementBuilder ScrollForward(int steps = 55)
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".scrollForward({0})", steps);
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Performs a forward scroll action on the scrollable layout element until the text you
+        /// provided is visible, or until swipe attempts have been exhausted. See <see cref="SetMaxSearchSwipes"/>
+        /// Maps to the UiScrollable.scrollTextIntoView() method.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolltextintoview</remarks>
+        public TerminatedStatementBuilder ScrollTextIntoView(string text)
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".scrollTextIntoView(\"{0}\")", text);
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Scrolls to the beginning of a scrollable layout element. The beginning can be at the top-most
+        /// edge in the case of vertical controls, or the left-most edge for horizontal controls. Make sure
+        /// to take into account devices configured with right-to-left languages like Arabic and Hebrew.
+        /// Maps to the UiScrollable.scrollToBeginning(int, int) method.
+        /// </summary>
+        /// <param name="maxSwipes"></param>
+        /// <param name="steps">
+        /// Use steps to control the speed, so that it may be a scroll, or fling
+        /// </param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolltobeginning</remarks>
+        public TerminatedStatementBuilder ScrollToBeginning(int maxSwipes, int steps = 55)
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".scrollToBeginning({0}, {1})", maxSwipes, steps);
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Scrolls to the end of a scrollable layout element. The end can be at the bottom-most edge in
+        /// the case of vertical controls, or the right-most edge for horizontal controls. Make sure to take
+        /// into account devices configured with right-to-left languages like Arabic and Hebrew.
+        /// Maps to the UiScrollable.scrollToEnd(int, int) method.
+        /// </summary>
+        /// <param name="maxSwipes"></param>
+        /// <param name="steps">
+        /// Use steps to control the speed, so that it may be a scroll, or fling
+        /// </param>
+        /// <remarks></remarks>
+        public TerminatedStatementBuilder ScrollToEnd(int maxSwipes, int steps = 55)
+        {
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".scrollToEnd({0}, {1})", maxSwipes, steps);
+            return new TerminatedStatementBuilder(forkedBuilder);
+        }
+
+        /// <summary>
+        /// Sets the percentage of a widget's size that's considered as no-touch zone when swiping.
+        /// The no-touch zone is set as percentage of a widget's total width or height, denoting a margin
+        /// around the swipable area of the widget. Swipes must always start and end inside this margin.
+        /// This is important when the widget being swiped may not respond to the swipe if started at a
+        /// point too near to the edge. The default is 10% from either edge.
+        /// Maps to the UiScrollable.setSwipeDeadZonePercentage(double) method.
+        /// </summary>
+        /// <param name="swipeDeadZonePercentage">
+        /// A percentage value from 0 to 1
+        /// </param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#setswipedeadzonepercentage</remarks>
+        public AndroidUiScrollable SetSwipeDeadZonePercentage(double swipeDeadZonePercentage)
+        {
+            if (swipeDeadZonePercentage < 0 || swipeDeadZonePercentage > 1)
+                throw new ArgumentOutOfRangeException(nameof(swipeDeadZonePercentage), "Must be a value between 0 and 1");
+
+            _builder.AppendFormat(".setSwipeDeadZonePercentage({0})", swipeDeadZonePercentage);
+            return this;
+        }
+
+        /// <summary>
         /// Sets the scrolling direction of the list.
+        /// Maps to UiScrollable.setAsHorizontalList() or UiScrollable.setAsVerticalList() depending on the provided <see cref="ListDirection"/>.
         /// </summary>
         /// <param name="direction"></param>
         /// <returns></returns>
@@ -59,15 +311,29 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         }
 
         /// <summary>
+        /// Sets the maximum number of scrolls allowed when performing a scroll action in search of a child element.
+        /// See <see cref="GetChildByDescription"/> and <see cref="GetChildByText"/>.
+        /// Maps to the UiScrollable.setMaxSearchSwipes(int) method.
+        /// </summary>
+        /// <param name="swipes"></param>
+        /// <remarks></remarks>
+        public AndroidUiScrollable SetMaxSearchSwipes(int swipes)
+        {
+            _builder.AppendFormat(".setMaxSearchSwipes({0})", swipes);
+            return this;
+        }
+
+        /// <summary>
         /// Perform a scroll forward action to move through the scrollable layout element until a visible item that matches the selector is found.
         /// Maps to the UiScrollable.scrollIntoView(UiSelector) method.
         /// </summary>
         /// <param name="uiSelector"></param>
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollintoview</remarks>
-        public AndroidUiScrollable ScrollIntoView(AndroidUiSelector uiSelector)
+        public TerminatedStatementBuilder ScrollIntoView(AndroidUiSelector uiSelector)
         {
-            _builder.AppendFormat(".scrollIntoView({0})", uiSelector.Build());
-            return this;
+            var forkedBuilder = new StringBuilder(_builder.ToString());
+            forkedBuilder.AppendFormat(".scrollIntoView({0})", uiSelector.Build());
+            return new TerminatedStatementBuilder(forkedBuilder);
         }
 
         /// <summary>
@@ -83,9 +349,14 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
             return this;
         }
 
+        /// <summary>
+        /// Compiles the current UiScrollable statements that have
+        /// been added to this instance.
+        /// </summary>
+        /// <returns></returns>
         public string Build()
         {
-            return Compile(false);
+            return Build(false);
         }
 
         /// <summary>
@@ -95,7 +366,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// Should the statement be returned with a semicolon terminator at the end. Defaults to false.
         /// The terminator is only appended to the returned statement string - this <see cref="AndroidUiScrollable"/> is not affected.
         /// </param>
-        public string Compile(bool terminateStatement)
+        public string Build(bool terminateStatement)
         {
             if (terminateStatement)
                 return _builder + ";";

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
@@ -47,6 +47,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiScrollable(AndroidUiSelector uiSelector)
         {
+            if (uiSelector == null)
+                throw new ArgumentNullException(nameof(uiSelector));
+
             _builder = new StringBuilder().AppendFormat("new UiScrollable({0})", uiSelector.Build());
         }
 
@@ -91,6 +94,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingtobeginning</remarks>
         public TerminatedStatementBuilder FlingToBeginning(int maxSwipes)
         {
+            if (maxSwipes < 0)
+                throw new ArgumentOutOfRangeException(nameof(maxSwipes), "Must be 0 (zero) or greater");
+
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".flingToBeginning({0})", maxSwipes);
             return new TerminatedStatementBuilder(forkedBuilder);
@@ -106,6 +112,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingtoend</remarks>
         public TerminatedStatementBuilder FlingToEnd(int maxSwipes)
         {
+            if (maxSwipes < 0)
+                throw new ArgumentOutOfRangeException(nameof(maxSwipes), "Must be 0 (zero) or greater");
+
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".flingToEnd({0})", maxSwipes);
             return new TerminatedStatementBuilder(forkedBuilder);
@@ -131,6 +140,12 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbydescription_1</remarks>
         public TerminatedStatementBuilder GetChildByDescription(AndroidUiSelector uiSelector, string description, bool allowScrollSearch = true)
         {
+            if (uiSelector == null)
+                throw new ArgumentNullException(nameof(uiSelector));
+
+            if (description == null)
+                throw new ArgumentNullException(nameof(description));
+
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".getChildByDescription({0}, \"{1}\", {2})", 
                 uiSelector.Build(), 
@@ -149,6 +164,12 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbyinstance</remarks>
         public TerminatedStatementBuilder GetChildByInstance(AndroidUiSelector uiSelector, int instance)
         {
+            if (uiSelector == null)
+                throw new ArgumentNullException(nameof(uiSelector));
+
+            if (instance < 0)
+                throw new ArgumentOutOfRangeException(nameof(instance), "Must be 0 (zero) or greater");
+
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".getChildByInstance({0}, {1})", uiSelector.Build(), instance);
             return new TerminatedStatementBuilder(forkedBuilder);
@@ -169,6 +190,12 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         public TerminatedStatementBuilder GetChildByText(AndroidUiSelector uiSelector, string text,
             bool allowScrollSearch = true)
         {
+            if (uiSelector == null)
+                throw new ArgumentNullException(nameof(uiSelector));
+
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".getChildByText({0}, \"{1}\", {2})", 
                 uiSelector.Build(), 
@@ -190,6 +217,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollbackward</remarks>
         public TerminatedStatementBuilder ScrollBackward(int steps = 55)
         {
+            if (steps < 0)
+                throw new ArgumentOutOfRangeException(nameof(steps), "Must be 0 (zero) or greater");
+
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollBackward({0})", steps);
             return new TerminatedStatementBuilder(forkedBuilder);
@@ -204,6 +234,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolldescriptionintoview</remarks>
         public TerminatedStatementBuilder ScrollDescriptionIntoView(string description)
         {
+            if (description == null)
+                throw new ArgumentNullException(nameof(description));
+
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollDescriptionIntoView(\"{0}\")", description);
             return new TerminatedStatementBuilder(forkedBuilder);
@@ -222,6 +255,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollforward</remarks>
         public TerminatedStatementBuilder ScrollForward(int steps = 55)
         {
+            if (steps < 0)
+                throw new ArgumentOutOfRangeException(nameof(steps), "Must be 0 (zero) or greater");
+
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollForward({0})", steps);
             return new TerminatedStatementBuilder(forkedBuilder);
@@ -236,6 +272,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolltextintoview</remarks>
         public TerminatedStatementBuilder ScrollTextIntoView(string text)
         {
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollTextIntoView(\"{0}\")", text);
             return new TerminatedStatementBuilder(forkedBuilder);
@@ -254,6 +293,12 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolltobeginning</remarks>
         public TerminatedStatementBuilder ScrollToBeginning(int maxSwipes, int steps = 55)
         {
+            if (maxSwipes < 0)
+                throw new ArgumentOutOfRangeException(nameof(maxSwipes), "Must be 0 (zero) or greater");
+
+            if (steps < 0)
+                throw new ArgumentOutOfRangeException(nameof(steps), "Must be 0 (zero) or greater");
+
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollToBeginning({0}, {1})", maxSwipes, steps);
             return new TerminatedStatementBuilder(forkedBuilder);
@@ -272,6 +317,12 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks></remarks>
         public TerminatedStatementBuilder ScrollToEnd(int maxSwipes, int steps = 55)
         {
+            if (maxSwipes < 0)
+                throw new ArgumentOutOfRangeException(nameof(maxSwipes), "Must be 0 (zero) or greater");
+
+            if (steps < 0)
+                throw new ArgumentOutOfRangeException(nameof(steps), "Must be 0 (zero) or greater");
+
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollToEnd({0}, {1})", maxSwipes, steps);
             return new TerminatedStatementBuilder(forkedBuilder);
@@ -319,6 +370,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks></remarks>
         public AndroidUiScrollable SetMaxSearchSwipes(int swipes)
         {
+            if (swipes < 0)
+                throw new ArgumentOutOfRangeException(nameof(swipes), "Must be 0 (zero) or greater");
+
             _builder.AppendFormat(".setMaxSearchSwipes({0})", swipes);
             return this;
         }
@@ -331,6 +385,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollintoview</remarks>
         public TerminatedStatementBuilder ScrollIntoView(AndroidUiSelector uiSelector)
         {
+            if (uiSelector == null)
+                throw new ArgumentNullException(nameof(uiSelector));
+
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollIntoView({0})", uiSelector.Build());
             return new TerminatedStatementBuilder(forkedBuilder);
@@ -345,6 +402,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiScrollable AddRawText(string text)
         {
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
             _builder.Append(text);
             return this;
         }

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
@@ -1,4 +1,18 @@
-﻿using System.Text;
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+using System.Text;
 using OpenQA.Selenium.Appium.Android.Enums;
 using OpenQA.Selenium.Appium.Interfaces;
 

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
@@ -60,9 +60,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingbackward</remarks>
         public TerminatedStatementBuilder FlingBackward()
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".flingBackward()");
-            return new TerminatedStatementBuilder(forkedBuilder);
+            return AppendTerminalStatement(".flingBackward()");
         }
 
         /// <summary>
@@ -75,9 +73,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingforward</remarks>
         public TerminatedStatementBuilder FlingForward()
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".flingForward()");
-            return new TerminatedStatementBuilder(forkedBuilder);
+            return AppendTerminalStatement(".flingForward()");
         }
 
         /// <summary>
@@ -91,9 +87,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingtobeginning</remarks>
         public TerminatedStatementBuilder FlingToBeginning(int maxSwipes)
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".flingToBeginning({0})", maxSwipes.RequireIsPositive(nameof(maxSwipes)));
-            return new TerminatedStatementBuilder(forkedBuilder);
+            return AppendTerminalStatement(".flingToBeginning({0})", maxSwipes.RequireIsPositive(nameof(maxSwipes)));
         }
 
         /// <summary>
@@ -106,9 +100,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingtoend</remarks>
         public TerminatedStatementBuilder FlingToEnd(int maxSwipes)
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".flingToEnd({0})", maxSwipes.RequireIsPositive(nameof(maxSwipes)));
-            return new TerminatedStatementBuilder(forkedBuilder);
+            return AppendTerminalStatement(".flingToEnd({0})", maxSwipes.RequireIsPositive(nameof(maxSwipes)));
         }
 
         /// <summary>
@@ -131,12 +123,10 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbydescription_1</remarks>
         public TerminatedStatementBuilder GetChildByDescription(AndroidUiSelector uiSelector, string description, bool allowScrollSearch = true)
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".getChildByDescription({0}, \"{1}\", {2})", 
-                uiSelector.RequireNotNull(nameof(uiSelector)).Build(), 
+            return AppendTerminalStatement(".getChildByDescription({0}, \"{1}\", {2})",
+                uiSelector.RequireNotNull(nameof(uiSelector)).Build(),
                 description.RequireNotNull(nameof(description)),
                 allowScrollSearch.ToString().ToLowerInvariant());
-            return new TerminatedStatementBuilder(forkedBuilder);
         }
 
         /// <summary>
@@ -149,11 +139,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbyinstance</remarks>
         public TerminatedStatementBuilder GetChildByInstance(AndroidUiSelector uiSelector, int instance)
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".getChildByInstance({0}, {1})", 
-                uiSelector.RequireNotNull(nameof(uiSelector)).Build(), 
+            return AppendTerminalStatement(".getChildByInstance({0}, {1})",
+                uiSelector.RequireNotNull(nameof(uiSelector)).Build(),
                 instance.RequireIsPositive(nameof(instance)));
-            return new TerminatedStatementBuilder(forkedBuilder);
         }
 
         /// <summary>
@@ -171,12 +159,10 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         public TerminatedStatementBuilder GetChildByText(AndroidUiSelector uiSelector, string text,
             bool allowScrollSearch = true)
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".getChildByText({0}, \"{1}\", {2})", 
-                uiSelector.RequireNotNull(nameof(uiSelector)).Build(), 
+            return AppendTerminalStatement(".getChildByText({0}, \"{1}\", {2})",
+                uiSelector.RequireNotNull(nameof(uiSelector)).Build(),
                 text.RequireNotNull(nameof(text)),
                 allowScrollSearch.ToString().ToLowerInvariant());
-            return new TerminatedStatementBuilder(forkedBuilder);
         }
 
         /// <summary>
@@ -192,9 +178,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollbackward</remarks>
         public TerminatedStatementBuilder ScrollBackward(int steps = 55)
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollBackward({0})", steps.RequireIsPositive(nameof(steps)));
-            return new TerminatedStatementBuilder(forkedBuilder);
+            return AppendTerminalStatement(".scrollBackward({0})", steps.RequireIsPositive(nameof(steps)));
         }
 
         /// <summary>
@@ -206,10 +190,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolldescriptionintoview</remarks>
         public TerminatedStatementBuilder ScrollDescriptionIntoView(string description)
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollDescriptionIntoView(\"{0}\")", 
+            return AppendTerminalStatement(".scrollDescriptionIntoView(\"{0}\")",
                 description.RequireNotNull(nameof(description)));
-            return new TerminatedStatementBuilder(forkedBuilder);
         }
 
         /// <summary>
@@ -225,9 +207,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollforward</remarks>
         public TerminatedStatementBuilder ScrollForward(int steps = 55)
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollForward({0})", steps.RequireIsPositive(nameof(steps)));
-            return new TerminatedStatementBuilder(forkedBuilder);
+            return AppendTerminalStatement(".scrollForward({0})", steps.RequireIsPositive(nameof(steps)));
         }
 
         /// <summary>
@@ -239,9 +219,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolltextintoview</remarks>
         public TerminatedStatementBuilder ScrollTextIntoView(string text)
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollTextIntoView(\"{0}\")", text.RequireNotNull(nameof(text)));
-            return new TerminatedStatementBuilder(forkedBuilder);
+            return AppendTerminalStatement(".scrollTextIntoView(\"{0}\")",
+                text.RequireNotNull(nameof(text)));
         }
 
         /// <summary>
@@ -257,11 +236,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolltobeginning</remarks>
         public TerminatedStatementBuilder ScrollToBeginning(int maxSwipes, int steps = 55)
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollToBeginning({0}, {1})", 
-                maxSwipes.RequireIsPositive(nameof(maxSwipes)), 
+            return AppendTerminalStatement(".scrollToBeginning({0}, {1})",
+                maxSwipes.RequireIsPositive(nameof(maxSwipes)),
                 steps.RequireIsPositive(nameof(steps)));
-            return new TerminatedStatementBuilder(forkedBuilder);
         }
 
         /// <summary>
@@ -277,11 +254,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks></remarks>
         public TerminatedStatementBuilder ScrollToEnd(int maxSwipes, int steps = 55)
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollToEnd({0}, {1})", 
-                maxSwipes.RequireIsPositive(nameof(maxSwipes)), 
+            return AppendTerminalStatement(".scrollToEnd({0}, {1})",
+                maxSwipes.RequireIsPositive(nameof(maxSwipes)),
                 steps.RequireIsPositive(nameof(steps)));
-            return new TerminatedStatementBuilder(forkedBuilder);
         }
 
         /// <summary>
@@ -336,10 +311,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollintoview</remarks>
         public TerminatedStatementBuilder ScrollIntoView(AndroidUiSelector uiSelector)
         {
-            var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollIntoView({0})", 
+            return AppendTerminalStatement(".scrollIntoView({0})",
                 uiSelector.RequireNotNull(nameof(uiSelector)).Build());
-            return new TerminatedStatementBuilder(forkedBuilder);
         }
 
         /// <summary>
@@ -378,6 +351,21 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
                 return _builder + ";";
 
             return _builder.ToString();
+        }
+
+        /// <summary>
+        /// Append a statement that immediately ends the current statement chain.
+        /// </summary>
+        /// <param name="format">
+        /// A <see cref="string.Format(string,object[])"/> compatible formatting string
+        /// </param>
+        /// <param name="args">
+        /// An array of objects to format
+        /// </param>
+        private TerminatedStatementBuilder AppendTerminalStatement(string format, params object[] args)
+        {
+            var clonedBuilder = new StringBuilder(_builder.ToString()).AppendFormat(format, args);
+            return new TerminatedStatementBuilder(clonedBuilder);
         }
     }
 }

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
@@ -47,9 +47,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiScrollable(AndroidUiSelector uiSelector)
         {
-            if (uiSelector == null)
-                throw new ArgumentNullException(nameof(uiSelector));
-
+            _ = uiSelector ?? throw new ArgumentNullException(nameof(uiSelector));
             _builder = new StringBuilder().AppendFormat("new UiScrollable({0})", uiSelector.Build());
         }
 
@@ -140,11 +138,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbydescription_1</remarks>
         public TerminatedStatementBuilder GetChildByDescription(AndroidUiSelector uiSelector, string description, bool allowScrollSearch = true)
         {
-            if (uiSelector == null)
-                throw new ArgumentNullException(nameof(uiSelector));
-
-            if (description == null)
-                throw new ArgumentNullException(nameof(description));
+            _ = uiSelector ?? throw new ArgumentNullException(nameof(uiSelector));
+            _ = description ?? throw new ArgumentNullException(nameof(description));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".getChildByDescription({0}, \"{1}\", {2})", 
@@ -164,8 +159,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbyinstance</remarks>
         public TerminatedStatementBuilder GetChildByInstance(AndroidUiSelector uiSelector, int instance)
         {
-            if (uiSelector == null)
-                throw new ArgumentNullException(nameof(uiSelector));
+            _ = uiSelector ?? throw new ArgumentNullException(nameof(uiSelector));
 
             if (instance < 0)
                 throw new ArgumentOutOfRangeException(nameof(instance), "Must be 0 (zero) or greater");
@@ -190,11 +184,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         public TerminatedStatementBuilder GetChildByText(AndroidUiSelector uiSelector, string text,
             bool allowScrollSearch = true)
         {
-            if (uiSelector == null)
-                throw new ArgumentNullException(nameof(uiSelector));
-
-            if (text == null)
-                throw new ArgumentNullException(nameof(text));
+            _ = uiSelector ?? throw new ArgumentNullException(nameof(uiSelector));
+            _ = text ?? throw new ArgumentNullException(nameof(text));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".getChildByText({0}, \"{1}\", {2})", 
@@ -234,8 +225,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolldescriptionintoview</remarks>
         public TerminatedStatementBuilder ScrollDescriptionIntoView(string description)
         {
-            if (description == null)
-                throw new ArgumentNullException(nameof(description));
+            _ = description ?? throw new ArgumentNullException(nameof(description));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollDescriptionIntoView(\"{0}\")", description);
@@ -272,8 +262,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolltextintoview</remarks>
         public TerminatedStatementBuilder ScrollTextIntoView(string text)
         {
-            if (text == null)
-                throw new ArgumentNullException(nameof(text));
+            _ = text ?? throw new ArgumentNullException(nameof(text));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollTextIntoView(\"{0}\")", text);
@@ -385,8 +374,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollintoview</remarks>
         public TerminatedStatementBuilder ScrollIntoView(AndroidUiSelector uiSelector)
         {
-            if (uiSelector == null)
-                throw new ArgumentNullException(nameof(uiSelector));
+            _ = uiSelector ?? throw new ArgumentNullException(nameof(uiSelector));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollIntoView({0})", uiSelector.Build());
@@ -402,8 +390,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiScrollable AddRawText(string text)
         {
-            if (text == null)
-                throw new ArgumentNullException(nameof(text));
+            _ = text ?? throw new ArgumentNullException(nameof(text));
 
             _builder.Append(text);
             return this;

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
@@ -44,7 +44,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <param name="uiSelector"></param>
         public AndroidUiScrollable(AndroidUiSelector uiSelector)
         {
-            _builder = new StringBuilder().AppendFormat("new UiScrollable({0})", uiSelector.Compile());
+            _builder = new StringBuilder().AppendFormat("new UiScrollable({0})", uiSelector.Build());
         }
 
         /// <summary>
@@ -66,7 +66,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollintoview</remarks>
         public AndroidUiScrollable ScrollIntoView(AndroidUiSelector uiSelector)
         {
-            _builder.AppendFormat(".scrollIntoView({0})", uiSelector.Compile());
+            _builder.AppendFormat(".scrollIntoView({0})", uiSelector.Build());
             return this;
         }
 
@@ -83,7 +83,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
             return this;
         }
 
-        public string Compile()
+        public string Build()
         {
             return Compile(false);
         }

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
@@ -91,9 +91,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingtobeginning</remarks>
         public TerminatedStatementBuilder FlingToBeginning(int maxSwipes)
         {
-            maxSwipes.RequireIsPositive(nameof(maxSwipes));
             var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".flingToBeginning({0})", maxSwipes);
+            forkedBuilder.AppendFormat(".flingToBeginning({0})", maxSwipes.RequireIsPositive(nameof(maxSwipes)));
             return new TerminatedStatementBuilder(forkedBuilder);
         }
 
@@ -107,9 +106,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingtoend</remarks>
         public TerminatedStatementBuilder FlingToEnd(int maxSwipes)
         {
-            maxSwipes.RequireIsPositive(nameof(maxSwipes));
             var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".flingToEnd({0})", maxSwipes);
+            forkedBuilder.AppendFormat(".flingToEnd({0})", maxSwipes.RequireIsPositive(nameof(maxSwipes)));
             return new TerminatedStatementBuilder(forkedBuilder);
         }
 
@@ -133,13 +131,10 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbydescription_1</remarks>
         public TerminatedStatementBuilder GetChildByDescription(AndroidUiSelector uiSelector, string description, bool allowScrollSearch = true)
         {
-            uiSelector.RequireNotNull(nameof(uiSelector));
-            description.RequireNotNull(nameof(description));
-
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".getChildByDescription({0}, \"{1}\", {2})", 
-                uiSelector.Build(), 
-                description,
+                uiSelector.RequireNotNull(nameof(uiSelector)).Build(), 
+                description.RequireNotNull(nameof(description)),
                 allowScrollSearch.ToString().ToLowerInvariant());
             return new TerminatedStatementBuilder(forkedBuilder);
         }
@@ -154,11 +149,10 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbyinstance</remarks>
         public TerminatedStatementBuilder GetChildByInstance(AndroidUiSelector uiSelector, int instance)
         {
-            uiSelector.RequireNotNull(nameof(uiSelector));
-            instance.RequireIsPositive(nameof(instance));
-
             var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".getChildByInstance({0}, {1})", uiSelector.Build(), instance);
+            forkedBuilder.AppendFormat(".getChildByInstance({0}, {1})", 
+                uiSelector.RequireNotNull(nameof(uiSelector)).Build(), 
+                instance.RequireIsPositive(nameof(instance)));
             return new TerminatedStatementBuilder(forkedBuilder);
         }
 
@@ -177,13 +171,10 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         public TerminatedStatementBuilder GetChildByText(AndroidUiSelector uiSelector, string text,
             bool allowScrollSearch = true)
         {
-            uiSelector.RequireNotNull(nameof(uiSelector));
-            text.RequireNotNull(nameof(text));
-
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".getChildByText({0}, \"{1}\", {2})", 
-                uiSelector.Build(), 
-                text, 
+                uiSelector.RequireNotNull(nameof(uiSelector)).Build(), 
+                text.RequireNotNull(nameof(text)),
                 allowScrollSearch.ToString().ToLowerInvariant());
             return new TerminatedStatementBuilder(forkedBuilder);
         }
@@ -201,10 +192,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollbackward</remarks>
         public TerminatedStatementBuilder ScrollBackward(int steps = 55)
         {
-            steps.RequireIsPositive(nameof(steps));
-
             var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollBackward({0})", steps);
+            forkedBuilder.AppendFormat(".scrollBackward({0})", steps.RequireIsPositive(nameof(steps)));
             return new TerminatedStatementBuilder(forkedBuilder);
         }
 
@@ -217,10 +206,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolldescriptionintoview</remarks>
         public TerminatedStatementBuilder ScrollDescriptionIntoView(string description)
         {
-            description.RequireNotNull(nameof(description));
-
             var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollDescriptionIntoView(\"{0}\")", description);
+            forkedBuilder.AppendFormat(".scrollDescriptionIntoView(\"{0}\")", 
+                description.RequireNotNull(nameof(description)));
             return new TerminatedStatementBuilder(forkedBuilder);
         }
 
@@ -237,10 +225,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollforward</remarks>
         public TerminatedStatementBuilder ScrollForward(int steps = 55)
         {
-            steps.RequireIsPositive(nameof(steps));
-
             var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollForward({0})", steps);
+            forkedBuilder.AppendFormat(".scrollForward({0})", steps.RequireIsPositive(nameof(steps)));
             return new TerminatedStatementBuilder(forkedBuilder);
         }
 
@@ -253,10 +239,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolltextintoview</remarks>
         public TerminatedStatementBuilder ScrollTextIntoView(string text)
         {
-            text.RequireNotNull(nameof(text));
-
             var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollTextIntoView(\"{0}\")", text);
+            forkedBuilder.AppendFormat(".scrollTextIntoView(\"{0}\")", text.RequireNotNull(nameof(text)));
             return new TerminatedStatementBuilder(forkedBuilder);
         }
 
@@ -273,11 +257,10 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolltobeginning</remarks>
         public TerminatedStatementBuilder ScrollToBeginning(int maxSwipes, int steps = 55)
         {
-            maxSwipes.RequireIsPositive(nameof(maxSwipes));
-            steps.RequireIsPositive(nameof(steps));
-
             var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollToBeginning({0}, {1})", maxSwipes, steps);
+            forkedBuilder.AppendFormat(".scrollToBeginning({0}, {1})", 
+                maxSwipes.RequireIsPositive(nameof(maxSwipes)), 
+                steps.RequireIsPositive(nameof(steps)));
             return new TerminatedStatementBuilder(forkedBuilder);
         }
 
@@ -294,11 +277,10 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks></remarks>
         public TerminatedStatementBuilder ScrollToEnd(int maxSwipes, int steps = 55)
         {
-            maxSwipes.RequireIsPositive(nameof(maxSwipes));
-            steps.RequireIsPositive(nameof(steps));
-
             var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollToEnd({0}, {1})", maxSwipes, steps);
+            forkedBuilder.AppendFormat(".scrollToEnd({0}, {1})", 
+                maxSwipes.RequireIsPositive(nameof(maxSwipes)), 
+                steps.RequireIsPositive(nameof(steps)));
             return new TerminatedStatementBuilder(forkedBuilder);
         }
 
@@ -354,10 +336,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollintoview</remarks>
         public TerminatedStatementBuilder ScrollIntoView(AndroidUiSelector uiSelector)
         {
-            uiSelector.RequireNotNull(nameof(uiSelector));
-
             var forkedBuilder = new StringBuilder(_builder.ToString());
-            forkedBuilder.AppendFormat(".scrollIntoView({0})", uiSelector.Build());
+            forkedBuilder.AppendFormat(".scrollIntoView({0})", 
+                uiSelector.RequireNotNull(nameof(uiSelector)).Build());
             return new TerminatedStatementBuilder(forkedBuilder);
         }
 

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiScrollable.cs
@@ -12,7 +12,6 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
-using System;
 using System.Text;
 using OpenQA.Selenium.Appium.Android.Enums;
 using OpenQA.Selenium.Appium.Interfaces;
@@ -47,8 +46,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiScrollable(AndroidUiSelector uiSelector)
         {
-            _ = uiSelector ?? throw new ArgumentNullException(nameof(uiSelector));
-            _builder = new StringBuilder().AppendFormat("new UiScrollable({0})", uiSelector.Build());
+            _builder = new StringBuilder().AppendFormat("new UiScrollable({0})", 
+                uiSelector.RequireNotNull(nameof(uiSelector)).Build());
         }
 
         /// <summary>
@@ -92,9 +91,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingtobeginning</remarks>
         public TerminatedStatementBuilder FlingToBeginning(int maxSwipes)
         {
-            if (maxSwipes < 0)
-                throw new ArgumentOutOfRangeException(nameof(maxSwipes), "Must be 0 (zero) or greater");
-
+            maxSwipes.RequireIsPositive(nameof(maxSwipes));
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".flingToBeginning({0})", maxSwipes);
             return new TerminatedStatementBuilder(forkedBuilder);
@@ -110,9 +107,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#flingtoend</remarks>
         public TerminatedStatementBuilder FlingToEnd(int maxSwipes)
         {
-            if (maxSwipes < 0)
-                throw new ArgumentOutOfRangeException(nameof(maxSwipes), "Must be 0 (zero) or greater");
-
+            maxSwipes.RequireIsPositive(nameof(maxSwipes));
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".flingToEnd({0})", maxSwipes);
             return new TerminatedStatementBuilder(forkedBuilder);
@@ -138,8 +133,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbydescription_1</remarks>
         public TerminatedStatementBuilder GetChildByDescription(AndroidUiSelector uiSelector, string description, bool allowScrollSearch = true)
         {
-            _ = uiSelector ?? throw new ArgumentNullException(nameof(uiSelector));
-            _ = description ?? throw new ArgumentNullException(nameof(description));
+            uiSelector.RequireNotNull(nameof(uiSelector));
+            description.RequireNotNull(nameof(description));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".getChildByDescription({0}, \"{1}\", {2})", 
@@ -159,10 +154,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#getchildbyinstance</remarks>
         public TerminatedStatementBuilder GetChildByInstance(AndroidUiSelector uiSelector, int instance)
         {
-            _ = uiSelector ?? throw new ArgumentNullException(nameof(uiSelector));
-
-            if (instance < 0)
-                throw new ArgumentOutOfRangeException(nameof(instance), "Must be 0 (zero) or greater");
+            uiSelector.RequireNotNull(nameof(uiSelector));
+            instance.RequireIsPositive(nameof(instance));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".getChildByInstance({0}, {1})", uiSelector.Build(), instance);
@@ -184,8 +177,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         public TerminatedStatementBuilder GetChildByText(AndroidUiSelector uiSelector, string text,
             bool allowScrollSearch = true)
         {
-            _ = uiSelector ?? throw new ArgumentNullException(nameof(uiSelector));
-            _ = text ?? throw new ArgumentNullException(nameof(text));
+            uiSelector.RequireNotNull(nameof(uiSelector));
+            text.RequireNotNull(nameof(text));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".getChildByText({0}, \"{1}\", {2})", 
@@ -208,8 +201,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollbackward</remarks>
         public TerminatedStatementBuilder ScrollBackward(int steps = 55)
         {
-            if (steps < 0)
-                throw new ArgumentOutOfRangeException(nameof(steps), "Must be 0 (zero) or greater");
+            steps.RequireIsPositive(nameof(steps));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollBackward({0})", steps);
@@ -225,7 +217,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolldescriptionintoview</remarks>
         public TerminatedStatementBuilder ScrollDescriptionIntoView(string description)
         {
-            _ = description ?? throw new ArgumentNullException(nameof(description));
+            description.RequireNotNull(nameof(description));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollDescriptionIntoView(\"{0}\")", description);
@@ -245,8 +237,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollforward</remarks>
         public TerminatedStatementBuilder ScrollForward(int steps = 55)
         {
-            if (steps < 0)
-                throw new ArgumentOutOfRangeException(nameof(steps), "Must be 0 (zero) or greater");
+            steps.RequireIsPositive(nameof(steps));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollForward({0})", steps);
@@ -262,7 +253,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolltextintoview</remarks>
         public TerminatedStatementBuilder ScrollTextIntoView(string text)
         {
-            _ = text ?? throw new ArgumentNullException(nameof(text));
+            text.RequireNotNull(nameof(text));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollTextIntoView(\"{0}\")", text);
@@ -282,11 +273,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrolltobeginning</remarks>
         public TerminatedStatementBuilder ScrollToBeginning(int maxSwipes, int steps = 55)
         {
-            if (maxSwipes < 0)
-                throw new ArgumentOutOfRangeException(nameof(maxSwipes), "Must be 0 (zero) or greater");
-
-            if (steps < 0)
-                throw new ArgumentOutOfRangeException(nameof(steps), "Must be 0 (zero) or greater");
+            maxSwipes.RequireIsPositive(nameof(maxSwipes));
+            steps.RequireIsPositive(nameof(steps));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollToBeginning({0}, {1})", maxSwipes, steps);
@@ -306,11 +294,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks></remarks>
         public TerminatedStatementBuilder ScrollToEnd(int maxSwipes, int steps = 55)
         {
-            if (maxSwipes < 0)
-                throw new ArgumentOutOfRangeException(nameof(maxSwipes), "Must be 0 (zero) or greater");
-
-            if (steps < 0)
-                throw new ArgumentOutOfRangeException(nameof(steps), "Must be 0 (zero) or greater");
+            maxSwipes.RequireIsPositive(nameof(maxSwipes));
+            steps.RequireIsPositive(nameof(steps));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollToEnd({0}, {1})", maxSwipes, steps);
@@ -331,10 +316,8 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#setswipedeadzonepercentage</remarks>
         public AndroidUiScrollable SetSwipeDeadZonePercentage(double swipeDeadZonePercentage)
         {
-            if (swipeDeadZonePercentage < 0 || swipeDeadZonePercentage > 1)
-                throw new ArgumentOutOfRangeException(nameof(swipeDeadZonePercentage), "Must be a value between 0 and 1");
-
-            _builder.AppendFormat(".setSwipeDeadZonePercentage({0})", swipeDeadZonePercentage);
+            _builder.AppendFormat(".setSwipeDeadZonePercentage({0})", 
+                swipeDeadZonePercentage.RequirePercentage(nameof(swipeDeadZonePercentage)));
             return this;
         }
 
@@ -359,10 +342,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks></remarks>
         public AndroidUiScrollable SetMaxSearchSwipes(int swipes)
         {
-            if (swipes < 0)
-                throw new ArgumentOutOfRangeException(nameof(swipes), "Must be 0 (zero) or greater");
-
-            _builder.AppendFormat(".setMaxSearchSwipes({0})", swipes);
+            _builder.AppendFormat(".setMaxSearchSwipes({0})", swipes.RequireIsPositive(nameof(swipes)));
             return this;
         }
 
@@ -374,7 +354,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiScrollable#scrollintoview</remarks>
         public TerminatedStatementBuilder ScrollIntoView(AndroidUiSelector uiSelector)
         {
-            _ = uiSelector ?? throw new ArgumentNullException(nameof(uiSelector));
+            uiSelector.RequireNotNull(nameof(uiSelector));
 
             var forkedBuilder = new StringBuilder(_builder.ToString());
             forkedBuilder.AppendFormat(".scrollIntoView({0})", uiSelector.Build());
@@ -390,9 +370,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiScrollable AddRawText(string text)
         {
-            _ = text ?? throw new ArgumentNullException(nameof(text));
-
-            _builder.Append(text);
+            _builder.Append(text.RequireNotNull(nameof(text)));
             return this;
         }
 

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
@@ -1,0 +1,450 @@
+﻿using System.Text;
+using OpenQA.Selenium.Appium.Interfaces;
+
+namespace OpenQA.Selenium.Appium.Android.UiAutomator
+{
+    /// <summary>
+    /// A convenience class to wrap Android UiSelector method calls.
+    /// The output of this class can be passed to some methods to find an element using
+    /// the Android UiSelector class.
+    /// </summary>
+    /// <remarks>
+    /// Class docs: https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html
+    /// </remarks>
+    public class AndroidUiSelector : IUiAutomatorStatementBuilder
+    {
+        private readonly StringBuilder _builder;
+
+        /// <summary>
+        /// Creates a new UiSelector builder.
+        /// </summary>
+        public AndroidUiSelector()
+        {
+            _builder = new StringBuilder("new UiSelector()");
+        }
+
+        /// <summary>
+        /// Creates a new UiSelector builder by copying all existing data
+        /// from the given selector.
+        /// </summary>
+        /// <param name="selector">
+        /// The <see cref="AndroidUiSelector"/> to copy into this new instance
+        /// </param>
+        public AndroidUiSelector(AndroidUiSelector selector)
+        {
+            _builder = new StringBuilder(selector.Compile());
+        }
+
+        /// <summary>
+        /// Set the search criteria to match widgets that are checkable. Typically, using this search criteria
+        /// alone is not useful. You should also include additional criteria, such as text, content-description,
+        /// or the class name for a widget. If no other search criteria is specified, and there is more than one
+        /// matching widget, the first widget in the tree is selected.
+        /// Maps to the UiSelector.checkable(boolean) method.
+        /// </summary>
+        /// <param name="value">
+        /// When true, matches elements which are checkable. When false, matches elements which are not checkable.
+        /// </param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#checkable</remarks>
+        public AndroidUiSelector IsCheckable(bool value)
+        {
+            _builder.AppendFormat(".checkable({0})", value.ToString().ToLowerInvariant());
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match widgets that are currently checked (usually for checkboxes). Typically,
+        /// using this search criteria alone is not useful. You should also include additional criteria, such as text,
+        /// content-description, or the class name for a widget. If no other search criteria is specified, and there is
+        /// more than one matching widget, the first widget in the tree is selected.
+        /// Maps to the UiSelector.checked(boolean) method.
+        /// </summary>
+        /// <param name="value">
+        /// When true, matches elements which are checked. When false, matches elements which are not checked.
+        /// </param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#checked</remarks>
+        public AndroidUiSelector IsChecked(bool value)
+        {
+            _builder.AppendFormat(".checkable({0})", value.ToString().ToLowerInvariant());
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a child UiSelector criteria to this selector. Use this selector to narrow the search scope to child
+        /// widgets under a specific parent widget.
+        /// Maps to the UiSelector.childSelector(UiSelector) method.
+        /// </summary>
+        /// <param name="selector"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#childselector</remarks>
+        public AndroidUiSelector ChildSelector(AndroidUiSelector selector)
+        {
+            _builder.AppendFormat(".childSelector({0})", selector.Compile());
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the class property for a widget (for example, "android.widget.Button").
+        /// Maps to the UiSelector.className(String) method.
+        /// </summary>
+        /// <param name="className"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#classname</remarks>
+        public AndroidUiSelector ClassNameEquals(string className)
+        {
+            _builder.AppendFormat(".className(\"{0}\")", className);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the class property for a widget (for example, "android.widget.Button").
+        /// Maps to the UiSelector.classNameMatches(String) method.
+        /// </summary>
+        /// <param name="regex"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#classnamematches</remarks>
+        public AndroidUiSelector ClassNameMatches(string regex)
+        {
+            _builder.AppendFormat(".classNameMatches(\"{0}\")", regex);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match widgets that are clickable. Typically, using this search criteria alone is not
+        /// useful. You should also include additional criteria, such as text, content-description, or the class name for a
+        /// widget. If no other search criteria is specified, and there is more than one matching widget, the first widget
+        /// in the tree is selected.
+        /// Maps to the UiSelector.clickable(boolean) method.
+        /// </summary>
+        /// <param name="value">
+        /// When true, matches elements which are clickable. When false, matches elements which are not clickable.
+        /// </param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#clickable</remarks>
+        public AndroidUiSelector IsClickable(bool value)
+        {
+            _builder.AppendFormat(".clickable({0})", value.ToString().ToLowerInvariant());
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the content-description property for a widget. The content-description
+        /// is typically used by the Android Accessibility framework to provide an audio prompt for the widget when
+        /// the widget is selected. The content-description for the widget must match exactly with the string in your
+        /// input argument. Matching is case-sensitive.
+        /// Maps to the UiSelector.description(String) method.
+        /// </summary>
+        /// <param name="description"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#description</remarks>
+        public AndroidUiSelector DescriptionEquals(string description)
+        {
+            _builder.AppendFormat(".description(\"{0}\")", description);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the content-description property for a widget. The content-description is
+        /// typically used by the Android Accessibility framework to provide an audio prompt for the widget when the
+        /// widget is selected. The content-description for the widget must contain the string in your input argument.
+        /// Matching is case-insensitive.
+        /// Maps to the UiSelector.descriptionContains(String) method.
+        /// </summary>
+        /// <param name="description"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#descriptioncontains</remarks>
+        public AndroidUiSelector DescriptionContains(string description)
+        {
+            _builder.AppendFormat(".descriptionContains(\"{0}\")", description);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the content-description property for a widget. The content-description is
+        /// typically used by the Android Accessibility framework to provide an audio prompt for the widget when the
+        /// widget is selected. The content-description for the widget must match exactly with the string in your input
+        /// argument.
+        /// Maps to the UiSelector.descriptionMatches(String) method.
+        /// </summary>
+        /// <param name="description"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#descriptionmatches</remarks>
+        public AndroidUiSelector DescriptionMatches(string description)
+        {
+            _builder.AppendFormat(".descriptionMatches(\"{0}\")", description);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the content-description property for a widget. The content-description is
+        /// typically used by the Android Accessibility framework to provide an audio prompt for the widget when the
+        /// widget is selected. The content-description for the widget must start with the string in your input argument.
+        /// Matching is case-insensitive.
+        /// Maps to the UiSelector.descriptionStartsWith(String) method.
+        /// </summary>
+        /// <param name="description"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#descriptionstartswith</remarks>
+        public AndroidUiSelector DescriptionStartsWith(string description)
+        {
+            _builder.AppendFormat(".descriptionStartsWith(\"{0}\")", description);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match widgets that are enabled. Typically, using this search criteria alone is not
+        /// useful. You should also include additional criteria, such as text, content-description, or the class name for
+        /// a widget. If no other search criteria is specified, and there is more than one matching widget, the first
+        /// widget in the tree is selected.
+        /// Maps to the UiSelector.enabled(boolean) method.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#enabled</remarks>
+        public AndroidUiSelector IsEnabled(bool value)
+        {
+            _builder.AppendFormat(".enabled({0})", value.ToString().ToLowerInvariant());
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match widgets that are focusable. Typically, using this search criteria alone is
+        /// not useful. You should also include additional criteria, such as text, content-description, or the class
+        /// name for a widget. If no other search criteria is specified, and there is more than one matching widget,
+        /// the first widget in the tree is selected.
+        /// Maps to the UiSelector.focusable(boolean) method.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#focusable</remarks>
+        public AndroidUiSelector IsFocusable(bool value)
+        {
+            _builder.AppendFormat(".focusable({0})", value.ToString().ToLowerInvariant());
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match widgets that have focus. Typically, using this search criteria alone is
+        /// not useful. You should also include additional criteria, such as text, content-description, or the class
+        /// name for a widget. If no other search criteria is specified, and there is more than one matching widget,
+        /// the first widget in the tree is selected.
+        /// Maps to the UiSelector.focused(boolean) method.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#focused</remarks>
+        public AndroidUiSelector IsFocused(bool value)
+        {
+            _builder.AppendFormat(".focused({0})", value.ToString().ToLowerInvariant());
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a child UiSelector criteria to this selector which is used to start search from the parent widget.
+        /// Use this selector to narrow the search scope to sibling widgets as well all child widgets under a parent.
+        /// Maps to the UiSelector.fromParent(UiSelector) method.
+        /// </summary>
+        /// <param name="selector"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#fromparent</remarks>
+        public AndroidUiSelector FromParent(AndroidUiSelector selector)
+        {
+            _builder.AppendFormat(".fromParent({0})", selector.Compile());
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the widget by its node index in the layout hierarchy. The index value must
+        /// be 0 or greater. Using the index can be unreliable and should only be used as a last resort for matching.
+        /// Instead, consider using the <see cref="Instance"/> method.
+        /// Maps to the UiSelector.index(int) method.
+        /// </summary>
+        /// <param name="index"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#index</remarks>
+        public AndroidUiSelector Index(int index)
+        {
+            _builder.AppendFormat(".index({0})", index);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the widget by its instance number. The instance value must
+        /// be 0 or greater, where the first instance is 0. For example, to simulate a user click on the
+        /// third image that is enabled in a UI screen, you could specify a a search criteria where the
+        /// instance is 2, the className(String) matches the image widget class, and enabled(boolean) is
+        /// true.
+        /// Maps to the UiSelector.instance(int) method.
+        /// </summary>
+        /// <param name="instance">
+        /// The 0-indexed instance to match on
+        /// </param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#instance</remarks>
+        public AndroidUiSelector Instance(int instance)
+        {
+            _builder.AppendFormat(".instance({0})", instance);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match widgets that are long-clickable. Typically, using this search
+        /// criteria alone is not useful. You should also include additional criteria, such as text,
+        /// content-description, or the class name for a widget. If no other search criteria is specified,
+        /// and there is more than one matching widget, the first widget in the tree is selected.
+        /// Maps to the UiSelector.longClickable(int) method.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#longclickable</remarks>
+        public AndroidUiSelector IsLongClickable(bool value)
+        {
+            _builder.AppendFormat(".longClickable({0})", value.ToString().ToLowerInvariant());
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the package name of the application that contains the widget.
+        /// Maps to the UiSelector.packageName(String) method.
+        /// </summary>
+        /// <param name="packageName"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#packagename</remarks>
+        public AndroidUiSelector PackageNameEquals(string packageName)
+        {
+            _builder.AppendFormat(".packageName(\"{0}\")", packageName);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the package name of the application that contains the widget.
+        /// Maps to the UiSelector.packageNameMatches(String) method.
+        /// </summary>
+        /// <param name="regex"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#packagenamematches</remarks>
+        public AndroidUiSelector PackageNameMatches(string regex)
+        {
+            _builder.AppendFormat(".packageNameMatches(\"{0}\")", regex);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the given resource ID.
+        /// Maps to the UiSelector.resourceId(String) method.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#resourceid</remarks>
+        public AndroidUiSelector ResourceIdEquals(string id)
+        {
+            _builder.AppendFormat(".resourceId(\"{0}\")", id);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the resource ID of the widget, using a regular expression.
+        /// Maps to the UiSelector.resourceIdMatches(String) method.
+        /// </summary>
+        /// <param name="regex"></param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#resourceidmatches</remarks>
+        public AndroidUiSelector ResourceIdMatches(string regex)
+        {
+            _builder.AppendFormat(".resourceIdMatches(\"{0}\")", regex);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match widgets that are scrollable. Typically, using this
+        /// search criteria alone is not useful. You should also include additional criteria, such
+        /// as text, content-description, or the class name for a widget. If no other search criteria
+        /// is specified, and there is more than one matching widget, the first widget in the tree
+        /// is selected.
+        /// Maps to the UiSelector.scrollable(boolean) method.
+        /// </summary>
+        /// <param name="value">
+        /// When true, matches elements which are scrollable. When false, matches elements which are not scrollable.
+        /// </param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#scrollable</remarks>
+        public AndroidUiSelector IsScrollable(bool value)
+        {
+            _builder.AppendFormat(".scrollable({0})", value.ToString().ToLowerInvariant());
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match widgets that are currently selected. Typically, using this
+        /// search criteria alone is not useful. You should also include additional criteria, such as text,
+        /// content-description, or the class name for a widget. If no other search criteria is specified, and
+        /// there is more than one matching widget, the first widget in the tree is selected.
+        /// Maps to the UiSelector.selected(boolean) method.
+        /// </summary>
+        /// <param name="value">
+        /// When true, matches elements which are scrollable. When false, matches elements which are not scrollable.
+        /// </param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#selected</remarks>
+        public AndroidUiSelector IsSelected(bool value)
+        {
+            _builder.AppendFormat(".selected({0})", value.ToString().ToLowerInvariant());
+            return this;
+        }
+
+        /// <summary>
+        /// Includes elements whose accessibility-id attribute is equal to the given text.
+        /// Maps to the UiSelector.text(String) method.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#text</remarks>
+        public AndroidUiSelector AccessibilityIdEquals(string text)
+        {
+            // these are the same method. this version is only included to prevent confusion
+            // since its kinda weird that it handles both text and accessibility-id
+            return TextEquals(text);
+        }
+
+        /// <summary>
+        /// Includes elements whose text attribute is equal to the given text.
+        /// Maps to the UiSelector.text(String) method.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#text</remarks>
+        public AndroidUiSelector TextEquals(string text)
+        {
+            _builder.AppendFormat(".text(\"{0}\")", text);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the visible text in a widget where the visible text must contain the
+        /// string in your input argument. The matching is case-sensitive.
+        /// Maps to the UiSelector.textContains(String) method.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#textcontains</remarks>
+        public AndroidUiSelector TextContains(string text)
+        {
+            _builder.AppendFormat(".textContains(\"{0}\")", text);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the search criteria to match the visible text displayed in a layout element, using a regular expression.
+        /// The text in the widget must match exactly with the string in your input argument.
+        /// Maps to the UiSelector.textMatches(String) method.
+        /// </summary>
+        /// <param name="regex">
+        /// A regular expression
+        /// </param>
+        /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#textmatches</remarks>
+        public AndroidUiSelector TextMatches(string regex)
+        {
+            _builder.AppendFormat(".textMatches(\"{0}\")", regex);
+            return this;
+        }
+
+        /// <summary>
+        /// Append raw text to this <see cref="AndroidUiSelector"/> instance. The target language is Java.
+        /// Text entered here will not be checked for validity. Use this at your own risk.
+        /// </summary>
+        /// <param name="text">
+        /// Text to be appended to the UiSelector command builder.
+        /// </param>
+        public AndroidUiSelector AddRawText(string text)
+        {
+            _builder.Append(text);
+            return this;
+        }
+
+        /// <summary>
+        /// Compiles the current UiSelector statements that have
+        /// been added to this instance.
+        /// </summary>
+        /// <returns></returns>
+        public string Compile()
+        {
+            return _builder.ToString();
+        }
+    }
+}

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
@@ -12,6 +12,7 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
+using System;
 using System.Text;
 using OpenQA.Selenium.Appium.Interfaces;
 
@@ -46,6 +47,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiSelector(AndroidUiSelector selector)
         {
+            if (selector == null)
+                throw new ArgumentNullException(nameof(selector));
+
             _builder = new StringBuilder(selector.Build());
         }
 
@@ -92,6 +96,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#childselector</remarks>
         public AndroidUiSelector ChildSelector(AndroidUiSelector selector)
         {
+            if (selector == null)
+                throw new ArgumentNullException(nameof(selector));
+
             _builder.AppendFormat(".childSelector({0})", selector.Build());
             return this;
         }
@@ -104,6 +111,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#classname</remarks>
         public AndroidUiSelector ClassNameEquals(string className)
         {
+            if (className == null)
+                throw new ArgumentNullException(nameof(className));
+
             _builder.AppendFormat(".className(\"{0}\")", className);
             return this;
         }
@@ -116,6 +126,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#classnamematches</remarks>
         public AndroidUiSelector ClassNameMatches(string regex)
         {
+            if (regex == null)
+                throw new ArgumentNullException(nameof(regex));
+
             _builder.AppendFormat(".classNameMatches(\"{0}\")", regex);
             return this;
         }
@@ -148,6 +161,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#description</remarks>
         public AndroidUiSelector DescriptionEquals(string description)
         {
+            if (description == null)
+                throw new ArgumentNullException(nameof(description));
+
             _builder.AppendFormat(".description(\"{0}\")", description);
             return this;
         }
@@ -163,6 +179,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#descriptioncontains</remarks>
         public AndroidUiSelector DescriptionContains(string description)
         {
+            if (description == null)
+                throw new ArgumentNullException(nameof(description));
+
             _builder.AppendFormat(".descriptionContains(\"{0}\")", description);
             return this;
         }
@@ -178,6 +197,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#descriptionmatches</remarks>
         public AndroidUiSelector DescriptionMatches(string description)
         {
+            if (description == null)
+                throw new ArgumentNullException(nameof(description));
+
             _builder.AppendFormat(".descriptionMatches(\"{0}\")", description);
             return this;
         }
@@ -193,6 +215,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#descriptionstartswith</remarks>
         public AndroidUiSelector DescriptionStartsWith(string description)
         {
+            if (description == null)
+                throw new ArgumentNullException(nameof(description));
+
             _builder.AppendFormat(".descriptionStartsWith(\"{0}\")", description);
             return this;
         }
@@ -251,6 +276,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#fromparent</remarks>
         public AndroidUiSelector FromParent(AndroidUiSelector selector)
         {
+            if (selector == null)
+                throw new ArgumentNullException(nameof(selector));
+
             _builder.AppendFormat(".fromParent({0})", selector.Build());
             return this;
         }
@@ -265,6 +293,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#index</remarks>
         public AndroidUiSelector Index(int index)
         {
+            if (index < 0)
+                throw new ArgumentOutOfRangeException(nameof(index), "Must be 0 (zero) or greater");
+
             _builder.AppendFormat(".index({0})", index);
             return this;
         }
@@ -283,6 +314,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#instance</remarks>
         public AndroidUiSelector Instance(int instance)
         {
+            if (instance < 0)
+                throw new ArgumentOutOfRangeException(nameof(instance), "Must be 0 (zero) or greater");
+
             _builder.AppendFormat(".instance({0})", instance);
             return this;
         }
@@ -310,6 +344,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#packagename</remarks>
         public AndroidUiSelector PackageNameEquals(string packageName)
         {
+            if (packageName == null)
+                throw new ArgumentNullException(nameof(packageName));
+
             _builder.AppendFormat(".packageName(\"{0}\")", packageName);
             return this;
         }
@@ -322,6 +359,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#packagenamematches</remarks>
         public AndroidUiSelector PackageNameMatches(string regex)
         {
+            if (regex == null)
+                throw new ArgumentNullException(nameof(regex));
+
             _builder.AppendFormat(".packageNameMatches(\"{0}\")", regex);
             return this;
         }
@@ -334,6 +374,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#resourceid</remarks>
         public AndroidUiSelector ResourceIdEquals(string id)
         {
+            if (id == null)
+                throw new ArgumentNullException(nameof(id));
+
             _builder.AppendFormat(".resourceId(\"{0}\")", id);
             return this;
         }
@@ -346,6 +389,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#resourceidmatches</remarks>
         public AndroidUiSelector ResourceIdMatches(string regex)
         {
+            if (regex == null)
+                throw new ArgumentNullException(nameof(regex));
+
             _builder.AppendFormat(".resourceIdMatches(\"{0}\")", regex);
             return this;
         }
@@ -393,6 +439,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#text</remarks>
         public AndroidUiSelector AccessibilityIdEquals(string text)
         {
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
             // these are the same method. this version is only included to prevent confusion
             // since its kinda weird that it handles both text and accessibility-id
             return TextEquals(text);
@@ -406,6 +455,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#text</remarks>
         public AndroidUiSelector TextEquals(string text)
         {
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
             _builder.AppendFormat(".text(\"{0}\")", text);
             return this;
         }
@@ -419,6 +471,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#textcontains</remarks>
         public AndroidUiSelector TextContains(string text)
         {
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
             _builder.AppendFormat(".textContains(\"{0}\")", text);
             return this;
         }
@@ -434,6 +489,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#textmatches</remarks>
         public AndroidUiSelector TextMatches(string regex)
         {
+            if (regex == null)
+                throw new ArgumentNullException(nameof(regex));
+
             _builder.AppendFormat(".textMatches(\"{0}\")", regex);
             return this;
         }
@@ -447,6 +505,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector#textstartswith</remarks>
         public AndroidUiSelector TextStartsWith(string text)
         {
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
             _builder.AppendFormat(".textStartsWith(\"{0}\")", text);
             return this;
         }
@@ -460,6 +521,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiSelector AddRawText(string text)
         {
+            if (text == null)
+                throw new ArgumentNullException(nameof(text));
+
             _builder.Append(text);
             return this;
         }

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
@@ -1,4 +1,18 @@
-﻿using System.Text;
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+using System.Text;
 using OpenQA.Selenium.Appium.Interfaces;
 
 namespace OpenQA.Selenium.Appium.Android.UiAutomator

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
@@ -439,6 +439,19 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         }
 
         /// <summary>
+        /// Set the search criteria to match visible text in a widget that is prefixed by the text parameter.
+        /// The matching is case-insensitive.
+        /// Maps to the UiSelector.textStartsWith(String) method.
+        /// </summary>
+        /// <param name="text"></param>
+        /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector#textstartswith</remarks>
+        public AndroidUiSelector TextStartsWith(string text)
+        {
+            _builder.AppendFormat(".textStartsWith(\"{0}\")", text);
+            return this;
+        }
+
+        /// <summary>
         /// Append raw text to this <see cref="AndroidUiSelector"/> instance. The target language is Java.
         /// Text entered here will not be checked for validity. Use this at your own risk.
         /// </summary>

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
@@ -47,8 +47,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiSelector(AndroidUiSelector selector)
         {
-            if (selector == null)
-                throw new ArgumentNullException(nameof(selector));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
 
             _builder = new StringBuilder(selector.Build());
         }
@@ -96,8 +95,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#childselector</remarks>
         public AndroidUiSelector ChildSelector(AndroidUiSelector selector)
         {
-            if (selector == null)
-                throw new ArgumentNullException(nameof(selector));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
 
             _builder.AppendFormat(".childSelector({0})", selector.Build());
             return this;
@@ -111,8 +109,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#classname</remarks>
         public AndroidUiSelector ClassNameEquals(string className)
         {
-            if (className == null)
-                throw new ArgumentNullException(nameof(className));
+            _ = className ?? throw new ArgumentNullException(nameof(className));
 
             _builder.AppendFormat(".className(\"{0}\")", className);
             return this;
@@ -126,8 +123,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#classnamematches</remarks>
         public AndroidUiSelector ClassNameMatches(string regex)
         {
-            if (regex == null)
-                throw new ArgumentNullException(nameof(regex));
+            _ = regex ?? throw new ArgumentNullException(nameof(regex));
 
             _builder.AppendFormat(".classNameMatches(\"{0}\")", regex);
             return this;
@@ -161,8 +157,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#description</remarks>
         public AndroidUiSelector DescriptionEquals(string description)
         {
-            if (description == null)
-                throw new ArgumentNullException(nameof(description));
+            _ = description ?? throw new ArgumentNullException(nameof(description));
 
             _builder.AppendFormat(".description(\"{0}\")", description);
             return this;
@@ -179,8 +174,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#descriptioncontains</remarks>
         public AndroidUiSelector DescriptionContains(string description)
         {
-            if (description == null)
-                throw new ArgumentNullException(nameof(description));
+            _ = description ?? throw new ArgumentNullException(nameof(description));
 
             _builder.AppendFormat(".descriptionContains(\"{0}\")", description);
             return this;
@@ -197,8 +191,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#descriptionmatches</remarks>
         public AndroidUiSelector DescriptionMatches(string description)
         {
-            if (description == null)
-                throw new ArgumentNullException(nameof(description));
+            _ = description ?? throw new ArgumentNullException(nameof(description));
 
             _builder.AppendFormat(".descriptionMatches(\"{0}\")", description);
             return this;
@@ -215,8 +208,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#descriptionstartswith</remarks>
         public AndroidUiSelector DescriptionStartsWith(string description)
         {
-            if (description == null)
-                throw new ArgumentNullException(nameof(description));
+            _ = description ?? throw new ArgumentNullException(nameof(description));
 
             _builder.AppendFormat(".descriptionStartsWith(\"{0}\")", description);
             return this;
@@ -276,8 +268,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#fromparent</remarks>
         public AndroidUiSelector FromParent(AndroidUiSelector selector)
         {
-            if (selector == null)
-                throw new ArgumentNullException(nameof(selector));
+            _ = selector ?? throw new ArgumentNullException(nameof(selector));
 
             _builder.AppendFormat(".fromParent({0})", selector.Build());
             return this;
@@ -344,8 +335,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#packagename</remarks>
         public AndroidUiSelector PackageNameEquals(string packageName)
         {
-            if (packageName == null)
-                throw new ArgumentNullException(nameof(packageName));
+            _ = packageName ?? throw new ArgumentNullException(nameof(packageName));
 
             _builder.AppendFormat(".packageName(\"{0}\")", packageName);
             return this;
@@ -359,8 +349,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#packagenamematches</remarks>
         public AndroidUiSelector PackageNameMatches(string regex)
         {
-            if (regex == null)
-                throw new ArgumentNullException(nameof(regex));
+            _ = regex ?? throw new ArgumentNullException(nameof(regex));
 
             _builder.AppendFormat(".packageNameMatches(\"{0}\")", regex);
             return this;
@@ -374,8 +363,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#resourceid</remarks>
         public AndroidUiSelector ResourceIdEquals(string id)
         {
-            if (id == null)
-                throw new ArgumentNullException(nameof(id));
+            _ = id ?? throw new ArgumentNullException(nameof(id));
 
             _builder.AppendFormat(".resourceId(\"{0}\")", id);
             return this;
@@ -389,8 +377,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#resourceidmatches</remarks>
         public AndroidUiSelector ResourceIdMatches(string regex)
         {
-            if (regex == null)
-                throw new ArgumentNullException(nameof(regex));
+            _ = regex ?? throw new ArgumentNullException(nameof(regex));
 
             _builder.AppendFormat(".resourceIdMatches(\"{0}\")", regex);
             return this;
@@ -439,8 +426,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#text</remarks>
         public AndroidUiSelector AccessibilityIdEquals(string text)
         {
-            if (text == null)
-                throw new ArgumentNullException(nameof(text));
+            _ = text ?? throw new ArgumentNullException(nameof(text));
 
             // these are the same method. this version is only included to prevent confusion
             // since its kinda weird that it handles both text and accessibility-id
@@ -455,8 +441,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#text</remarks>
         public AndroidUiSelector TextEquals(string text)
         {
-            if (text == null)
-                throw new ArgumentNullException(nameof(text));
+            _ = text ?? throw new ArgumentNullException(nameof(text));
 
             _builder.AppendFormat(".text(\"{0}\")", text);
             return this;
@@ -471,8 +456,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#textcontains</remarks>
         public AndroidUiSelector TextContains(string text)
         {
-            if (text == null)
-                throw new ArgumentNullException(nameof(text));
+            _ = text ?? throw new ArgumentNullException(nameof(text));
 
             _builder.AppendFormat(".textContains(\"{0}\")", text);
             return this;
@@ -489,8 +473,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#textmatches</remarks>
         public AndroidUiSelector TextMatches(string regex)
         {
-            if (regex == null)
-                throw new ArgumentNullException(nameof(regex));
+            _ = regex ?? throw new ArgumentNullException(nameof(regex));
 
             _builder.AppendFormat(".textMatches(\"{0}\")", regex);
             return this;
@@ -505,8 +488,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector#textstartswith</remarks>
         public AndroidUiSelector TextStartsWith(string text)
         {
-            if (text == null)
-                throw new ArgumentNullException(nameof(text));
+            _ = text ?? throw new ArgumentNullException(nameof(text));
 
             _builder.AppendFormat(".textStartsWith(\"{0}\")", text);
             return this;
@@ -521,8 +503,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiSelector AddRawText(string text)
         {
-            if (text == null)
-                throw new ArgumentNullException(nameof(text));
+            _ = text ?? throw new ArgumentNullException(nameof(text));
 
             _builder.Append(text);
             return this;

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
@@ -46,7 +46,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiSelector(AndroidUiSelector selector)
         {
-            _builder = new StringBuilder(selector.Compile());
+            _builder = new StringBuilder(selector.Build());
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#childselector</remarks>
         public AndroidUiSelector ChildSelector(AndroidUiSelector selector)
         {
-            _builder.AppendFormat(".childSelector({0})", selector.Compile());
+            _builder.AppendFormat(".childSelector({0})", selector.Build());
             return this;
         }
 
@@ -251,7 +251,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#fromparent</remarks>
         public AndroidUiSelector FromParent(AndroidUiSelector selector)
         {
-            _builder.AppendFormat(".fromParent({0})", selector.Compile());
+            _builder.AppendFormat(".fromParent({0})", selector.Build());
             return this;
         }
 
@@ -456,7 +456,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// been added to this instance.
         /// </summary>
         /// <returns></returns>
-        public string Compile()
+        public string Build()
         {
             return _builder.ToString();
         }

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
@@ -79,7 +79,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#checked</remarks>
         public AndroidUiSelector IsChecked(bool value)
         {
-            _builder.AppendFormat(".checkable({0})", value.ToString().ToLowerInvariant());
+            _builder.AppendFormat(".checked({0})", value.ToString().ToLowerInvariant());
             return this;
         }
 

--- a/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/AndroidUiSelector.cs
@@ -12,7 +12,6 @@
 //See the License for the specific language governing permissions and
 //limitations under the License.
 
-using System;
 using System.Text;
 using OpenQA.Selenium.Appium.Interfaces;
 
@@ -47,9 +46,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiSelector(AndroidUiSelector selector)
         {
-            _ = selector ?? throw new ArgumentNullException(nameof(selector));
-
-            _builder = new StringBuilder(selector.Build());
+            _builder = new StringBuilder(selector.RequireNotNull(nameof(selector)).Build());
         }
 
         /// <summary>
@@ -95,9 +92,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#childselector</remarks>
         public AndroidUiSelector ChildSelector(AndroidUiSelector selector)
         {
-            _ = selector ?? throw new ArgumentNullException(nameof(selector));
-
-            _builder.AppendFormat(".childSelector({0})", selector.Build());
+            _builder.AppendFormat(".childSelector({0})", selector.RequireNotNull(nameof(selector)).Build());
             return this;
         }
 
@@ -109,9 +104,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#classname</remarks>
         public AndroidUiSelector ClassNameEquals(string className)
         {
-            _ = className ?? throw new ArgumentNullException(nameof(className));
-
-            _builder.AppendFormat(".className(\"{0}\")", className);
+            _builder.AppendFormat(".className(\"{0}\")", className.RequireNotNull(nameof(className)));
             return this;
         }
 
@@ -123,9 +116,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#classnamematches</remarks>
         public AndroidUiSelector ClassNameMatches(string regex)
         {
-            _ = regex ?? throw new ArgumentNullException(nameof(regex));
-
-            _builder.AppendFormat(".classNameMatches(\"{0}\")", regex);
+            _builder.AppendFormat(".classNameMatches(\"{0}\")", regex.RequireNotNull(nameof(regex)));
             return this;
         }
 
@@ -157,9 +148,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#description</remarks>
         public AndroidUiSelector DescriptionEquals(string description)
         {
-            _ = description ?? throw new ArgumentNullException(nameof(description));
-
-            _builder.AppendFormat(".description(\"{0}\")", description);
+            _builder.AppendFormat(".description(\"{0}\")", description.RequireNotNull(nameof(description)));
             return this;
         }
 
@@ -174,9 +163,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#descriptioncontains</remarks>
         public AndroidUiSelector DescriptionContains(string description)
         {
-            _ = description ?? throw new ArgumentNullException(nameof(description));
-
-            _builder.AppendFormat(".descriptionContains(\"{0}\")", description);
+            _builder.AppendFormat(".descriptionContains(\"{0}\")", description.RequireNotNull(nameof(description)));
             return this;
         }
 
@@ -191,9 +178,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#descriptionmatches</remarks>
         public AndroidUiSelector DescriptionMatches(string description)
         {
-            _ = description ?? throw new ArgumentNullException(nameof(description));
-
-            _builder.AppendFormat(".descriptionMatches(\"{0}\")", description);
+            _builder.AppendFormat(".descriptionMatches(\"{0}\")", description.RequireNotNull(nameof(description)));
             return this;
         }
 
@@ -208,9 +193,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#descriptionstartswith</remarks>
         public AndroidUiSelector DescriptionStartsWith(string description)
         {
-            _ = description ?? throw new ArgumentNullException(nameof(description));
-
-            _builder.AppendFormat(".descriptionStartsWith(\"{0}\")", description);
+            _builder.AppendFormat(".descriptionStartsWith(\"{0}\")", description.RequireNotNull(nameof(description)));
             return this;
         }
 
@@ -268,9 +251,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#fromparent</remarks>
         public AndroidUiSelector FromParent(AndroidUiSelector selector)
         {
-            _ = selector ?? throw new ArgumentNullException(nameof(selector));
-
-            _builder.AppendFormat(".fromParent({0})", selector.Build());
+            _builder.AppendFormat(".fromParent({0})", selector.RequireNotNull(nameof(selector)).Build());
             return this;
         }
 
@@ -284,10 +265,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#index</remarks>
         public AndroidUiSelector Index(int index)
         {
-            if (index < 0)
-                throw new ArgumentOutOfRangeException(nameof(index), "Must be 0 (zero) or greater");
-
-            _builder.AppendFormat(".index({0})", index);
+            _builder.AppendFormat(".index({0})", index.RequireIsPositive(nameof(index)));
             return this;
         }
 
@@ -305,10 +283,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#instance</remarks>
         public AndroidUiSelector Instance(int instance)
         {
-            if (instance < 0)
-                throw new ArgumentOutOfRangeException(nameof(instance), "Must be 0 (zero) or greater");
-
-            _builder.AppendFormat(".instance({0})", instance);
+            _builder.AppendFormat(".instance({0})", instance.RequireIsPositive(nameof(instance)));
             return this;
         }
 
@@ -335,9 +310,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#packagename</remarks>
         public AndroidUiSelector PackageNameEquals(string packageName)
         {
-            _ = packageName ?? throw new ArgumentNullException(nameof(packageName));
-
-            _builder.AppendFormat(".packageName(\"{0}\")", packageName);
+            _builder.AppendFormat(".packageName(\"{0}\")", packageName.RequireNotNull(nameof(packageName)));
             return this;
         }
 
@@ -349,9 +322,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#packagenamematches</remarks>
         public AndroidUiSelector PackageNameMatches(string regex)
         {
-            _ = regex ?? throw new ArgumentNullException(nameof(regex));
-
-            _builder.AppendFormat(".packageNameMatches(\"{0}\")", regex);
+            _builder.AppendFormat(".packageNameMatches(\"{0}\")", regex.RequireNotNull(nameof(regex)));
             return this;
         }
 
@@ -363,9 +334,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#resourceid</remarks>
         public AndroidUiSelector ResourceIdEquals(string id)
         {
-            _ = id ?? throw new ArgumentNullException(nameof(id));
-
-            _builder.AppendFormat(".resourceId(\"{0}\")", id);
+            _builder.AppendFormat(".resourceId(\"{0}\")", id.RequireNotNull(nameof(id)));
             return this;
         }
 
@@ -377,9 +346,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#resourceidmatches</remarks>
         public AndroidUiSelector ResourceIdMatches(string regex)
         {
-            _ = regex ?? throw new ArgumentNullException(nameof(regex));
-
-            _builder.AppendFormat(".resourceIdMatches(\"{0}\")", regex);
+            _builder.AppendFormat(".resourceIdMatches(\"{0}\")", regex.RequireNotNull(nameof(regex)));
             return this;
         }
 
@@ -426,11 +393,9 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#text</remarks>
         public AndroidUiSelector AccessibilityIdEquals(string text)
         {
-            _ = text ?? throw new ArgumentNullException(nameof(text));
-
             // these are the same method. this version is only included to prevent confusion
             // since its kinda weird that it handles both text and accessibility-id
-            return TextEquals(text);
+            return TextEquals(text.RequireNotNull(nameof(text)));
         }
 
         /// <summary>
@@ -441,9 +406,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#text</remarks>
         public AndroidUiSelector TextEquals(string text)
         {
-            _ = text ?? throw new ArgumentNullException(nameof(text));
-
-            _builder.AppendFormat(".text(\"{0}\")", text);
+            _builder.AppendFormat(".text(\"{0}\")", text.RequireNotNull(nameof(text)));
             return this;
         }
 
@@ -456,9 +419,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector.html#textcontains</remarks>
         public AndroidUiSelector TextContains(string text)
         {
-            _ = text ?? throw new ArgumentNullException(nameof(text));
-
-            _builder.AppendFormat(".textContains(\"{0}\")", text);
+            _builder.AppendFormat(".textContains(\"{0}\")", text.RequireNotNull(nameof(text)));
             return this;
         }
 
@@ -473,9 +434,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/androidx/test/uiautomator/UiSelector#textmatches</remarks>
         public AndroidUiSelector TextMatches(string regex)
         {
-            _ = regex ?? throw new ArgumentNullException(nameof(regex));
-
-            _builder.AppendFormat(".textMatches(\"{0}\")", regex);
+            _builder.AppendFormat(".textMatches(\"{0}\")", regex.RequireNotNull(nameof(regex)));
             return this;
         }
 
@@ -488,9 +447,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// <remarks>https://developer.android.com/reference/android/support/test/uiautomator/UiSelector#textstartswith</remarks>
         public AndroidUiSelector TextStartsWith(string text)
         {
-            _ = text ?? throw new ArgumentNullException(nameof(text));
-
-            _builder.AppendFormat(".textStartsWith(\"{0}\")", text);
+            _builder.AppendFormat(".textStartsWith(\"{0}\")", text.RequireNotNull(nameof(text)));
             return this;
         }
 
@@ -503,9 +460,7 @@ namespace OpenQA.Selenium.Appium.Android.UiAutomator
         /// </param>
         public AndroidUiSelector AddRawText(string text)
         {
-            _ = text ?? throw new ArgumentNullException(nameof(text));
-
-            _builder.Append(text);
+            _builder.Append(text.RequireNotNull(nameof(text)));
             return this;
         }
 

--- a/src/Appium.Net/Appium/Android/UiAutomator/TerminatedStatementBuilder.cs
+++ b/src/Appium.Net/Appium/Android/UiAutomator/TerminatedStatementBuilder.cs
@@ -1,0 +1,20 @@
+﻿using System.Text;
+using OpenQA.Selenium.Appium.Interfaces;
+
+namespace OpenQA.Selenium.Appium.Android.UiAutomator
+{
+    public class TerminatedStatementBuilder : IUiAutomatorStatementBuilder
+    {
+        private readonly StringBuilder _builder;
+
+        internal TerminatedStatementBuilder(StringBuilder builder)
+        {
+            _builder = builder;
+        }
+
+        public string Build()
+        {
+            return _builder.ToString();
+        }
+    }
+}

--- a/src/Appium.Net/Appium/GuardClauses.cs
+++ b/src/Appium.Net/Appium/GuardClauses.cs
@@ -1,0 +1,60 @@
+﻿using System;
+
+namespace OpenQA.Selenium.Appium
+{
+    public static class GuardClauses
+    {
+        /// <summary>
+        /// The given value must not be null, otherwise an <see cref="ArgumentNullException"/>
+        /// will be thrown.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="value">The value to test</param>
+        /// <param name="paramName">
+        /// The name of the parameter which is being checked. This is to help identify
+        /// the parameter which did not meet the requirement. Use nameof() to ensure
+        /// proper refactoring support.
+        /// </param>
+        public static T RequireNotNull<T>(this T value, string paramName) where T : class
+        {
+            return value ?? throw new ArgumentNullException(paramName);
+        }
+
+        /// <summary>
+        /// The given value must be greater than or equal to 0 (zero), otherwise
+        /// an <see cref="ArgumentOutOfRangeException"/> will be thrown.
+        /// </summary>
+        /// <param name="value">The value to test</param>
+        /// <param name="paramName">
+        /// The name of the parameter which is being checked. This is to help identify
+        /// the parameter which did not meet the requirement. Use nameof() to ensure
+        /// proper refactoring support.
+        /// </param>
+        public static int RequireIsPositive(this int value, string paramName)
+        {
+            if (value >= 0)
+                return value;
+
+            throw new ArgumentOutOfRangeException(paramName, "Must be 0 (zero) or greater");
+        }
+
+        /// <summary>
+        /// The given value must be between 0 and 1, otherwise an <see cref="ArgumentOutOfRangeException"/>
+        /// will be thrown.
+        /// </summary>
+        /// <param name="value">The value to test</param>
+        /// <param name="paramName">
+        /// The name of the parameter which is being checked. This is to help identify
+        /// the parameter which did not meet the requirement. Use nameof() to ensure
+        /// proper refactoring support.
+        /// </param>
+        /// <returns></returns>
+        public static double RequirePercentage(this double value, string paramName)
+        {
+            if (value > 0 && value < 1)
+                return value;
+
+            throw new ArgumentOutOfRangeException(paramName, "Must be a value between 0 and 1");
+        }
+    }
+}

--- a/src/Appium.Net/Appium/Interfaces/IFindByAndroidUIAutomator.cs
+++ b/src/Appium.Net/Appium/Interfaces/IFindByAndroidUIAutomator.cs
@@ -33,6 +33,14 @@ namespace OpenQA.Selenium.Appium.Interfaces
         W FindElementByAndroidUIAutomator(string selector);
 
         /// <summary>
+        /// Finds the first element in the page that matches the Android UIAutomator selector supplied
+        /// </summary>
+        /// <param name="selector">Selector for the element.</param>
+        /// <returns>IWebElement object so that you can interact that object</returns>
+        W FindElementByAndroidUIAutomator(IUiAutomatorStatementBuilder selector);
+
+
+        /// <summary>
         /// Finds a list of elements that match the Android UIAutomator selector supplied
         /// </summary>
         /// <param name="selector">Selector for the elements.</param>
@@ -44,5 +52,12 @@ namespace OpenQA.Selenium.Appium.Interfaces
         /// </code>
         /// </example>
         IReadOnlyCollection<W> FindElementsByAndroidUIAutomator(string selector);
+
+        /// <summary>
+        /// Finds a list of elements that match the Android UIAutomator selector supplied
+        /// </summary>
+        /// <param name="selector">Selector for the elements.</param>
+        /// <returns>ReadOnlyCollection of IWebElement object so that you can interact with those objects</returns>
+        IReadOnlyCollection<W> FindElementsByAndroidUIAutomator(IUiAutomatorStatementBuilder selector);
     }
 }

--- a/src/Appium.Net/Appium/Interfaces/IUiAutomatorStatementBuilder.cs
+++ b/src/Appium.Net/Appium/Interfaces/IUiAutomatorStatementBuilder.cs
@@ -16,6 +16,6 @@ namespace OpenQA.Selenium.Appium.Interfaces
 {
     public interface IUiAutomatorStatementBuilder
     {
-        string Compile();
+        string Build();
     }
 }

--- a/src/Appium.Net/Appium/Interfaces/IUiAutomatorStatementBuilder.cs
+++ b/src/Appium.Net/Appium/Interfaces/IUiAutomatorStatementBuilder.cs
@@ -1,4 +1,18 @@
-﻿namespace OpenQA.Selenium.Appium.Interfaces
+﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//you may not use this file except in compliance with the License.
+//See the NOTICE file distributed with this work for additional
+//information regarding copyright ownership.
+//You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS,
+//WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//See the License for the specific language governing permissions and
+//limitations under the License.
+
+namespace OpenQA.Selenium.Appium.Interfaces
 {
     public interface IUiAutomatorStatementBuilder
     {

--- a/src/Appium.Net/Appium/Interfaces/IUiAutomatorStatementBuilder.cs
+++ b/src/Appium.Net/Appium/Interfaces/IUiAutomatorStatementBuilder.cs
@@ -1,0 +1,7 @@
+﻿namespace OpenQA.Selenium.Appium.Interfaces
+{
+    public interface IUiAutomatorStatementBuilder
+    {
+        string Compile();
+    }
+}

--- a/src/Appium.Net/Appium/MobileBy.cs
+++ b/src/Appium.Net/Appium/MobileBy.cs
@@ -87,6 +87,15 @@ namespace OpenQA.Selenium.Appium
         public static By AndroidUIAutomator(string selector) => new ByAndroidUIAutomator(selector);
 
         /// <summary>
+        /// This method creates a <see cref="OpenQA.Selenium.By"/> strategy 
+        /// that searches for elements using Android UI automation framework.
+        /// <see cref="http://developer.android.com/intl/ru/tools/testing-support-library/index.html#uia-apis"/>
+        /// </summary>
+        /// <param name="selector">The selector to use in finding the element.</param>
+        /// <returns></returns>
+        public static By AndroidUIAutomator(IUiAutomatorStatementBuilder selector) => new ByAndroidUIAutomator(selector);
+
+        /// <summary>
         /// This method creates a <see cref="OpenQA.Selenium.By"/> strategy
         /// that searches for elements using Espresso's Data Matcher.
         /// <see cref="http://appium.io/docs/en/writing-running-appium/android/espresso-datamatcher-selector"/>
@@ -161,6 +170,14 @@ namespace OpenQA.Selenium.Appium
         /// </summary>
         /// <param name="selector">The selector to use in finding the element.</param>
         public ByAndroidUIAutomator(string selector) : base(selector, MobileSelector.AndroidUIAutomator)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ByAndroidUIAutomator"/> class.
+        /// </summary>
+        /// <param name="selector">The selector to use in finding the element.</param>
+        public ByAndroidUIAutomator(IUiAutomatorStatementBuilder selector) : base(selector.Compile(), MobileSelector.AndroidUIAutomator)
         {
         }
 

--- a/src/Appium.Net/Appium/MobileBy.cs
+++ b/src/Appium.Net/Appium/MobileBy.cs
@@ -177,7 +177,7 @@ namespace OpenQA.Selenium.Appium
         /// Initializes a new instance of the <see cref="ByAndroidUIAutomator"/> class.
         /// </summary>
         /// <param name="selector">The selector to use in finding the element.</param>
-        public ByAndroidUIAutomator(IUiAutomatorStatementBuilder selector) : base(selector.Compile(), MobileSelector.AndroidUIAutomator)
+        public ByAndroidUIAutomator(IUiAutomatorStatementBuilder selector) : base(selector.Build(), MobileSelector.AndroidUIAutomator)
         {
         }
 

--- a/test/integration/Android/AndroidUiScrollableTests.cs
+++ b/test/integration/Android/AndroidUiScrollableTests.cs
@@ -1,0 +1,193 @@
+﻿using System;
+using NUnit.Framework;
+using OpenQA.Selenium.Appium.Android.Enums;
+using OpenQA.Selenium.Appium.Android.UiAutomator;
+
+namespace Appium.Net.Integration.Tests.Android
+{
+    public class AndroidUiScrollableTests
+    {
+        private AndroidUiScrollable _sut;
+        private const string ScrollableCtor = "new UiScrollable(new UiSelector().scrollable(true))";
+
+        [SetUp]
+        public void Setup()
+        {
+            _sut = new AndroidUiScrollable();
+        }
+
+        [Test]
+        public void NewScrollablesStartWithEmptyConstructorCall()
+        {
+            var statement = _sut.Build();
+            Assert.AreEqual(ScrollableCtor, statement);
+        }
+
+        [Test]
+        public void NewScrollableUsesCustomScrollContainerSelector()
+        {
+            var selector = new AndroidUiSelector().Instance(7);
+            var statement = new AndroidUiScrollable(selector).Build();
+            Assert.AreEqual("new UiScrollable(new UiSelector().instance(7))", statement);
+        }
+
+        [Test]
+        public void FlingBackwardAddsCorrectCallToStatement()
+        {
+            var statement = _sut.FlingBackward().Build();
+            Assert.AreEqual(ScrollableCtor + ".flingBackward()", statement);
+        }
+
+        [Test]
+        public void FlingForwardAddsCorrectCallToStatement()
+        {
+            var statement = _sut.FlingForward().Build();
+            Assert.AreEqual(ScrollableCtor + ".flingForward()", statement);
+        }
+
+        [Test]
+        public void FlingToBeginningAddsCorrectCallToStatement()
+        {
+            var statement = _sut.FlingToBeginning(45).Build();
+            Assert.AreEqual(ScrollableCtor + ".flingToBeginning(45)", statement);
+        }
+
+        [Test]
+        public void FlingToEndAddsCorrectCallToStatement()
+        {
+            var statement = _sut.FlingToEnd(77).Build();
+            Assert.AreEqual(ScrollableCtor + ".flingToEnd(77)", statement);
+        }
+
+        [Test]
+        public void GetChildByDescriptionAddsCorrectCallToStatement()
+        {
+            var statement = _sut.GetChildByDescription(new AndroidUiSelector(), "Hello World", false).Build();
+            Assert.AreEqual(ScrollableCtor + ".getChildByDescription(new UiSelector(), \"Hello World\", false)", statement);
+        }
+
+        [Test]
+        public void GetChildByInstanceAddsCorrectCallToStatement()
+        {
+            var statement = _sut.GetChildByInstance(new AndroidUiSelector(), 9).Build();
+            Assert.AreEqual(ScrollableCtor + ".getChildByInstance(new UiSelector(), 9)", statement);
+        }
+
+        [Test]
+        public void GetChildByTextAddsCorrectCallToStatement()
+        {
+            var statement = _sut.GetChildByText(new AndroidUiSelector(), "Help", false).Build();
+            Assert.AreEqual(ScrollableCtor + ".getChildByText(new UiSelector(), \"Help\", false)", statement);
+        }
+
+        [Test]
+        public void ScrollBackwardAddsCorrectCallToStatement()
+        {
+            var statement = _sut.ScrollBackward(32).Build();
+            Assert.AreEqual(ScrollableCtor + ".scrollBackward(32)", statement);
+        }
+
+        [Test]
+        public void ScrollDescriptionIntoViewAddsCorrectCallToStatement()
+        {
+            var statement = _sut.ScrollDescriptionIntoView("Description Here").Build();
+            Assert.AreEqual(ScrollableCtor + ".scrollDescriptionIntoView(\"Description Here\")", statement);
+        }
+
+        [Test]
+        public void ScrollForwardAddsCorrectCallToStatement()
+        {
+            var statement = _sut.ScrollForward(46).Build();
+            Assert.AreEqual(ScrollableCtor + ".scrollForward(46)", statement);
+        }
+
+        [Test]
+        public void ScrollIntoViewAddsCorrectCallToStatement()
+        {
+            var statement = _sut.ScrollIntoView(new AndroidUiSelector()).Build();
+            Assert.AreEqual(ScrollableCtor + ".scrollIntoView(new UiSelector())", statement);
+        }
+
+        [Test]
+        public void ScrollTextIntoViewAddsCorrectCallToStatement()
+        {
+            var statement = _sut.ScrollTextIntoView("Some Text").Build();
+            Assert.AreEqual(ScrollableCtor + ".scrollTextIntoView(\"Some Text\")", statement);
+        }
+
+        [Test]
+        public void ScrollToBeginningAddsCorrectCallToStatement()
+        {
+            var statement = _sut.ScrollToBeginning(12, 90).Build();
+            Assert.AreEqual(ScrollableCtor + ".scrollToBeginning(12, 90)", statement);
+        }
+
+        [Test]
+        public void ScrollToEndAddsCorrectCallToStatement()
+        {
+            var statement = _sut.ScrollToEnd(32, 51).Build();
+            Assert.AreEqual(ScrollableCtor + ".scrollToEnd(32, 51)", statement);
+        }
+
+        [Test]
+        public void SetScrollDirectionVerticalAddsCorrectCallToStatement()
+        {
+            var statement = _sut.SetScrollDirection(ListDirection.Vertical).Build();
+            Assert.AreEqual(ScrollableCtor + ".setAsVerticalList()", statement);
+        }
+
+        [Test]
+        public void SetScrollDirectionHorizontalAddsCorrectCallToStatement()
+        {
+            var statement = _sut.SetScrollDirection(ListDirection.Horizontal).Build();
+            Assert.AreEqual(ScrollableCtor + ".setAsHorizontalList()", statement);
+        }
+
+        [Test]
+        public void SetMaxSearchSwipesAddsCorrectCallToStatement()
+        {
+            var statement = _sut.SetMaxSearchSwipes(80).Build();
+            Assert.AreEqual(ScrollableCtor + ".setMaxSearchSwipes(80)", statement);
+        }
+
+        [Test]
+        public void SetSwipeDeadZonePercentageAddsCorrectCallToStatement()
+        {
+            var statement = _sut.SetSwipeDeadZonePercentage(.67).Build();
+            Assert.AreEqual(ScrollableCtor + ".setSwipeDeadZonePercentage(0.67)", statement);
+        }
+
+        [TestCase(1.1)]
+        [TestCase(-1)]
+        public void SetSwipeDeadZonePercentageThrowsExceptionIfOutOfRange(double invalidValue)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => 
+                _sut.SetSwipeDeadZonePercentage(invalidValue));
+        }
+
+        [Test]
+        public void SomeStatementsCanBeChained()
+        {
+            var statement = _sut
+                .SetSwipeDeadZonePercentage(0.11)
+                .SetMaxSearchSwipes(44)
+                .Build();
+            Assert.AreEqual(ScrollableCtor + ".setSwipeDeadZonePercentage(0.11).setMaxSearchSwipes(44)", statement);
+        }
+
+        [Test]
+        public void AddRawTextAppendsText()
+        {
+            var statment = _sut.AddRawText("@").Build();
+            Assert.AreEqual(ScrollableCtor + "@", statment);
+        }
+
+        [Test]
+        public void RequestingStatementTerminationOnBuildAppendsSemicolon()
+        {
+            var statement = _sut.SetSwipeDeadZonePercentage(.67).Build(true);
+            var lastCharOfStatement = statement[statement.Length - 1];
+            Assert.AreEqual(';', lastCharOfStatement);
+        }
+    }
+}

--- a/test/integration/Android/AndroidUiSelectorTests.cs
+++ b/test/integration/Android/AndroidUiSelectorTests.cs
@@ -1,0 +1,232 @@
+﻿using NUnit.Framework;
+using OpenQA.Selenium.Appium.Android.UiAutomator;
+
+namespace Appium.Net.Integration.Tests.Android
+{
+    public class AndroidUiSelectorTests
+    {
+        private AndroidUiSelector _sut;
+        private const string CtorStatement = "new UiSelector()";
+
+        [SetUp]
+        public void Setup()
+        {
+            _sut = new AndroidUiSelector();
+        }
+
+        [Test]
+        public void NewSelectorStartsWithJustConstructorCall()
+        {
+            var statment = _sut.Build();
+            Assert.AreEqual(CtorStatement, statment);
+        }
+
+        [Test]
+        public void IsCheckableAddsCorrectCallToStatement()
+        {
+            var statment = _sut.IsCheckable(true).Build();
+            Assert.AreEqual(CtorStatement + ".checkable(true)", statment);
+        }
+
+        [Test]
+        public void IsCheckedAddsCorrectCallToStatement()
+        {
+            var statment = _sut.IsChecked(false).Build();
+            Assert.AreEqual(CtorStatement + ".checked(false)", statment);
+        }
+
+        [Test]
+        public void ChildSelectorAddsCorrectCallToStatement()
+        {
+            var statment = _sut.ChildSelector(new AndroidUiSelector()).Build();
+            Assert.AreEqual(CtorStatement + $".childSelector({CtorStatement})", statment);
+        }
+
+        [Test]
+        public void ClassNameEqualsAddsCorrectCallToStatement()
+        {
+            var statment = _sut.ClassNameEquals("Class1").Build();
+            Assert.AreEqual(CtorStatement + ".className(\"Class1\")", statment);
+        }
+
+        [Test]
+        public void ClassNameMatchesAddsCorrectCallToStatement()
+        {
+            var statment = _sut.ClassNameMatches("regex").Build();
+            Assert.AreEqual(CtorStatement + ".classNameMatches(\"regex\")", statment);
+        }
+
+        [Test]
+        public void IsClickableAddsCorrectCallToStatement()
+        {
+            var statment = _sut.IsClickable(true).Build();
+            Assert.AreEqual(CtorStatement + ".clickable(true)", statment);
+        }
+
+        [Test]
+        public void DescriptionEqualsAddsCorrectCallToStatement()
+        {
+            var statment = _sut.DescriptionEquals("Desc").Build();
+            Assert.AreEqual(CtorStatement + ".description(\"Desc\")", statment);
+        }
+
+        [Test]
+        public void DescriptionContainsAddsCorrectCallToStatement()
+        {
+            var statment = _sut.DescriptionContains("Val").Build();
+            Assert.AreEqual(CtorStatement + ".descriptionContains(\"Val\")", statment);
+        }
+
+        [Test]
+        public void DescriptionMatchesAddsCorrectCallToStatement()
+        {
+            var statment = _sut.DescriptionMatches("regex").Build();
+            Assert.AreEqual(CtorStatement + ".descriptionMatches(\"regex\")", statment);
+        }
+
+        [Test]
+        public void DescriptionStartsWithAddsCorrectCallToStatement()
+        {
+            var statment = _sut.DescriptionStartsWith("Hello").Build();
+            Assert.AreEqual(CtorStatement + ".descriptionStartsWith(\"Hello\")", statment);
+        }
+
+        [Test]
+        public void IsEnabledAddsCorrectCallToStatement()
+        {
+            var statment = _sut.IsEnabled(true).Build();
+            Assert.AreEqual(CtorStatement + ".enabled(true)", statment);
+        }
+
+        [Test]
+        public void IsFocusableAddsCorrectCallToStatement()
+        {
+            var statment = _sut.IsFocusable(true).Build();
+            Assert.AreEqual(CtorStatement + ".focusable(true)", statment);
+        }
+
+        [Test]
+        public void IsFocusedAddsCorrectCallToStatement()
+        {
+            var statment = _sut.IsFocused(false).Build();
+            Assert.AreEqual(CtorStatement + ".focused(false)", statment);
+        }
+
+        [Test]
+        public void FromParentAddsCorrectCallToStatement()
+        {
+            var statment = _sut.FromParent(new AndroidUiSelector()).Build();
+            Assert.AreEqual(CtorStatement + $".fromParent({CtorStatement})", statment);
+        }
+
+        [Test]
+        public void IndexAddsCorrectCallToStatement()
+        {
+            var statment = _sut.Index(7).Build();
+            Assert.AreEqual(CtorStatement + ".index(7)", statment);
+        }
+
+        [Test]
+        public void InstanceAddsCorrectCallToStatement()
+        {
+            var statment = _sut.Instance(4).Build();
+            Assert.AreEqual(CtorStatement + ".instance(4)", statment);
+        }
+
+        [Test]
+        public void LongClickableAddsCorrectCallToStatement()
+        {
+            var statment = _sut.IsLongClickable(false).Build();
+            Assert.AreEqual(CtorStatement + ".longClickable(false)", statment);
+        }
+
+        [Test]
+        public void PackageNameEqualsAddsCorrectCallToStatement()
+        {
+            var statment = _sut.PackageNameEquals("com.org.unique").Build();
+            Assert.AreEqual(CtorStatement + ".packageName(\"com.org.unique\")", statment);
+        }
+
+        [Test]
+        public void PackageNameMatchesAddsCorrectCallToStatement()
+        {
+            var statment = _sut.PackageNameMatches("regex").Build();
+            Assert.AreEqual(CtorStatement + ".packageNameMatches(\"regex\")", statment);
+        }
+
+        [Test]
+        public void ResourceIdEqualsAddsCorrectCallToStatement()
+        {
+            var statment = _sut.ResourceIdEquals("my-id").Build();
+            Assert.AreEqual(CtorStatement + ".resourceId(\"my-id\")", statment);
+        }
+
+        [Test]
+        public void ResourceIdMatchesAddsCorrectCallToStatement()
+        {
+            var statment = _sut.ResourceIdMatches("regex").Build();
+            Assert.AreEqual(CtorStatement + ".resourceIdMatches(\"regex\")", statment);
+        }
+
+        [Test]
+        public void IsScrollableAddsCorrectCallToStatement()
+        {
+            var statment = _sut.IsScrollable(true).Build();
+            Assert.AreEqual(CtorStatement + ".scrollable(true)", statment);
+        }
+
+        [Test]
+        public void IsSelectedAddsCorrectCallToStatement()
+        {
+            var statment = _sut.IsSelected(false).Build();
+            Assert.AreEqual(CtorStatement + ".selected(false)", statment);
+        }
+
+        [Test]
+        public void TextEqualsAddsCorrectCallToStatement()
+        {
+            var statment = _sut.TextEquals("some text").Build();
+            Assert.AreEqual(CtorStatement + ".text(\"some text\")", statment);
+        }
+
+        [Test]
+        public void TextContainsAddsCorrectCallToStatement()
+        {
+            var statment = _sut.TextContains("some text").Build();
+            Assert.AreEqual(CtorStatement + ".textContains(\"some text\")", statment);
+        }
+
+        [Test]
+        public void TextMatchesAddsCorrectCallToStatement()
+        {
+            var statment = _sut.TextMatches("some text").Build();
+            Assert.AreEqual(CtorStatement + ".textMatches(\"some text\")", statment);
+        }
+
+        [Test]
+        public void TextStartsWithAddsCorrectCallToStatement()
+        {
+            var statment = _sut.TextStartsWith("some text").Build();
+            Assert.AreEqual(CtorStatement + ".textStartsWith(\"some text\")", statment);
+        }
+
+        [Test]
+        public void AddRawTextAppendsText()
+        {
+            var statment = _sut.AddRawText("@").Build();
+            Assert.AreEqual(CtorStatement + "@", statment);
+        }
+
+        [Test]
+        public void CanChainCalls()
+        {
+            var statment = _sut
+                .ResourceIdMatches(".*my_id")
+                .ClassNameEquals("andoid.widget.TextField")
+                .IsLongClickable(true)
+                .Build();
+            Assert.AreEqual(CtorStatement + ".resourceIdMatches(\".*my_id\").className(\"andoid.widget.TextField\").longClickable(true)", 
+                statment);
+        }
+    }
+}

--- a/test/integration/Android/AndroidUiSelectorTests.cs
+++ b/test/integration/Android/AndroidUiSelectorTests.cs
@@ -17,216 +17,216 @@ namespace Appium.Net.Integration.Tests.Android
         [Test]
         public void NewSelectorStartsWithJustConstructorCall()
         {
-            var statment = _sut.Build();
-            Assert.AreEqual(CtorStatement, statment);
+            var statement = _sut.Build();
+            Assert.AreEqual(CtorStatement, statement);
         }
 
         [Test]
         public void IsCheckableAddsCorrectCallToStatement()
         {
-            var statment = _sut.IsCheckable(true).Build();
-            Assert.AreEqual(CtorStatement + ".checkable(true)", statment);
+            var statement = _sut.IsCheckable(true).Build();
+            Assert.AreEqual(CtorStatement + ".checkable(true)", statement);
         }
 
         [Test]
         public void IsCheckedAddsCorrectCallToStatement()
         {
-            var statment = _sut.IsChecked(false).Build();
-            Assert.AreEqual(CtorStatement + ".checked(false)", statment);
+            var statement = _sut.IsChecked(false).Build();
+            Assert.AreEqual(CtorStatement + ".checked(false)", statement);
         }
 
         [Test]
         public void ChildSelectorAddsCorrectCallToStatement()
         {
-            var statment = _sut.ChildSelector(new AndroidUiSelector()).Build();
-            Assert.AreEqual(CtorStatement + $".childSelector({CtorStatement})", statment);
+            var statement = _sut.ChildSelector(new AndroidUiSelector()).Build();
+            Assert.AreEqual(CtorStatement + $".childSelector({CtorStatement})", statement);
         }
 
         [Test]
         public void ClassNameEqualsAddsCorrectCallToStatement()
         {
-            var statment = _sut.ClassNameEquals("Class1").Build();
-            Assert.AreEqual(CtorStatement + ".className(\"Class1\")", statment);
+            var statement = _sut.ClassNameEquals("Class1").Build();
+            Assert.AreEqual(CtorStatement + ".className(\"Class1\")", statement);
         }
 
         [Test]
         public void ClassNameMatchesAddsCorrectCallToStatement()
         {
-            var statment = _sut.ClassNameMatches("regex").Build();
-            Assert.AreEqual(CtorStatement + ".classNameMatches(\"regex\")", statment);
+            var statement = _sut.ClassNameMatches("regex").Build();
+            Assert.AreEqual(CtorStatement + ".classNameMatches(\"regex\")", statement);
         }
 
         [Test]
         public void IsClickableAddsCorrectCallToStatement()
         {
-            var statment = _sut.IsClickable(true).Build();
-            Assert.AreEqual(CtorStatement + ".clickable(true)", statment);
+            var statement = _sut.IsClickable(true).Build();
+            Assert.AreEqual(CtorStatement + ".clickable(true)", statement);
         }
 
         [Test]
         public void DescriptionEqualsAddsCorrectCallToStatement()
         {
-            var statment = _sut.DescriptionEquals("Desc").Build();
-            Assert.AreEqual(CtorStatement + ".description(\"Desc\")", statment);
+            var statement = _sut.DescriptionEquals("Desc").Build();
+            Assert.AreEqual(CtorStatement + ".description(\"Desc\")", statement);
         }
 
         [Test]
         public void DescriptionContainsAddsCorrectCallToStatement()
         {
-            var statment = _sut.DescriptionContains("Val").Build();
-            Assert.AreEqual(CtorStatement + ".descriptionContains(\"Val\")", statment);
+            var statement = _sut.DescriptionContains("Val").Build();
+            Assert.AreEqual(CtorStatement + ".descriptionContains(\"Val\")", statement);
         }
 
         [Test]
         public void DescriptionMatchesAddsCorrectCallToStatement()
         {
-            var statment = _sut.DescriptionMatches("regex").Build();
-            Assert.AreEqual(CtorStatement + ".descriptionMatches(\"regex\")", statment);
+            var statement = _sut.DescriptionMatches("regex").Build();
+            Assert.AreEqual(CtorStatement + ".descriptionMatches(\"regex\")", statement);
         }
 
         [Test]
         public void DescriptionStartsWithAddsCorrectCallToStatement()
         {
-            var statment = _sut.DescriptionStartsWith("Hello").Build();
-            Assert.AreEqual(CtorStatement + ".descriptionStartsWith(\"Hello\")", statment);
+            var statement = _sut.DescriptionStartsWith("Hello").Build();
+            Assert.AreEqual(CtorStatement + ".descriptionStartsWith(\"Hello\")", statement);
         }
 
         [Test]
         public void IsEnabledAddsCorrectCallToStatement()
         {
-            var statment = _sut.IsEnabled(true).Build();
-            Assert.AreEqual(CtorStatement + ".enabled(true)", statment);
+            var statement = _sut.IsEnabled(true).Build();
+            Assert.AreEqual(CtorStatement + ".enabled(true)", statement);
         }
 
         [Test]
         public void IsFocusableAddsCorrectCallToStatement()
         {
-            var statment = _sut.IsFocusable(true).Build();
-            Assert.AreEqual(CtorStatement + ".focusable(true)", statment);
+            var statement = _sut.IsFocusable(true).Build();
+            Assert.AreEqual(CtorStatement + ".focusable(true)", statement);
         }
 
         [Test]
         public void IsFocusedAddsCorrectCallToStatement()
         {
-            var statment = _sut.IsFocused(false).Build();
-            Assert.AreEqual(CtorStatement + ".focused(false)", statment);
+            var statement = _sut.IsFocused(false).Build();
+            Assert.AreEqual(CtorStatement + ".focused(false)", statement);
         }
 
         [Test]
         public void FromParentAddsCorrectCallToStatement()
         {
-            var statment = _sut.FromParent(new AndroidUiSelector()).Build();
-            Assert.AreEqual(CtorStatement + $".fromParent({CtorStatement})", statment);
+            var statement = _sut.FromParent(new AndroidUiSelector()).Build();
+            Assert.AreEqual(CtorStatement + $".fromParent({CtorStatement})", statement);
         }
 
         [Test]
         public void IndexAddsCorrectCallToStatement()
         {
-            var statment = _sut.Index(7).Build();
-            Assert.AreEqual(CtorStatement + ".index(7)", statment);
+            var statement = _sut.Index(7).Build();
+            Assert.AreEqual(CtorStatement + ".index(7)", statement);
         }
 
         [Test]
         public void InstanceAddsCorrectCallToStatement()
         {
-            var statment = _sut.Instance(4).Build();
-            Assert.AreEqual(CtorStatement + ".instance(4)", statment);
+            var statement = _sut.Instance(4).Build();
+            Assert.AreEqual(CtorStatement + ".instance(4)", statement);
         }
 
         [Test]
         public void LongClickableAddsCorrectCallToStatement()
         {
-            var statment = _sut.IsLongClickable(false).Build();
-            Assert.AreEqual(CtorStatement + ".longClickable(false)", statment);
+            var statement = _sut.IsLongClickable(false).Build();
+            Assert.AreEqual(CtorStatement + ".longClickable(false)", statement);
         }
 
         [Test]
         public void PackageNameEqualsAddsCorrectCallToStatement()
         {
-            var statment = _sut.PackageNameEquals("com.org.unique").Build();
-            Assert.AreEqual(CtorStatement + ".packageName(\"com.org.unique\")", statment);
+            var statement = _sut.PackageNameEquals("com.org.unique").Build();
+            Assert.AreEqual(CtorStatement + ".packageName(\"com.org.unique\")", statement);
         }
 
         [Test]
         public void PackageNameMatchesAddsCorrectCallToStatement()
         {
-            var statment = _sut.PackageNameMatches("regex").Build();
-            Assert.AreEqual(CtorStatement + ".packageNameMatches(\"regex\")", statment);
+            var statement = _sut.PackageNameMatches("regex").Build();
+            Assert.AreEqual(CtorStatement + ".packageNameMatches(\"regex\")", statement);
         }
 
         [Test]
         public void ResourceIdEqualsAddsCorrectCallToStatement()
         {
-            var statment = _sut.ResourceIdEquals("my-id").Build();
-            Assert.AreEqual(CtorStatement + ".resourceId(\"my-id\")", statment);
+            var statement = _sut.ResourceIdEquals("my-id").Build();
+            Assert.AreEqual(CtorStatement + ".resourceId(\"my-id\")", statement);
         }
 
         [Test]
         public void ResourceIdMatchesAddsCorrectCallToStatement()
         {
-            var statment = _sut.ResourceIdMatches("regex").Build();
-            Assert.AreEqual(CtorStatement + ".resourceIdMatches(\"regex\")", statment);
+            var statement = _sut.ResourceIdMatches("regex").Build();
+            Assert.AreEqual(CtorStatement + ".resourceIdMatches(\"regex\")", statement);
         }
 
         [Test]
         public void IsScrollableAddsCorrectCallToStatement()
         {
-            var statment = _sut.IsScrollable(true).Build();
-            Assert.AreEqual(CtorStatement + ".scrollable(true)", statment);
+            var statement = _sut.IsScrollable(true).Build();
+            Assert.AreEqual(CtorStatement + ".scrollable(true)", statement);
         }
 
         [Test]
         public void IsSelectedAddsCorrectCallToStatement()
         {
-            var statment = _sut.IsSelected(false).Build();
-            Assert.AreEqual(CtorStatement + ".selected(false)", statment);
+            var statement = _sut.IsSelected(false).Build();
+            Assert.AreEqual(CtorStatement + ".selected(false)", statement);
         }
 
         [Test]
         public void TextEqualsAddsCorrectCallToStatement()
         {
-            var statment = _sut.TextEquals("some text").Build();
-            Assert.AreEqual(CtorStatement + ".text(\"some text\")", statment);
+            var statement = _sut.TextEquals("some text").Build();
+            Assert.AreEqual(CtorStatement + ".text(\"some text\")", statement);
         }
 
         [Test]
         public void TextContainsAddsCorrectCallToStatement()
         {
-            var statment = _sut.TextContains("some text").Build();
-            Assert.AreEqual(CtorStatement + ".textContains(\"some text\")", statment);
+            var statement = _sut.TextContains("some text").Build();
+            Assert.AreEqual(CtorStatement + ".textContains(\"some text\")", statement);
         }
 
         [Test]
         public void TextMatchesAddsCorrectCallToStatement()
         {
-            var statment = _sut.TextMatches("some text").Build();
-            Assert.AreEqual(CtorStatement + ".textMatches(\"some text\")", statment);
+            var statement = _sut.TextMatches("some text").Build();
+            Assert.AreEqual(CtorStatement + ".textMatches(\"some text\")", statement);
         }
 
         [Test]
         public void TextStartsWithAddsCorrectCallToStatement()
         {
-            var statment = _sut.TextStartsWith("some text").Build();
-            Assert.AreEqual(CtorStatement + ".textStartsWith(\"some text\")", statment);
+            var statement = _sut.TextStartsWith("some text").Build();
+            Assert.AreEqual(CtorStatement + ".textStartsWith(\"some text\")", statement);
         }
 
         [Test]
         public void AddRawTextAppendsText()
         {
-            var statment = _sut.AddRawText("@").Build();
-            Assert.AreEqual(CtorStatement + "@", statment);
+            var statement = _sut.AddRawText("@").Build();
+            Assert.AreEqual(CtorStatement + "@", statement);
         }
 
         [Test]
         public void CanChainCalls()
         {
-            var statment = _sut
+            var statement = _sut
                 .ResourceIdMatches(".*my_id")
                 .ClassNameEquals("andoid.widget.TextField")
                 .IsLongClickable(true)
                 .Build();
             Assert.AreEqual(CtorStatement + ".resourceIdMatches(\".*my_id\").className(\"andoid.widget.TextField\").longClickable(true)", 
-                statment);
+                statement);
         }
     }
 }

--- a/test/integration/Android/ElementTest.cs
+++ b/test/integration/Android/ElementTest.cs
@@ -1,6 +1,5 @@
 ﻿using Appium.Net.Integration.Tests.helpers;
 using NUnit.Framework;
-using NUnit.Framework.Constraints;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
@@ -55,6 +54,19 @@ namespace Appium.Net.Integration.Tests.Android
             Assert.GreaterOrEqual(
                 _driver.FindElementById("android:id/content").FindElements(byAndroidUiAutomator).Count,
                 1);
+        }
+
+        [Test]
+        public void CanFindByDescriptionUsingBuilderWhenNewlineCharacterIncluded()
+        {
+            _driver.StartActivity("io.appium.android.apis", ".accessibility.TaskListActivity");
+            By byAndroidUiAutomator = new ByAndroidUIAutomator(new AndroidUiSelector().DescriptionEquals(
+                "1. Enable QueryBack (Settings -> Accessibility -> QueryBack). \n\n" +
+                "2. Enable Explore-by-Touch (Settings -> Accessibility -> Explore by Touch). \n\n" +
+                "3. Touch explore the list."));
+
+            Assert.IsNotNull(_driver.FindElementById("android:id/content").FindElement(byAndroidUiAutomator).Text);
+            Assert.GreaterOrEqual(_driver.FindElementById("android:id/content").FindElements(byAndroidUiAutomator).Count, 1);
         }
 
         [Test]

--- a/test/integration/Android/ElementTest.cs
+++ b/test/integration/Android/ElementTest.cs
@@ -70,6 +70,17 @@ namespace Appium.Net.Integration.Tests.Android
         }
 
         [Test]
+        public void CanFindByDescriptionUsingBuilderWhenDoubleQuoteCharacterIncluded()
+        {
+            _driver.StartActivity("io.appium.android.apis", ".text.Link");
+            By byAndroidUiAutomator = new ByAndroidUIAutomator(new AndroidUiSelector()
+                .DescriptionContains("Use a \"tel:\" URL"));
+
+            Assert.IsNotNull(_driver.FindElementById("android:id/content").FindElement(byAndroidUiAutomator).Text);
+            Assert.GreaterOrEqual(_driver.FindElementById("android:id/content").FindElements(byAndroidUiAutomator).Count, 1);
+        }
+
+        [Test]
         public void ReplaceValueTest()
         {
             var originalValue = "original value";

--- a/test/integration/Android/ElementTest.cs
+++ b/test/integration/Android/ElementTest.cs
@@ -1,8 +1,10 @@
 ﻿using Appium.Net.Integration.Tests.helpers;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.Android.UiAutomator;
 
 namespace Appium.Net.Integration.Tests.Android
 {
@@ -42,6 +44,16 @@ namespace Appium.Net.Integration.Tests.Android
             By byAndroidUiAutomator = new ByAndroidUIAutomator("new UiSelector().clickable(true)");
             Assert.IsNotNull(_driver.FindElementById("android:id/content").FindElement(byAndroidUiAutomator).Text);
             Assert.GreaterOrEqual(_driver.FindElementById("android:id/content").FindElements(byAndroidUiAutomator).Count,
+                1);
+        }
+
+        [Test]
+        public void FindByAndroidUiAutomatorBuilderTest()
+        {
+            By byAndroidUiAutomator = new ByAndroidUIAutomator(new AndroidUiSelector().IsClickable(true));
+            Assert.IsNotNull(_driver.FindElementById("android:id/content").FindElement(byAndroidUiAutomator).Text);
+            Assert.GreaterOrEqual(
+                _driver.FindElementById("android:id/content").FindElements(byAndroidUiAutomator).Count,
                 1);
         }
 
@@ -87,6 +99,17 @@ namespace Appium.Net.Integration.Tests.Android
             var list = _driver.FindElement(By.Id("android:id/list"));
             var locator = new ByAndroidUIAutomator("new UiScrollable(new UiSelector()).scrollIntoView("
                                                    + "new UiSelector().text(\"Radio Group\"));");
+            var radioGroup = list.FindElement(locator);
+            Assert.NotNull(radioGroup.Location);
+        }
+
+        [Test]
+        public void ScrollingToSubElementUsingBuilder()
+        {
+            _driver.FindElementByAccessibilityId("Views").Click();
+            var list = _driver.FindElement(By.Id("android:id/list"));
+            var locator = new ByAndroidUIAutomator(new AndroidUiScrollable()
+                .ScrollIntoView(new AndroidUiSelector().TextEquals("Radio Group")));
             var radioGroup = list.FindElement(locator);
             Assert.NotNull(radioGroup.Location);
         }


### PR DESCRIPTION
## Change list

- Added 2 new fluent-builder style classes (`AndroidUiSelector`, `AndroidUiScrollable`) for building valid `UiSelector` and `UiScrollable` calls.
    - Added new interface `IUiAutomatorStatementBuilder` which both new classes implement
- Added method overloads to `IFindByAndroidUIAutomator`
    - `FindElementByAndroidUIAutomator(IUiAutomatorStatementBuilder)`
    - `FindElementsByAndroidUIAutomator(IUiAutomatorStatementBuilder)`
- Added ctor overload to `ByAndroidUIAutomator`
    - `ByAndroidUIAutomator(IUiAutomatorStatementBuilder selector)`
- Added static `By.AndroidUIAutomator(IUiAutomatorStatementBuilder)` overload
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 

I have not submitted a doc change as there doesn't seem to currently be a good place to document this change.

#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

While it is nice to be able to use UiAutomator directly, it is a bit of a pain to build using strings directly. This PR adds two fluent-builder style classes to guide the library user through creating valid UiAutomator statements. Each builder can be compiled to a string and used with existing methods, though I've added several interface/ctor overloads to make this more discoverable.

If it is desirable to keep the `IFindByAndroidUIAutomator` interface more simple, the overloads I've added can be converted to extension methods.

Each builder has an `AddRawText(string)` method which will add any provided text directly to the builder. This is to allow extensibility by library users in the case that the method they require is not included in the fluent builder wrapper. At this time, UiSelector is fully wrapped, but UiScrollable is pretty bare-bones.

**Ex. 1: Find an element by UiSelector**
```csharp
var options = new AppiumOptions {PlatformName = "Android"};
var driver = new AndroidDriver<AndroidElement>(options);

var element = driver.FindElementByAndroidUIAutomator(new AndroidUiSelector()
    .ClassNameEquals("android.widget.TextView")
    .Instance(1));
```

**Ex. 2: Scroll to an element which matches a selector**
```csharp
var options = new AppiumOptions {PlatformName = "Android"};
var driver = new AndroidDriver<AndroidElement>(options);

var element = driver.FindElementByAndroidUIAutomator(new AndroidUiScrollable()
    .ScrollIntoView(new AndroidUiSelector()
        .ResourceIdMatches(".*my_unique_id")
        .TextEquals("Test Element")));
```

**Ex. 3: Scroll to an element which matches a selector, using preexisting overload which is not aware of the builder**
```csharp
var options = new AppiumOptions {PlatformName = "Android"};
var driver = new AndroidDriver<AndroidElement>(options);

var element = driver.FindElementByAndroidUIAutomator(new AndroidUiScrollable()
    .ScrollIntoView(new AndroidUiSelector()
        .ResourceIdMatches(".*my_unique_id")
        .TextEquals("Test Element"))
    .Compile());
```

**Other supported uses**
```csharp
var staticBy = MobileBy.AndroidUIAutomator(new AndroidUiSelector().ResourceIdMatches(".*my_unique_id"));

var newBy = new ByAndroidUIAutomator(new AndroidUiSelector().ResourceIdMatches(".*my_unique_id"))
```