### PR TITLE
feat: otherApps enum missing from appium-dotnet-driver implementation…

### DIFF
--- a/src/Appium.Net/Appium/Enums/MobileCapabilityType.cs
+++ b/src/Appium.Net/Appium/Enums/MobileCapabilityType.cs
@@ -91,5 +91,11 @@ namespace OpenQA.Selenium.Appium.Enums
         /// On Android, this will also remove the app after the session is complete. Default false
         /// </summary>
         public static readonly string FullReset = "fullReset";
+
+        /// <summary>
+        /// App or list of apps (as a JSON array) to install prior to running tests. Note that it will not work with
+        /// automationName of Espresso and iOS real devices.
+        /// </summary>
+        public static readonly string OtherApps = "otherApps";
     }
 }


### PR DESCRIPTION
… (#445)

## Change list

Added enum MobileCapabilityType.OtherApps for consistency with Java client.
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

