### PR TITLE
fix: Custom environment variables are now correctly applied to Node process

### DIFF
--- a/src/Appium.Net/Appium/Service/AppiumLocalService.cs
+++ b/src/Appium.Net/Appium/Service/AppiumLocalService.cs
@@ -13,6 +13,7 @@
 //limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using OpenQA.Selenium.Appium.Service.Exceptions;
 using OpenQA.Selenium.Remote;
 using System.IO;
@@ -29,6 +30,7 @@ namespace OpenQA.Selenium.Appium.Service
         private readonly IPAddress IP;
         private readonly int Port;
         private readonly TimeSpan InitializationTimeout;
+        private readonly IDictionary<string, string> EnvironmentForProcess;
         private Process Service;
 
         /// <summary>
@@ -42,13 +44,15 @@ namespace OpenQA.Selenium.Appium.Service
             string arguments, 
             IPAddress ip, 
             int port,
-            TimeSpan initializationTimeout)
+            TimeSpan initializationTimeout, 
+            IDictionary<string, string> environmentForProcess)
         {
             NodeJS = nodeJS;
             IP = ip;
             Arguments = arguments;
             Port = port;
             InitializationTimeout = initializationTimeout;
+            EnvironmentForProcess = environmentForProcess;
         }
 
         /// <summary>
@@ -80,6 +84,14 @@ namespace OpenQA.Selenium.Appium.Service
             Service.StartInfo.Arguments = Arguments;
             Service.StartInfo.UseShellExecute = false;
             Service.StartInfo.CreateNoWindow = true;
+
+            if (EnvironmentForProcess != null)
+            {
+                foreach (var entry in EnvironmentForProcess)
+                {
+                    Service.StartInfo.EnvironmentVariables[entry.Key] = entry.Value ?? string.Empty;
+                }
+            }
 
             Service.StartInfo.RedirectStandardOutput = true;
             Service.OutputDataReceived += (sender, e) => OutputDataReceived?.Invoke(this, e);

--- a/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
+++ b/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
@@ -488,7 +488,7 @@ namespace OpenQA.Selenium.Appium.Service
             {
                 NodeJS = DefaultExecutable;
             }
-            return new AppiumLocalService(NodeJS, Args, IPAddress.Parse(this.IpAddress), this.Port, StartUpTimeout);
+            return new AppiumLocalService(NodeJS, Args, IPAddress.Parse(this.IpAddress), this.Port, StartUpTimeout, EnvironmentForAProcess);
         }
     }
 }


### PR DESCRIPTION
## Change list
`AppiumLocalService` now honors environment variables set in the `AppiumServiceBuilder`.
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

I attempted to write a test for this, however there are very few (and very specific) uses of environment variables in Appium. It would make sense to have a test in the `StartingAppLocallyTest` class, but I believe Appium itself doesn't use any environment variables. The only way to test this that I am aware of is to override `JAVA_HOME` or `ANDROID_HOME` while attempting to start an Android session. Setting one of those to an invalid value should cause the session to fail and throw an exception, proving that the custom environment variable was set (assuming the session would have otherwise succeeded).

It seems the tests are set up to run against either remote or local Appium servers. Since we would need to start a local Appium server for this test to work, I'm not sure if it would work with your testing infrastructure. Also, since the test would be tied to a specific capability set, I'm not sure how useful it would be. However, I can write the test if you are ok with the limitations I've described.

## Details
This PR completes what appears to be some unfinished development work in the `AppiumLocalService` class. Values provided in the `AppiumServiceBuilder` are now routed to the process which runs Node. This allows overriding values such as `JAVA_HOME` or `ANDROID_HOME` which couldn't be done safely otherwise.