### PR TITLE
fix: Update Android.Enums AutomatorSetting values

### DIFF
--- a/src/Appium.Net/Appium/Android/Enums/AutomatorSetting.cs
+++ b/src/Appium.Net/Appium/Android/Enums/AutomatorSetting.cs
@@ -17,10 +17,10 @@ namespace OpenQA.Selenium.Appium.Android.Enums
     public sealed class AutomatorSetting
     {
         public static readonly string IgnoreUnimportantViews = "ignoreUnimportantViews";
-        public static readonly string WaitForIDLETimeout = "setWaitForIdleTimeout";
-        public static readonly string WaitForSelectorTimeout = "setWaitForSelectorTimeout";
-        public static readonly string WaitScrollAcknowledgmentTimeout = "setScrollAcknowledgmentTimeout";
-        public static readonly string WaitActionAcknowledgmentTimeout = "setActionAcknowledgmentTimeout";
-        public static readonly string KeyInjectionDelay = "setKeyInjectionDelay";
+        public static readonly string WaitForIDLETimeout = "waitForIdleTimeout";
+        public static readonly string WaitForSelectorTimeout = "waitForSelectorTimeout";
+        public static readonly string WaitScrollAcknowledgmentTimeout = "scrollAcknowledgmentTimeout";
+        public static readonly string WaitActionAcknowledgmentTimeout = "actionAcknowledgmentTimeout";
+        public static readonly string KeyInjectionDelay = "keyInjectionDelay";
     }
 }


### PR DESCRIPTION
## Change list

- Update Android.Enums AutomatorSetting values
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

Group Name: SettingTest
Duration: 0:00:00.458
0 test(s) failed
0 test(s) skipped
3 test(s) passed

## Details

using the current Enums we have in android will throw the below exception for 5/6 Settings:

`OpenQA.Selenium.WebDriverException: 'Setting '**setActionAcknowledgmentTimeout**' is not supported. Only the following settings are supported: [actionAcknowledgmentTimeout, allowInvisibleElements, ignoreUnimportantViews, elementResponseAttributes, enableMultiWindows, enableNotificationListener, keyInjectionDelay, scrollAcknowledgmentTimeout, shouldUseCompactResponses, waitForIdleTimeout, waitForSelectorTimeout, normalizeTagNames, shutdownOnPowerDisconnect, simpleBoundsCalculation, trackScrollEvents, wakeLockTimeout, serverPort, mjpegServerPort, mjpegServerFramerate, mjpegScalingFactor, mjpegServerScreenshotQuality, mjpegBilinearFiltering, useResourcesForOrientationDetection]'`


