### PR TITLE
feat: add missing iOS Screen recording options

### DIFF
--- a/src/Appium.Net/Appium/ScreenRecording/BaseStartScreenRecordingOptions.cs
+++ b/src/Appium.Net/Appium/ScreenRecording/BaseStartScreenRecordingOptions.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Globalization;
 
 namespace OpenQA.Selenium.Appium.ScreenRecording
 {
-    public abstract class BaseStartScreenRecordingOptions<T> : BaseScreenRecordingOptions<T> where T : BaseStartScreenRecordingOptions<T>
+    public abstract class BaseStartScreenRecordingOptions<T> : BaseScreenRecordingOptions<T>
+        where T : BaseStartScreenRecordingOptions<T>
     {
         /// <summary>
         /// The maximum recording time.
@@ -11,7 +13,8 @@ namespace OpenQA.Selenium.Appium.ScreenRecording
         /// <returns>self instance for chaining.</returns>
         public T WithTimeLimit(TimeSpan timeLimit)
         {
-            Parameters["timeLimit"] = (int) timeLimit.TotalSeconds;
+            Parameters["timeLimit"] = timeLimit.TotalSeconds
+                .ToString(CultureInfo.InvariantCulture);
             return (T) this;
         }
 

--- a/src/Appium.Net/Appium/ScreenRecording/BaseStartScreenRecordingOptions.cs
+++ b/src/Appium.Net/Appium/ScreenRecording/BaseStartScreenRecordingOptions.cs
@@ -13,8 +13,7 @@ namespace OpenQA.Selenium.Appium.ScreenRecording
         /// <returns>self instance for chaining.</returns>
         public T WithTimeLimit(TimeSpan timeLimit)
         {
-            Parameters["timeLimit"] = timeLimit.TotalSeconds
-                .ToString(CultureInfo.InvariantCulture);
+            Parameters["timeLimit"] = (int)timeLimit.TotalSeconds;;
             return (T) this;
         }
 

--- a/src/Appium.Net/Appium/iOS/IOSStartScreenRecordingOptions.cs
+++ b/src/Appium.Net/Appium/iOS/IOSStartScreenRecordingOptions.cs
@@ -28,6 +28,19 @@ namespace OpenQA.Selenium.Appium.iOS
             return this;
         }
 
+        /// <summary>
+        /// The format of the screen capture to be recorded.
+        /// Available formats: Execute <code>ffmpeg -codecs</code> in the terminal to see the list of supported video codecs.
+        /// ‘mjpeg’ by default. (Since Appium 1.10.0)
+        /// </summary>
+        /// <param name="videoType">one of available format names.</param>
+        /// <returns>self instance for chaining.</returns>
+        public IOSStartScreenRecordingOptions WithVideoType(string videoType)
+        {
+            Parameters["videoType"] = videoType;
+            return this;
+        }
+
         public enum VideoQuality
         {
             LOW, MEDIUM, HIGH, PHOTO
@@ -56,6 +69,61 @@ namespace OpenQA.Selenium.Appium.iOS
         public new IOSStartScreenRecordingOptions WithTimeLimit(TimeSpan timeLimit)
         {
             return base.WithTimeLimit(timeLimit);
+        }
+
+        /// <summary>
+        /// The Frames Per Second rate of the recorded video.
+        /// Change this value if the resulting video is too slow or too fast.
+        /// Defaults to 10. This can decrease the resulting file size.
+        /// </summary>
+        /// <param name="videoFps"></param>
+        /// <returns>self instance for chaining.</returns>
+        public IOSStartScreenRecordingOptions WithVideoFps(string videoFps)
+        {
+            Parameters["videoFps"] = videoFps;
+            return this;
+        }
+
+        /// <summary>
+        /// The scaling value to apply.
+        /// Read <see href="https://trac.ffmpeg.org/wiki/Scaling">here</see> for possible values.
+        /// Example value of 720p scaling is '1280:720'. This can decrease/increase the resulting file size.
+        /// No scale is applied by default.
+        /// </summary>
+        /// <param name="videoScale"></param>
+        /// <returns>self instance for chaining.</returns>
+        public IOSStartScreenRecordingOptions WithVideoScale(string videoScale)
+        {
+            Parameters["videoScale"] = videoScale;
+            return this;
+        }
+
+        /// <summary>
+        /// Output pixel format.
+        /// Run <code>ffmpeg -pix_fmts</code> to list possible values.
+        /// For QuickTime compatibility, set to “yuv420p” along with videoType: “libx264”.
+        /// Supported since Appium 1.12.0)
+        /// </summary>
+        /// <param name="pixelFormat"></param>
+        /// <returns></returns>
+        public IOSStartScreenRecordingOptions WithPixelFormat(string pixelFormat)
+        {
+            Parameters["pixelFormat"] = pixelFormat;
+            return this;
+        }
+
+        /// <summary>
+        /// The ffmpeg video filters to apply.
+        /// These filters allow to scale, flip, rotate and do many other useful transformations on the source video stream.
+        /// The format of the property must comply with listed <see href="https://ffmpeg.org/ffmpeg-filters.html">here</see>
+        /// Supported since Appium 1.15)
+        /// </summary>
+        /// <param name="videoFilters"></param>
+        /// <returns></returns>
+        public IOSStartScreenRecordingOptions WithVideoFilter(string videoFilters)
+        {
+            Parameters["videoFilters"] = videoFilters;
+            return this;
         }
     }
 }

--- a/test/integration/IOS/ScreenRecordingTest.cs
+++ b/test/integration/IOS/ScreenRecordingTest.cs
@@ -46,7 +46,9 @@ namespace Appium.Net.Integration.Tests.IOS
             _driver.StartRecordingScreen(
                 IOSStartScreenRecordingOptions.GetIosStartScreenRecordingOptions()
                     .WithTimeLimit(TimeSpan.FromSeconds(10))
-                    .WithVideoType(IOSStartScreenRecordingOptions.VideoType.H264));
+                    .WithVideoType(IOSStartScreenRecordingOptions.VideoType.H264)
+                    .WithVideoFps("10")
+                    .WithVideoScale("320:240"));
             Thread.Sleep(1000);
             var result = _driver.StopRecordingScreen();
             Assert.IsNotEmpty(result);


### PR DESCRIPTION
## Change list

Please provide briefly described change list which are you going to propose. 
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [x] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details
Added an overload for videoType option
Added the following options for iOS: videoScale, videoFps, videoPixelFormat, videoFilters
closes #400 
closes #404 

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
