### PR TITLE
build: reenable GeneratePackageOnBuild

### DIFF
--- a/src/Appium.Net/Appium.Net.csproj
+++ b/src/Appium.Net/Appium.Net.csproj
@@ -7,7 +7,7 @@
     <Company>Appium Commiters</Company>
     <Product>Appium-Dotnet-Driver</Product>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>Copyright © 2020</Copyright>
     <PackageProjectUrl>https://github.com/appium/appium-dotnet-driver</PackageProjectUrl>
     <RepositoryUrl>https://github.com/appium/appium-dotnet-driver</RepositoryUrl>


### PR DESCRIPTION
## Change list

Project file

## Details

Reenabled the GeneratePackageOnBuild property because the release github action looks for a generated package for it to publish.
The file version is still removed so the assembly and package should not show an outdated version