### PR TITLE
Fix: update broken link of 5.0.0-beta02 NuGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet Badge](https://buildstats.info/nuget/Appium.Webdriver)](https://www.nuget.org/packages/Appium.Webdriver/)
 [![Build Status](https://dev.azure.com/AppiumCI/dotnet-client/_apis/build/status/appium.appium-dotnet-driver?branchName=master)](https://dev.azure.com/AppiumCI/dotnet-client/_build/latest?definitionId=13&branchName=master)
 
-[![NuGet Badge](https://buildstats.info/nuget/Appium.Webdriver?includePreReleases=true)](https://www.nuget.org/packages/Appium.Webdriver)
+[![NuGet Badge](https://buildstats.info/nuget/Appium.Webdriver?includePreReleases=true)](https://www.nuget.org/packages/Appium.WebDriver/5.0.0-beta02)
 
 
 This driver is an extension of the [Selenium](http://docs.seleniumhq.org/) C# client. It has 


### PR DESCRIPTION
## Change list

Currently the NuGet badge for beta version redirect for v4.4.0, instead of the latest beta version.
 
## Types of changes

What types of changes are you proposing/introducing to .NET client?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New feature (non-breaking change which adds value to the project)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Documentation
- [x] Have you proposed a file change/ PR with appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests to pass against the beta version of appium? (for Bugfix or New feature)

## Details

Please provide more details about changes if it is necessary. If there are new features you can provide code samples which show the way they
work and possible use cases. Also you can create [gists](https://gist.github.com) with pasted C# code samples or put them here using markdown. 
About markdown please read [Mastering markdown](https://guides.github.com/features/mastering-markdown/) and [Writing on GitHub](https://help.github.com/categories/writing-on-github/) 
