### PR TITLE
test: Add validations to 'CanToggleData' Test

### DIFF
--- a/test/integration/Android/Device/NetworkTests.cs
+++ b/test/integration/Android/Device/NetworkTests.cs
@@ -26,7 +26,10 @@ namespace Appium.Net.Integration.Tests.Android.Device
         [OneTimeTearDown]
         public void TearDown()
         {
-            _driver.Dispose();
+            if (_driver != null)
+            {
+                _driver.Dispose();
+            }            
         }
 
         [Test]
@@ -35,7 +38,11 @@ namespace Appium.Net.Integration.Tests.Android.Device
             var androidDriver = (AndroidDriver) _driver;
 
             androidDriver.ToggleData();
+            ConnectionType currentConnectionType = androidDriver.ConnectionType;
+            Assert.That(currentConnectionType, Is.EqualTo(ConnectionType.WifiOnly));
             androidDriver.ToggleData();
+            currentConnectionType = androidDriver.ConnectionType;
+            Assert.That(currentConnectionType, Is.EqualTo(ConnectionType.AllNetworkOn));
         }
 
         [Test]


### PR DESCRIPTION
## Change list

Added Assert on currentConnectionType after we Toggle the Data
Dispose the Driver if it's not null
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

After toggling the data, better to check currentConnectionType was changed accordingly. 