### PR TITLE
feat: Add `simulatorStartupTimeout` iOS capability

### DIFF
--- a/src/Appium.Net/Appium/Enums/IOSMobileCapabilityType.cs
+++ b/src/Appium.Net/Appium/Enums/IOSMobileCapabilityType.cs
@@ -21,6 +21,11 @@ namespace OpenQA.Selenium.Appium.Enums
     public sealed class IOSMobileCapabilityType
     {
         /// <summary>
+        /// Amount of time in ms to wait for Simulator to startup before assuming it hung and failing the session. Default is 120000ms (2 minutes).
+        /// </summary>
+        public static readonly string SimulatorStartupTimeout = "simulatorStartupTimeout";
+
+        /// <summary>
         /// (Sim-only) Calendar format to set for the iOS Simulator
         /// </summary>
         public static readonly string CalendarFormat = "calendarFormat";


### PR DESCRIPTION
## Change list

- Added `SimulatorStartupTimeout` capability to `IOSMobileCapabilityType`.
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)
