### PR TITLE
fix: dev property should be in uppercase inside the env.json.sample file

### DIFF
--- a/test/integration/env.json.sample
+++ b/test/integration/env.json.sample
@@ -1,5 +1,5 @@
 {
-  "dev": false,
+  "DEV": false,
   "isRemoteAppiumServer": false,
   "remoteAppiumServerUri": "http://<remoteurl>:<port>/wd/hub",
 }


### PR DESCRIPTION
## Change list

Currently our 'env.json.sample' contains the 'dev' property as Lowercase while our code is looking for 'DEV' in uppercase.

https://github.com/appium/appium-dotnet-driver/blob/6434b152860a2cf3ff52e41b3c6522ebe31db646/test/integration/helpers/Env.cs#L47-L51

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [ ] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [x] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
