### PR TITLE
feat: Provide way to pass arguments to NodeJS

### DIFF
--- a/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
+++ b/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
@@ -496,7 +496,7 @@ namespace OpenQA.Selenium.Appium.Service
 
                 if (ServerOptions != null)
                 {
-                    argList.AddRange(ServerOptions.Argiments);
+                    argList.AddRange(ServerOptions.Arguments);
                 }
 
                 string result = string.Empty;

--- a/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
+++ b/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
@@ -40,7 +40,7 @@ namespace OpenQA.Selenium.Appium.Service
         private FileInfo NodeJS;
         private IDictionary<string, string> EnvironmentForAProcess;
         private string PathToLogFile;
-        private IDictionary<string, string> NodeOptions;
+        private string[] NodeOptions = new string[0];
 
 
         private static Process StartSearchingProcess(string file, string arguments)
@@ -311,22 +311,22 @@ namespace OpenQA.Selenium.Appium.Service
         /// Command line arguments that will be passed to NodeJS when it starts up.
         /// </summary>
         /// <param name="arguments">
-        /// A collection of argument name and argument value pairs that will be
-        /// passed to NodeJS.
+        /// A collection of arguments that will be passed to NodeJS. Spaces will automatically
+        /// be added between arguments. Arguments cannot be null, empty strings, or only whitespace.
         /// </param>
         /// <returns></returns>
-        public AppiumServiceBuilder WithNodeArguments(IDictionary<string, string> arguments)
+        public AppiumServiceBuilder WithNodeArguments(params string[] arguments)
         {
             if (arguments == null)
             {
                 throw new ArgumentNullException(nameof(arguments), "Argument cannot be null");
             }
 
-            foreach (var key in arguments.Keys)
+            foreach (var arg in arguments)
             {
-                if (string.IsNullOrEmpty(key))
+                if (string.IsNullOrWhiteSpace(arg))
                 {
-                    throw new ArgumentException("Node arguments cannot have null or empty keys", nameof(arguments));
+                    throw new ArgumentException("Node arguments cannot be null, empty, or only whitespace.", nameof(arguments));
                 }
             }
 
@@ -479,17 +479,7 @@ namespace OpenQA.Selenium.Appium.Service
                 List<string> argList = new List<string>();
                 CheckAppiumJS();
 
-                if (NodeOptions != null)
-                {
-                    foreach (var argPair in NodeOptions)
-                    {
-                        argList.Add(argPair.Key);
-                        if (!string.IsNullOrWhiteSpace(argPair.Value))
-                        {
-                            argList.Add(argPair.Value);
-                        }
-                    }
-                }
+                argList.AddRange(NodeOptions);
 
                 argList.Add($"\"{AppiumJS.FullName}\"");
                 argList.Add("--port");

--- a/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
+++ b/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
@@ -40,6 +40,7 @@ namespace OpenQA.Selenium.Appium.Service
         private FileInfo NodeJS;
         private IDictionary<string, string> EnvironmentForAProcess;
         private string PathToLogFile;
+        private IDictionary<string, string> NodeOptions;
 
 
         private static Process StartSearchingProcess(string file, string arguments)
@@ -306,6 +307,20 @@ namespace OpenQA.Selenium.Appium.Service
             return this;
         }
 
+        /// <summary>
+        /// Command line arguments to pass to NodeJS when it starts up.
+        /// </summary>
+        /// <param name="arguments">
+        /// A collection of argument name and argument value pairs that will be
+        /// passed to NodeJS.
+        /// </param>
+        /// <returns></returns>
+        public AppiumServiceBuilder WithNodeArguments(IDictionary<string, string> arguments)
+        {
+            NodeOptions = arguments;
+            return this;
+        }
+
         private void CheckAppiumJS()
         {
             if (AppiumJS != null)
@@ -450,6 +465,16 @@ namespace OpenQA.Selenium.Appium.Service
             {
                 List<string> argList = new List<string>();
                 CheckAppiumJS();
+
+                if (NodeOptions != null)
+                {
+                    foreach (var argPair in NodeOptions)
+                    {
+                        argList.Add(argPair.Key ?? string.Empty);
+                        argList.Add(argPair.Value ?? string.Empty);
+                    }
+                }
+
                 argList.Add($"\"{AppiumJS.FullName}\"");
                 argList.Add("--port");
                 argList.Add($"\"{Port}\"");

--- a/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
+++ b/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
@@ -308,7 +308,7 @@ namespace OpenQA.Selenium.Appium.Service
         }
 
         /// <summary>
-        /// Command line arguments to pass to NodeJS when it starts up.
+        /// Command line arguments that will be passed to NodeJS when it starts up.
         /// </summary>
         /// <param name="arguments">
         /// A collection of argument name and argument value pairs that will be
@@ -317,6 +317,19 @@ namespace OpenQA.Selenium.Appium.Service
         /// <returns></returns>
         public AppiumServiceBuilder WithNodeArguments(IDictionary<string, string> arguments)
         {
+            if (arguments == null)
+            {
+                throw new ArgumentNullException(nameof(arguments), "Argument cannot be null");
+            }
+
+            foreach (var key in arguments.Keys)
+            {
+                if (string.IsNullOrEmpty(key))
+                {
+                    throw new ArgumentException("Node arguments cannot have null or empty keys", nameof(arguments));
+                }
+            }
+
             NodeOptions = arguments;
             return this;
         }
@@ -470,8 +483,11 @@ namespace OpenQA.Selenium.Appium.Service
                 {
                     foreach (var argPair in NodeOptions)
                     {
-                        argList.Add(argPair.Key ?? string.Empty);
-                        argList.Add(argPair.Value ?? string.Empty);
+                        argList.Add(argPair.Key);
+                        if (!string.IsNullOrEmpty(argPair.Value))
+                        {
+                            argList.Add(argPair.Value);
+                        }
                     }
                 }
 

--- a/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
+++ b/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
@@ -311,9 +311,13 @@ namespace OpenQA.Selenium.Appium.Service
         /// Command line arguments that will be passed to NodeJS when it starts up.
         /// </summary>
         /// <param name="arguments">
-        /// A collection of arguments that will be passed to NodeJS. Spaces will automatically
-        /// be added between arguments. Arguments cannot be null, empty strings, or only whitespace.
+        /// A collection of raw string arguments that will be passed to NodeJS.
+        /// Spaces will be automatically added between arguments. You are responsible for
+        /// properly escaping any special characters for your operating system.
+        /// Arguments cannot be null, empty strings, or only whitespace.
         /// </param>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
         /// <returns></returns>
         public AppiumServiceBuilder WithNodeArguments(params string[] arguments)
         {

--- a/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
+++ b/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
@@ -484,7 +484,7 @@ namespace OpenQA.Selenium.Appium.Service
                     foreach (var argPair in NodeOptions)
                     {
                         argList.Add(argPair.Key);
-                        if (!string.IsNullOrEmpty(argPair.Value))
+                        if (!string.IsNullOrWhiteSpace(argPair.Value))
                         {
                             argList.Add(argPair.Value);
                         }

--- a/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
+++ b/src/Appium.Net/Appium/Service/AppiumServiceBuilder.cs
@@ -322,11 +322,11 @@ namespace OpenQA.Selenium.Appium.Service
                 throw new ArgumentNullException(nameof(arguments), "Argument cannot be null");
             }
 
-            foreach (var arg in arguments)
+            for (var i = 0; i < arguments.Length; i++)
             {
-                if (string.IsNullOrWhiteSpace(arg))
+                if (string.IsNullOrWhiteSpace(arguments[i]))
                 {
-                    throw new ArgumentException("Node arguments cannot be null, empty, or only whitespace.", nameof(arguments));
+                    throw new ArgumentException($"Invalid Node argument at index {i}. Node arguments cannot be null, empty, or only whitespace.", nameof(arguments));
                 }
             }
 

--- a/src/Appium.Net/Appium/Service/Options/OptionCollector.cs
+++ b/src/Appium.Net/Appium/Service/Options/OptionCollector.cs
@@ -176,7 +176,7 @@ namespace OpenQA.Selenium.Appium.Service.Options
         /// <summary>
         /// Builds a sequence of server arguments
         /// </summary>
-        internal IList<string> Argiments
+        internal IList<string> Arguments
         {
             get
             {

--- a/test/integration/ServerTests/AppiumLocalServerLaunchingTest.cs
+++ b/test/integration/ServerTests/AppiumLocalServerLaunchingTest.cs
@@ -295,11 +295,7 @@ namespace Appium.Net.Integration.Tests.ServerTests
         {
             var service = new AppiumServiceBuilder()
                 .WithStartUpTimeOut(TimeSpan.FromMilliseconds(500)) // we expect the Appium startup to fail, so fail quickly
-                .WithNodeArguments(new Dictionary<string, string>
-                {
-                    // show Node version and exit
-                    {"--version", string.Empty}
-                })
+                .WithNodeArguments("--version") // show Node version and exit
                 .Build();
 
             var nodeOutput = new StringBuilder();
@@ -324,18 +320,19 @@ namespace Appium.Net.Integration.Tests.ServerTests
         public void AttemptingToSetNodeArgumentsToNullThrowsException()
         {
             var serviceBuilder = new AppiumServiceBuilder();
-            Assert.Throws<ArgumentNullException>(() => serviceBuilder.WithNodeArguments(null));
+            string[] nullArray = null;
+            Assert.Throws<ArgumentNullException>(() => serviceBuilder.WithNodeArguments(nullArray));
         }
 
-        [Test]
-        public void AddingNodeArgumentWithEmptyKeyThrowsException()
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("\n")]
+        [TestCase("\t")]
+        public void AddingInvalidNodeArgumentThrowsException(string argument)
         {
             var serviceBuilder = new AppiumServiceBuilder();
-            Assert.Throws<ArgumentException>(() => serviceBuilder.WithNodeArguments(
-                new Dictionary<string, string>
-                {
-                    { string.Empty, string.Empty }
-                }));
+            Assert.Throws<ArgumentException>(() => serviceBuilder.WithNodeArguments(argument));
         }
     }
 }


### PR DESCRIPTION
## Change list

Added option to provide command line arguments to Node in the `AppiumServiceBuilder`.
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details
I've added this feature to support loading Appium from yarn PnP-ified packages (https://next.yarnpkg.com/features/pnp). We needed to pass `--require .pnp.js` to Node in order to include support for reading node packages from zip files. This allows us to reduce build time and have more manageable Node artifacts (~100 zip files rather than 1000s of tiny js files).
