### PR TITLE
chore: added github action - pr labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,21 @@
+Enhancement:
+  title: "^feat:.*"
+
+BugFix:
+  title: "^fix:.*"
+
+Documentation:
+  title: "^docs:.*"
+
+Build:
+  title: "^build:.*"
+
+CI:
+  title: "^ci:.*"
+
+Test:
+  title: "^test:.*"
+
+WIP:
+  title: "^WIP:.*"
+  mergeable: false

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -10,9 +10,7 @@ categories:
     label: 'Enhancement'
   - title: 'Bug Fixes'
     labels:
-      - 'Fix'
-      - 'Bugfix'
-      - 'Bug'
+      - 'BugFix'
   - title: 'Refactor'
     label: 'Refactor'
   - title: 'Dependencies'
@@ -20,7 +18,6 @@ categories:
       - 'Dependencies'
   - title: 'Pipeline'
     labels:
-      - 'Pipeline'
       - 'CI'
       - 'Build'
 
@@ -30,11 +27,9 @@ version-resolver:
       - 'BreakingChange'
   minor:
     labels:
-      - 'Feature'
       - 'Enhancement'
   patch:
     labels:
-      - 'Bug'
       - 'BugFix'
       - 'Dependencies'
   default: patch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,12 @@
+name: Label PRs
+
+on:
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: srvaroa/labeler@master
+    env:
+    GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Change list

.github/release-drafter.yml

Please provide briefly described change list which are you going to propose. 
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details
Add PR labeler [github action](https://github.com/srvaroa/labeler)
Consolidated labels for the release drafter

The purpose of this PR is to enable a github action that will enable automatic labelling of PRs based on the semantic commit type specified in the PR title. This will work in conjunction with the release drafter github action that will produce a draft release note based on items merged in with labels

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 