### PR TITLE
test: Bump NUnit from 4.5.1 to 4.6.1 and resolve compiler ambiguities

### DIFF
--- a/test/integration/Android/ActionsChainsTest.cs
+++ b/test/integration/Android/ActionsChainsTest.cs
@@ -1,4 +1,4 @@
-﻿//Licensed under the Apache License, Version 2.0 (the "License");
+//Licensed under the Apache License, Version 2.0 (the "License");
 //you may not use this file except in compliance with the License.
 //See the NOTICE file distributed with this work for additional
 //information regarding copyright ownership.
@@ -182,11 +182,11 @@ namespace Appium.Net.Integration.Tests.Android
 
             _driver.PerformActions(sequenceActions);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(origin.Location.Y, Is.Not.EqualTo(loc1.Y));
                 Assert.That(target.Location.Y, Is.Not.EqualTo(loc2.Y));
-            });
+            }
 
         }
 
@@ -243,11 +243,11 @@ namespace Appium.Net.Integration.Tests.Android
             var sequenceActions = actionBuilder.ToActionSequenceList();
             _driver.PerformActions(sequenceActions);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(origin.Location.Y, Is.Not.EqualTo(loc1.Y));
                 Assert.That(target.Location.Y, Is.Not.EqualTo(loc2.Y));
-            });
+            }
 
         }
     }

--- a/test/integration/Android/AndroidUiScrollableTests.cs
+++ b/test/integration/Android/AndroidUiScrollableTests.cs
@@ -161,8 +161,8 @@ namespace Appium.Net.Integration.Tests.Android
         [TestCase(-1)]
         public void SetSwipeDeadZonePercentageThrowsExceptionIfOutOfRange(double invalidValue)
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => 
-                _sut.SetSwipeDeadZonePercentage(invalidValue));
+            Assert.Throws<ArgumentOutOfRangeException>((System.Action)(() => 
+                _sut.SetSwipeDeadZonePercentage(invalidValue)));
         }
 
         [Test]

--- a/test/integration/Android/App/InstallAppTest.cs
+++ b/test/integration/Android/App/InstallAppTest.cs
@@ -66,7 +66,7 @@ namespace Appium.Net.Integration.Tests.Android.App
         public void MobileInstallApp_InvalidPath_Throws()
         {
             var badPath = "/nonexistent/path/app.apk";
-            var ex = Assert.Throws<UnknownErrorException>(() => _driver.InstallApp(badPath));
+            var ex = Assert.Throws<UnknownErrorException>((System.Action)(() => _driver.InstallApp(badPath)));
             Assert.That(ex.Message, Does.Contain("does not exist").IgnoreCase);
         }
 

--- a/test/integration/Android/ClipboardTest.cs
+++ b/test/integration/Android/ClipboardTest.cs
@@ -46,43 +46,41 @@ namespace Appium.Net.Integration.Tests.Android
         public void WhenSetClipboardContentTypeIsPlainTextGetClipboardShouldReturnEncodedBase64String()
         {
             _driver.SetClipboard(ClipboardContentType.PlainText, ClipboardTestString);
-            Assert.That(() => Regex.IsMatch(_driver.GetClipboard(ClipboardContentType.PlainText), Base64RegexPattern, RegexOptions.Multiline),
-                Is.True);
+            Assert.That(Regex.IsMatch(_driver.GetClipboard(ClipboardContentType.PlainText), Base64RegexPattern, RegexOptions.Multiline), Is.True);
         }
 
         [Test]
         public void WhenClipboardContentTypeIsPlainTextWithLabelGetClipboardTextShouldReturnActualText()
         {
             _driver.SetClipboardText(ClipboardTestString, label:"testing");
-            Assert.That(() => _driver.GetClipboardText(), Does.Match(ClipboardTestString));
+            Assert.That(_driver.GetClipboardText(), Does.Match(ClipboardTestString));
         }
 
         [Test]
         public void WhenClipboardContentTypeIsPlainTextWithOutLabelGetClipboardTextShouldReturnActualText()
         {
             _driver.SetClipboardText(ClipboardTestString, null);
-            Assert.That(() => _driver.GetClipboardText(), Does.Match(ClipboardTestString));
+            Assert.That(_driver.GetClipboardText(), Does.Match(ClipboardTestString));
         }
 
         [Test]
         public void WhenClipboardIsEmptyGetClipboardShouldReturnEmptyString()
         {
             _driver.SetClipboardText(string.Empty, null);
-            Assert.That(() => _driver.GetClipboard(ClipboardContentType.PlainText), Is.Empty);
+            Assert.That(_driver.GetClipboard(ClipboardContentType.PlainText), Is.Empty);
         }
 
         [Test]
         public void WhenClipboardIsEmptyGetClipboardTextShouldReturnEmptyString()
         {
             _driver.SetClipboardText(string.Empty, null);
-            Assert.That(() => _driver.GetClipboardText(), Is.Empty);
+            Assert.That(_driver.GetClipboardText(), Is.Empty);
         }
 
         [Test]
         public void WhenSetClipboardContentTypeIsImageSetClipboardShouldReturnNotImplementedException()
         {
-            Assert.That(() => _driver.SetClipboard(ClipboardContentType.Image, ClipboardTestString),
-                Throws.TypeOf<NotImplementedException>());
+            Assert.That((System.Action)(() => _driver.SetClipboard(ClipboardContentType.Image, ClipboardTestString)), Throws.TypeOf<NotImplementedException>());
         }
 
         [Test]
@@ -91,8 +89,7 @@ namespace Appium.Net.Integration.Tests.Android
 #endif
         public void WhenGetClipboardImageGetClipboardShouldReturnNotImplementedException()
         {
-            Assert.That(() => _driver.GetClipboardImage(),
-                Throws.TypeOf<NotImplementedException>());
+            Assert.That((System.Action)(() => _driver.GetClipboardImage()), Throws.TypeOf<NotImplementedException>());
         }
 
         [Test]
@@ -105,35 +102,31 @@ namespace Appium.Net.Integration.Tests.Android
             Image testImage = new Bitmap(100, 100); // Create a sample image for testing
 
             // Act & Assert
-            _ = Assert.Throws<NotImplementedException>(() => _driver.SetClipboardImage(testImage));
+            _ = Assert.Throws<NotImplementedException>((System.Action)(() => _driver.SetClipboardImage(testImage)));
         }
 
         [Test]
         public void WhenGetClipboardUrlGetClipboardShouldReturnNotImplementedException()
         {
-            Assert.That(() => _driver.GetClipboardUrl(),
-                Throws.TypeOf<NotImplementedException>());
+            Assert.That((System.Action)(() => _driver.GetClipboardUrl()), Throws.TypeOf<NotImplementedException>());
         }
 
         [Test]
         public void WhenSetClipboardContentTypeIsUrlSetClipboardShouldReturnNotImplementedException()
         {
-            Assert.That(() => _driver.SetClipboard(ClipboardContentType.Url, string.Empty),
-                Throws.TypeOf<NotImplementedException>());
+            Assert.That((System.Action)(() => _driver.SetClipboard(ClipboardContentType.Url, string.Empty)), Throws.TypeOf<NotImplementedException>());
         }
 
         [Test]
         public void WhenClipboardContentTypeIsUrlGetClipboardShouldReturnNotImplementedException()
         {
-            Assert.That(() => _driver.GetClipboard(ClipboardContentType.Url),
-                Throws.TypeOf<NotImplementedException>());
+            Assert.That((System.Action)(() => _driver.GetClipboard(ClipboardContentType.Url)), Throws.TypeOf<NotImplementedException>());
         }
 
         [Test]
         public void WhenClipboardContentTypeIsImageGetClipboardShouldReturnNotImplementedException()
         {
-            Assert.That(() => _driver.GetClipboard(ClipboardContentType.Image),
-                Throws.TypeOf<NotImplementedException>());
+            Assert.That((System.Action)(() => _driver.GetClipboard(ClipboardContentType.Image)), Throws.TypeOf<NotImplementedException>());
         }
     }
 }

--- a/test/integration/Android/Device/App/AppTests.cs
+++ b/test/integration/Android/Device/App/AppTests.cs
@@ -36,7 +36,7 @@ namespace Appium.Net.Integration.Tests.Android.Device.App
         public void CanActivateAppTest()
         {
             //Activate an app to foreground
-            Assert.DoesNotThrow((Action)(() => _driver.ActivateApp(ApiDemosPackageName)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.ActivateApp(ApiDemosPackageName)));
 
             Assert.That(_driver.GetAppState(ApiDemosPackageName), Is.EqualTo(AppState.RunningInForeground));
 
@@ -68,7 +68,6 @@ namespace Appium.Net.Integration.Tests.Android.Device.App
             Assert.DoesNotThrow((System.Action)(() => _driver.ActivateApp(ApiDemosPackageName)));
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement))));
             Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement))));
         }
 

--- a/test/integration/Android/Device/App/AppTests.cs
+++ b/test/integration/Android/Device/App/AppTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Appium.Net.Integration.Tests.helpers;
 using NUnit.Framework;
 using OpenQA.Selenium.Appium;
@@ -36,22 +36,22 @@ namespace Appium.Net.Integration.Tests.Android.Device.App
         public void CanActivateAppTest()
         {
             //Activate an app to foreground
-            Assert.DoesNotThrow(() => _driver.ActivateApp(ApiDemosPackageName));
+            Assert.DoesNotThrow((Action)(() => _driver.ActivateApp(ApiDemosPackageName)));
 
             Assert.That(_driver.GetAppState(ApiDemosPackageName), Is.EqualTo(AppState.RunningInForeground));
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement))));
         }
 
         [Test]
         public void CanActivateAppWithTimeoutTest()
         {
             //Activate an app to foreground
-            Assert.DoesNotThrow(() => _driver.ActivateApp(ApiDemosPackageName, TimeSpan.FromSeconds(20)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.ActivateApp(ApiDemosPackageName, TimeSpan.FromSeconds(20))));
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement))));
         }
         [Test]
         public void CanActivateAppFromBackgroundTest()
@@ -60,16 +60,16 @@ namespace Appium.Net.Integration.Tests.Android.Device.App
             _driver.ActivateApp(ApiDemosPackageName);
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement))));
 
-            Assert.DoesNotThrow(() => _driver.BackgroundApp());
+            Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp()));
 
             //Activates Test App to foreground from background
-            Assert.DoesNotThrow(() => _driver.ActivateApp(ApiDemosPackageName));
+            Assert.DoesNotThrow((System.Action)(() => _driver.ActivateApp(ApiDemosPackageName)));
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement)));
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement))));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(ApiDemoElement))));
         }
 
         #endregion
@@ -79,22 +79,19 @@ namespace Appium.Net.Integration.Tests.Android.Device.App
         [Test]
         public void CanBackgroundApp()
         {
-            Assert.DoesNotThrow(
-                () => _driver.BackgroundApp());
+            Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp()));
         }
 
         [Test]
         public void CanBackgroundAppForSeconds()
         {
-            Assert.DoesNotThrow(
-                () => _driver.BackgroundApp(TimeSpan.FromSeconds(5)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp(TimeSpan.FromSeconds(5))));
         }
 
         [Test]
         public void CanBackgroundAppToDeactivationUsingNegativeSecond()
         {
-            Assert.DoesNotThrow(
-                () => _driver.BackgroundApp(-TimeSpan.FromSeconds(-1)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp(-TimeSpan.FromSeconds(-1))));
         }
 
         #endregion

--- a/test/integration/Android/Device/App/AppTests.cs
+++ b/test/integration/Android/Device/App/AppTests.cs
@@ -90,7 +90,7 @@ namespace Appium.Net.Integration.Tests.Android.Device.App
         [Test]
         public void CanBackgroundAppToDeactivationUsingNegativeSecond()
         {
-            Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp(-TimeSpan.FromSeconds(-1))));
+            Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp(TimeSpan.FromSeconds(-1))));
         }
 
         #endregion

--- a/test/integration/Android/Device/Keys/KeyPressTest.cs
+++ b/test/integration/Android/Device/Keys/KeyPressTest.cs
@@ -66,31 +66,31 @@ namespace Appium.Net.Integration.Tests.Android.Device.Keys
         [Test]
         public void PressKeyCodeKeyEventTest()
         {
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
-                Assert.DoesNotThrow(() => _driver.PressKeyCode(new KeyEvent().WithKeyCode(AndroidKeyCode.Space)
-                    .WithMetaKeyModifier(AndroidKeyMetastate.Meta_Shift_On).WithFlag(AndroidKeyCode.FlagSoftKeyboard)));
-                Assert.Throws<InvalidOperationException>(() =>
-                    _driver.PressKeyCode(new KeyEvent().WithFlag(AndroidKeyCode.Home)));
-                Assert.Throws<InvalidOperationException>(() =>
+                Assert.DoesNotThrow((System.Action)(() => _driver.PressKeyCode(new KeyEvent().WithKeyCode(AndroidKeyCode.Space)
+                    .WithMetaKeyModifier(AndroidKeyMetastate.Meta_Shift_On).WithFlag(AndroidKeyCode.FlagSoftKeyboard))));
+                Assert.Throws<InvalidOperationException>((System.Action)(() =>
+                    _driver.PressKeyCode(new KeyEvent().WithFlag(AndroidKeyCode.Home))));
+                Assert.Throws<InvalidOperationException>((System.Action)(() =>
                     _driver.PressKeyCode(new KeyEvent().WithFlag(AndroidKeyCode.Home)
-                        .WithMetaKeyModifier(AndroidKeyCode.MetaAlt_ON)));
-            });
+                        .WithMetaKeyModifier(AndroidKeyCode.MetaAlt_ON))));
+            }
         }
 
         [Test]
         public void LongPressKeyCodeKeyEventTest()
         {
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
-                Assert.DoesNotThrow(() => _driver.LongPressKeyCode(new KeyEvent().WithKeyCode(AndroidKeyCode.Space)
-                    .WithMetaKeyModifier(AndroidKeyMetastate.Meta_Shift_On).WithFlag(AndroidKeyCode.FlagLongPress)));
-                Assert.Throws<InvalidOperationException>(() =>
-                    _driver.LongPressKeyCode(new KeyEvent().WithFlag(AndroidKeyCode.Home)));
-                Assert.Throws<InvalidOperationException>(() =>
+                Assert.DoesNotThrow((System.Action)(() => _driver.LongPressKeyCode(new KeyEvent().WithKeyCode(AndroidKeyCode.Space)
+                    .WithMetaKeyModifier(AndroidKeyMetastate.Meta_Shift_On).WithFlag(AndroidKeyCode.FlagLongPress))));
+                Assert.Throws<InvalidOperationException>((System.Action)(() =>
+                    _driver.LongPressKeyCode(new KeyEvent().WithFlag(AndroidKeyCode.Home))));
+                Assert.Throws<InvalidOperationException>((System.Action)(() =>
                     _driver.LongPressKeyCode(new KeyEvent().WithFlag(AndroidKeyCode.Home)
-                        .WithMetaKeyModifier(AndroidKeyCode.MetaAlt_ON)));
-            });
+                        .WithMetaKeyModifier(AndroidKeyCode.MetaAlt_ON))));
+            }
         }
     }
 }

--- a/test/integration/Android/Device/NetworkTests.cs
+++ b/test/integration/Android/Device/NetworkTests.cs
@@ -41,53 +41,52 @@ namespace Appium.Net.Integration.Tests.Android.Device
         [Test]
         public void CanMakeGsmCallTest()
         {
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
-                Assert.DoesNotThrow(() => _driver.MakeGsmCall("5551234567", GsmCallActions.Call));
-                Assert.DoesNotThrow(() => _driver.MakeGsmCall("5551234567", GsmCallActions.Accept));
-                Assert.DoesNotThrow(() => _driver.MakeGsmCall("5551234567", GsmCallActions.Cancel));
-                Assert.DoesNotThrow(() => _driver.MakeGsmCall("5551234567", GsmCallActions.Hold));
-            });
+                Assert.DoesNotThrow((System.Action)(() => _driver.MakeGsmCall("5551234567", GsmCallActions.Call)));
+                Assert.DoesNotThrow((System.Action)(() => _driver.MakeGsmCall("5551234567", GsmCallActions.Accept)));
+                Assert.DoesNotThrow((System.Action)(() => _driver.MakeGsmCall("5551234567", GsmCallActions.Cancel)));
+                Assert.DoesNotThrow((System.Action)(() => _driver.MakeGsmCall("5551234567", GsmCallActions.Hold)));
+            }
         }
 
         [Test]
         public void CanSetGsmSignalStrengthTest()
         {
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
-                Assert.DoesNotThrow(() => _driver.SetGsmSignalStrength(GsmSignalStrength.NoneOrUnknown));
-                Assert.DoesNotThrow(() => _driver.SetGsmSignalStrength(GsmSignalStrength.Poor));
-                Assert.DoesNotThrow(() => _driver.SetGsmSignalStrength(GsmSignalStrength.Good));
-                Assert.DoesNotThrow(() => _driver.SetGsmSignalStrength(GsmSignalStrength.Moderate));
-                Assert.DoesNotThrow(() => _driver.SetGsmSignalStrength(GsmSignalStrength.Great));
-            });
+                Assert.DoesNotThrow((System.Action)(() => _driver.SetGsmSignalStrength(GsmSignalStrength.NoneOrUnknown)));
+                Assert.DoesNotThrow((System.Action)(() => _driver.SetGsmSignalStrength(GsmSignalStrength.Poor)));
+                Assert.DoesNotThrow((System.Action)(() => _driver.SetGsmSignalStrength(GsmSignalStrength.Good)));
+                Assert.DoesNotThrow((System.Action)(() => _driver.SetGsmSignalStrength(GsmSignalStrength.Moderate)));
+                Assert.DoesNotThrow((System.Action)(() => _driver.SetGsmSignalStrength(GsmSignalStrength.Great)));
+            }
         }
 
         [Test]
         public void CanSetGsmVoiceStateTest()
         {
-            Assert.Multiple(() =>
-                {
-                    Assert.DoesNotThrow(() =>
-                        _driver.SetGsmVoice(GsmVoiceState.Unregistered));
-                    Assert.DoesNotThrow(() =>
-                        _driver.SetGsmVoice(GsmVoiceState.Home));
-                    Assert.DoesNotThrow(() =>
-                        _driver.SetGsmVoice(GsmVoiceState.Roaming));
-                    Assert.DoesNotThrow(() =>
-                        _driver.SetGsmVoice(GsmVoiceState.Denied));
-                    Assert.DoesNotThrow(() =>
-                        _driver.SetGsmVoice(GsmVoiceState.Off));
-                    Assert.DoesNotThrow(() =>
-                        _driver.SetGsmVoice(GsmVoiceState.On));
+            using (Assert.EnterMultipleScope())
+            {
+                    Assert.DoesNotThrow((System.Action)(() =>
+                        _driver.SetGsmVoice(GsmVoiceState.Unregistered)));
+                    Assert.DoesNotThrow((System.Action)(() =>
+                        _driver.SetGsmVoice(GsmVoiceState.Home)));
+                    Assert.DoesNotThrow((System.Action)(() =>
+                        _driver.SetGsmVoice(GsmVoiceState.Roaming)));
+                    Assert.DoesNotThrow((System.Action)(() =>
+                        _driver.SetGsmVoice(GsmVoiceState.Denied)));
+                    Assert.DoesNotThrow((System.Action)(() =>
+                        _driver.SetGsmVoice(GsmVoiceState.Off)));
+                    Assert.DoesNotThrow((System.Action)(() =>
+                        _driver.SetGsmVoice(GsmVoiceState.On)));
                 }
-            );
         }
 
         [Test]
         public void CanSendSmsTest()
         {
-            Assert.DoesNotThrow(() => _driver.SendSms("5551234567", "Hey lol"));
+            Assert.DoesNotThrow((System.Action)(() => _driver.SendSms("5551234567", "Hey lol")));
         }
     }
 }

--- a/test/integration/Android/Device/NetworkTests.cs
+++ b/test/integration/Android/Device/NetworkTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Appium.Net.Integration.Tests.helpers;
 using NUnit.Framework;
 using OpenQA.Selenium.Appium;
@@ -68,19 +68,19 @@ namespace Appium.Net.Integration.Tests.Android.Device
         {
             using (Assert.EnterMultipleScope())
             {
-                    Assert.DoesNotThrow((System.Action)(() =>
-                        _driver.SetGsmVoice(GsmVoiceState.Unregistered)));
-                    Assert.DoesNotThrow((System.Action)(() =>
-                        _driver.SetGsmVoice(GsmVoiceState.Home)));
-                    Assert.DoesNotThrow((System.Action)(() =>
-                        _driver.SetGsmVoice(GsmVoiceState.Roaming)));
-                    Assert.DoesNotThrow((System.Action)(() =>
-                        _driver.SetGsmVoice(GsmVoiceState.Denied)));
-                    Assert.DoesNotThrow((System.Action)(() =>
-                        _driver.SetGsmVoice(GsmVoiceState.Off)));
-                    Assert.DoesNotThrow((System.Action)(() =>
-                        _driver.SetGsmVoice(GsmVoiceState.On)));
-                }
+                Assert.DoesNotThrow((System.Action)(() =>
+                    _driver.SetGsmVoice(GsmVoiceState.Unregistered)));
+                Assert.DoesNotThrow((System.Action)(() =>
+                    _driver.SetGsmVoice(GsmVoiceState.Home)));
+                Assert.DoesNotThrow((System.Action)(() =>
+                    _driver.SetGsmVoice(GsmVoiceState.Roaming)));
+                Assert.DoesNotThrow((System.Action)(() =>
+                    _driver.SetGsmVoice(GsmVoiceState.Denied)));
+                Assert.DoesNotThrow((System.Action)(() =>
+                    _driver.SetGsmVoice(GsmVoiceState.Off)));
+                Assert.DoesNotThrow((System.Action)(() =>
+                    _driver.SetGsmVoice(GsmVoiceState.On)));
+            }
         }
 
         [Test]

--- a/test/integration/Android/ElementTestEspresso.cs
+++ b/test/integration/Android/ElementTestEspresso.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Appium.Net.Integration.Tests.helpers;
 using NUnit.Framework;
 using OpenQA.Selenium;
@@ -37,7 +37,7 @@ namespace Appium.Net.Integration.Tests.Android
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(
-                            Is.Not.EqualTo(_driver.FindElement(MobileBy.Id("android:id/list")).FindElement(byAndroidDataMatcher).Text), null);
+                    _driver.FindElement(MobileBy.Id("android:id/list")).FindElement(byAndroidDataMatcher).Text, Is.Not.Null);
                 Assert.That(
                     _driver.FindElement(MobileBy.Id("android:id/list")).FindElements(byAndroidDataMatcher), Is.Not.Empty);
             }
@@ -63,7 +63,7 @@ namespace Appium.Net.Integration.Tests.Android
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(
-                            Is.Not.EqualTo(_driver.FindElement(MobileBy.Id("android:id/list")).FindElement(byAndroidViewMatcher).Text), null);
+                    _driver.FindElement(MobileBy.Id("android:id/list")).FindElement(byAndroidViewMatcher).Text, Is.Not.Null);
                 Assert.That(
                     _driver.FindElement(MobileBy.Id("android:id/list")).FindElements(byAndroidViewMatcher), Is.Not.Empty);
             }

--- a/test/integration/Android/ElementTestEspresso.cs
+++ b/test/integration/Android/ElementTestEspresso.cs
@@ -34,13 +34,13 @@ namespace Appium.Net.Integration.Tests.Android
 
             By byAndroidDataMatcher = new ByAndroidDataMatcher(selectorData);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(
                             Is.Not.EqualTo(_driver.FindElement(MobileBy.Id("android:id/list")).FindElement(byAndroidDataMatcher).Text), null);
                 Assert.That(
                     _driver.FindElement(MobileBy.Id("android:id/list")).FindElements(byAndroidDataMatcher), Is.Not.Empty);
-            });
+            }
         }
 
         [Test]
@@ -60,13 +60,13 @@ namespace Appium.Net.Integration.Tests.Android
 
             By byAndroidViewMatcher = new ByAndroidViewMatcher(selectorData);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(
                             Is.Not.EqualTo(_driver.FindElement(MobileBy.Id("android:id/list")).FindElement(byAndroidViewMatcher).Text), null);
                 Assert.That(
                     _driver.FindElement(MobileBy.Id("android:id/list")).FindElements(byAndroidViewMatcher), Is.Not.Empty);
-            });
+            }
         }
 
         [OneTimeTearDown]

--- a/test/integration/Android/EmulatorDeviceTime.cs
+++ b/test/integration/Android/EmulatorDeviceTime.cs
@@ -36,13 +36,13 @@ namespace Appium.Net.Integration.Tests.Android
         public void DeviceTimeTest()
         {
             var time = _driver.DeviceTime;
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(time, Is.Not.Null);
                 Assert.That(time, Is.Not.EqualTo(Empty));
                 Console.WriteLine(time);
                 Assert.That(DateTime.Parse(time), Is.Not.EqualTo(DateTime.Now.AddDays(3)));
-            });
+            }
         }
     }
 }

--- a/test/integration/Android/SearchingTest.cs
+++ b/test/integration/Android/SearchingTest.cs
@@ -50,33 +50,33 @@ namespace Appium.Net.Integration.Tests.Android
         public void FindByAccessibilityIdTest()
         {
             By byAccessibilityId = new ByAccessibilityId("Graphics");
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(_driver.FindElement(byAccessibilityId).Text, Is.EqualTo("Graphics"));
                 Assert.That(_driver.FindElements(byAccessibilityId), Is.Not.Empty);
-            });
+            }
         }
 
         [Test]
         public void FindByAndroidUiAutomatorTest()
         {
             By byAndroidUiAutomator = new ByAndroidUIAutomator("new UiSelector().clickable(true)");
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(_driver.FindElement(byAndroidUiAutomator).Text, Is.Not.Null);
                 Assert.That(_driver.FindElements(byAndroidUiAutomator), Is.Not.Empty);
-            });
+            }
         }
 
         [Test]
         public void FindByXPathTest()
         {
             var byXPath = "//android.widget.TextView[contains(@text, 'Animat')]";
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(_driver.FindElement(By.XPath(byXPath)).Text, Is.Not.Null);
                 Assert.That(_driver.FindElements(By.XPath(byXPath)), Has.Count.EqualTo(1));
-            });
+            }
         }
 
         [Test]

--- a/test/integration/Android/Session/GeolocationTests.cs
+++ b/test/integration/Android/Session/GeolocationTests.cs
@@ -1,4 +1,4 @@
-﻿using Appium.Net.Integration.Tests.helpers;
+using Appium.Net.Integration.Tests.helpers;
 using NUnit.Framework;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
@@ -39,14 +39,14 @@ namespace Appium.Net.Integration.Tests.Android.Session.Geolocation
             {
                 Assert.Ignore("Skipping GetLocationTest test in CI environment");
             }
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
-                Assert.That(() => _driver.Location, Is.Not.Null);
-                Assert.DoesNotThrow(() => _driver.Location.ToDictionary());
+                Assert.That(_driver.Location, Is.Not.Null);
+                Assert.DoesNotThrow((System.Action)(() => _driver.Location.ToDictionary()));
                 Assert.That(_driver.Location.Altitude, Is.Not.EqualTo(0));
                 Assert.That(_driver.Location.Longitude, Is.Not.EqualTo(0));
                 Assert.That(_driver.Location.Latitude, Is.Not.EqualTo(0));
-            });
+            }
         }
 
         [Test]
@@ -64,14 +64,14 @@ namespace Appium.Net.Integration.Tests.Android.Session.Geolocation
                 Latitude = 10,
             };
             _driver.Location = testLocation;
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
-                Assert.That(() => _driver.Location, Is.Not.Null);
-                Assert.DoesNotThrow(() => _driver.Location.ToDictionary());
+                Assert.That(_driver.Location, Is.Not.Null);
+                Assert.DoesNotThrow((System.Action)(() => _driver.Location.ToDictionary()));
                 Assert.That(_driver.Location.Altitude, Is.Not.EqualTo(0));
                 Assert.That(_driver.Location.Longitude, Is.Not.EqualTo(0));
                 Assert.That(_driver.Location.Latitude, Is.Not.EqualTo(0));
-            });
+            }
         }
     }
 }

--- a/test/integration/Android/Session/GeolocationTests.cs
+++ b/test/integration/Android/Session/GeolocationTests.cs
@@ -39,13 +39,14 @@ namespace Appium.Net.Integration.Tests.Android.Session.Geolocation
             {
                 Assert.Ignore("Skipping GetLocationTest test in CI environment");
             }
+            var location = _driver.Location;
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(_driver.Location, Is.Not.Null);
-                Assert.DoesNotThrow((System.Action)(() => _driver.Location.ToDictionary()));
-                Assert.That(_driver.Location.Altitude, Is.Not.EqualTo(0));
-                Assert.That(_driver.Location.Longitude, Is.Not.EqualTo(0));
-                Assert.That(_driver.Location.Latitude, Is.Not.EqualTo(0));
+                Assert.That(location, Is.Not.Null);
+                Assert.DoesNotThrow((System.Action)(() => location.ToDictionary()));
+                Assert.That(location.Altitude, Is.Not.EqualTo(0));
+                Assert.That(location.Longitude, Is.Not.EqualTo(0));
+                Assert.That(location.Latitude, Is.Not.EqualTo(0));
             }
         }
 
@@ -64,13 +65,14 @@ namespace Appium.Net.Integration.Tests.Android.Session.Geolocation
                 Latitude = 10,
             };
             _driver.Location = testLocation;
+            var location = _driver.Location;
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(_driver.Location, Is.Not.Null);
-                Assert.DoesNotThrow((System.Action)(() => _driver.Location.ToDictionary()));
-                Assert.That(_driver.Location.Altitude, Is.Not.EqualTo(0));
-                Assert.That(_driver.Location.Longitude, Is.Not.EqualTo(0));
-                Assert.That(_driver.Location.Latitude, Is.Not.EqualTo(0));
+                Assert.That(location, Is.Not.Null);
+                Assert.DoesNotThrow((System.Action)(() => location.ToDictionary()));
+                Assert.That(location.Altitude, Is.Not.EqualTo(0));
+                Assert.That(location.Longitude, Is.Not.EqualTo(0));
+                Assert.That(location.Latitude, Is.Not.EqualTo(0));
             }
         }
     }

--- a/test/integration/Android/Session/GeolocationTests.cs
+++ b/test/integration/Android/Session/GeolocationTests.cs
@@ -42,8 +42,7 @@ namespace Appium.Net.Integration.Tests.Android.Session.Geolocation
             var location = _driver.Location;
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(location, Is.Not.Null);
-                Assert.DoesNotThrow((System.Action)(() => location.ToDictionary()));
+                Assert.That(location.ToDictionary(), Is.Not.Null);
                 Assert.That(location.Altitude, Is.Not.EqualTo(0));
                 Assert.That(location.Longitude, Is.Not.EqualTo(0));
                 Assert.That(location.Latitude, Is.Not.EqualTo(0));
@@ -68,8 +67,7 @@ namespace Appium.Net.Integration.Tests.Android.Session.Geolocation
             var location = _driver.Location;
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(location, Is.Not.Null);
-                Assert.DoesNotThrow((System.Action)(() => location.ToDictionary()));
+                Assert.That(location.ToDictionary(), Is.Not.Null);
                 Assert.That(location.Altitude, Is.Not.EqualTo(0));
                 Assert.That(location.Longitude, Is.Not.EqualTo(0));
                 Assert.That(location.Latitude, Is.Not.EqualTo(0));

--- a/test/integration/Android/Session/LogTests.cs
+++ b/test/integration/Android/Session/LogTests.cs
@@ -37,11 +37,11 @@ namespace Appium.Net.Integration.Tests.Android.Session.Logs
         {
             var logs = _driver.Manage().Logs;
             var availableLogTypes = _driver.Manage().Logs.AvailableLogTypes;
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(logs.AvailableLogTypes, Is.Not.Null);
                 Assert.That(availableLogTypes, Is.Not.Empty, nameof(availableLogTypes));
-            });
+            }
             Console.WriteLine(@"Available log types:");
             foreach (var logType in availableLogTypes)
             {
@@ -56,7 +56,7 @@ namespace Appium.Net.Integration.Tests.Android.Session.Logs
             Assert.That(availableLogTypes, Is.Not.Null);
             Assert.That(availableLogTypes, Has.Member(LogcatLogType));
 
-            Assert.DoesNotThrow(() => _driver.Manage().Logs.GetLog(LogcatLogType));
+            Assert.DoesNotThrow((System.Action)(() => _driver.Manage().Logs.GetLog(LogcatLogType)));
         }
 
         /// <summary>

--- a/test/integration/Android/SettingTest.cs
+++ b/test/integration/Android/SettingTest.cs
@@ -45,14 +45,14 @@ namespace Appium.Net.Integration.Tests.Android
             _driver.ConfiguratorSetWaitForSelectorTimeout(1000);
 
             var settings = _driver.Settings;
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(settings[AutomatorSetting.KeyInjectionDelay], Is.EqualTo(400));
                 Assert.That(settings[AutomatorSetting.WaitActionAcknowledgmentTimeout], Is.EqualTo(500));
                 Assert.That(settings[AutomatorSetting.WaitForIDLETimeout], Is.EqualTo(600));
                 Assert.That(settings[AutomatorSetting.WaitForSelectorTimeout], Is.EqualTo(1000));
                 Assert.That(settings[AutomatorSetting.WaitScrollAcknowledgmentTimeout], Is.EqualTo(300));
-            });
+            }
         }
 
         [Test]
@@ -69,14 +69,14 @@ namespace Appium.Net.Integration.Tests.Android
 
             _driver.Settings = data;
             var settings = _driver.Settings;
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(settings[AutomatorSetting.KeyInjectionDelay], Is.EqualTo(1500));
                 Assert.That(settings[AutomatorSetting.WaitActionAcknowledgmentTimeout], Is.EqualTo(2500));
                 Assert.That(settings[AutomatorSetting.WaitForIDLETimeout], Is.EqualTo(3500));
                 Assert.That(settings[AutomatorSetting.WaitForSelectorTimeout], Is.EqualTo(5000));
                 Assert.That(settings[AutomatorSetting.WaitScrollAcknowledgmentTimeout], Is.EqualTo(7000));
-            });
+            }
         }
 
         [OneTimeTearDown]

--- a/test/integration/Appium.Net.Integration.Tests.csproj
+++ b/test/integration/Appium.Net.Integration.Tests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/integration/Appium.Net.Integration.Tests.csproj
+++ b/test/integration/Appium.Net.Integration.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net48;net8.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>

--- a/test/integration/Element/AppiumElementCacheTest.cs
+++ b/test/integration/Element/AppiumElementCacheTest.cs
@@ -46,11 +46,11 @@ namespace Appium.Net.Integration.Tests.Element
             _element.SetCacheValues(cacheValues);
 
             // Verify cached values are returned (no server call needed)
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(_element.TagName, Is.EqualTo("android.widget.TextView"));
                 Assert.That(_element.Text, Is.EqualTo("Sample Text"));
-            });
+            }
         }
 
         [Test]
@@ -140,13 +140,13 @@ namespace Appium.Net.Integration.Tests.Element
 
             var rect = _element.Rect;
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(rect.X, Is.EqualTo(10));
                 Assert.That(rect.Y, Is.EqualTo(20));
                 Assert.That(rect.Width, Is.EqualTo(100));
                 Assert.That(rect.Height, Is.EqualTo(50));
-            });
+            }
         }
 
         [Test]
@@ -242,28 +242,28 @@ namespace Appium.Net.Integration.Tests.Element
                 { "selected", false }
             });
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(_element.TagName, Is.EqualTo("android.widget.EditText"));
                 Assert.That(_element.Text, Is.EqualTo("Enter text here"));
                 Assert.That(_element.Displayed, Is.True);
                 Assert.That(_element.Enabled, Is.True);
                 Assert.That(_element.Selected, Is.False);
-            });
+            }
         }
 
         [Test]
         public void ClearCache_WhenCacheIsNull_DoesNotThrow()
         {
             // Element starts with null cache, clearing should not throw
-            Assert.DoesNotThrow(() => _element.ClearCache());
+            Assert.DoesNotThrow((System.Action)(() => _element.ClearCache()));
         }
 
         [Test]
         public void DisableCache_WhenCacheIsNull_DoesNotThrow()
         {
             // Element starts with null cache, disabling should not throw
-            Assert.DoesNotThrow(() => _element.DisableCache());
+            Assert.DoesNotThrow((System.Action)(() => _element.DisableCache()));
         }
 
         [Test]

--- a/test/integration/IOS/ClipboardTest.cs
+++ b/test/integration/IOS/ClipboardTest.cs
@@ -1,4 +1,4 @@
-﻿using Appium.Net.Integration.Tests.helpers;
+using Appium.Net.Integration.Tests.helpers;
 using NUnit.Framework;
 using OpenQA.Selenium.Appium.Enums;
 using OpenQA.Selenium.Appium.iOS;
@@ -40,7 +40,7 @@ namespace Appium.Net.Integration.Tests.IOS
         public void WhenClipboardContentTypeIsPlainText_GetClipboardTextShouldReturnActualText()
         {
             _driver.SetClipboardText(ClipboardTestString);
-            Assert.That(_driver.GetClipboardText, Does.Match(ClipboardTestString));
+            Assert.That(_driver.GetClipboardText(), Does.Match(ClipboardTestString));
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace Appium.Net.Integration.Tests.IOS
             const string urlString = "https://github.com/appium/dotnet-client";
             _driver.SetClipboardUrl(urlString);
 
-            Assert.That(_driver.GetClipboardUrl, Does.Match(urlString));
+            Assert.That(_driver.GetClipboardUrl(), Does.Match(urlString));
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace Appium.Net.Integration.Tests.IOS
         public void WhenClipboardHasNoImage_GetClipboardImageShouldReturnNull()
         {
             _driver.SetClipboardText(ClipboardTestString);
-            Assert.That(_driver.GetClipboardImage, Is.Null);
+            Assert.That(_driver.GetClipboardImage(), Is.Null);
         }
 
         [Test]
@@ -92,7 +92,7 @@ namespace Appium.Net.Integration.Tests.IOS
         public void WhenClipboardIsEmpty_GetClipboardTextShouldReturnEmptyString()
         {
             _driver.SetClipboardText(string.Empty, null);
-            Assert.That(_driver.GetClipboardText, Is.Empty);
+            Assert.That(_driver.GetClipboardText(), Is.Empty);
         }
 
         [OneTimeTearDown]

--- a/test/integration/IOS/Device/AppTests.cs
+++ b/test/integration/IOS/Device/AppTests.cs
@@ -42,33 +42,33 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
         public void CanActivateAppTest()
         {
             //Activate an app to foreground
-            Assert.DoesNotThrow(() => _driver.ActivateApp(IosTestAppBundleId));
+            Assert.DoesNotThrow((System.Action)(() => _driver.ActivateApp(IosTestAppBundleId)));
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(IosTestAppElement)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(IosTestAppElement))));
         }
 
         [Test]
         public void CanActivateAppWithTimeoutTest()
         {
             //Activate an app to foreground
-            Assert.DoesNotThrow(() => _driver.ActivateApp(IosTestAppBundleId, TimeSpan.FromSeconds(20)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.ActivateApp(IosTestAppBundleId, TimeSpan.FromSeconds(20))));
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(IosTestAppElement)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(IosTestAppElement))));
         }
 
         [Test]
         public void CanActivateViaScriptAppTest()
         {
             //Activate an app to foreground
-            Assert.DoesNotThrow(() => _driver.ExecuteScript("mobile: activateApp",
-                new Dictionary<string, string> {{"bundleId", IosTestAppBundleId}}));
+            Assert.DoesNotThrow((System.Action)(() => _driver.ExecuteScript("mobile: activateApp",
+                new Dictionary<string, string> {{"bundleId", IosTestAppBundleId}})));
 
-            Assert.That(() => _driver.GetAppState(IosTestAppBundleId), Is.EqualTo(AppState.RunningInForeground));
+            Assert.That(_driver.GetAppState(IosTestAppBundleId), Is.EqualTo(AppState.RunningInForeground));
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(IosTestAppElement)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(IosTestAppElement))));
         }
 
         [Test]
@@ -78,13 +78,13 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
             _driver.ActivateApp(IosTestAppBundleId);
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(IosTestAppElement)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(IosTestAppElement))));
 
             //Activates Test App to foreground from background
-            Assert.DoesNotThrow(() => _driver.ActivateApp(UiCatalogAppTestAppBundleId));
+            Assert.DoesNotThrow((System.Action)(() => _driver.ActivateApp(UiCatalogAppTestAppBundleId)));
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(UiCatalogTestAppElement)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(UiCatalogTestAppElement))));
         }
 
         #endregion
@@ -108,11 +108,11 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
                 ["UITEST_LAUNCH"] = "1"
             };
 
-            Assert.DoesNotThrow(() =>
-                _driver.LaunchAppWithArguments(UiCatalogAppTestAppBundleId, processArguments, environmentVariables));
+            Assert.DoesNotThrow((System.Action)(() =>
+                _driver.LaunchAppWithArguments(UiCatalogAppTestAppBundleId, processArguments, environmentVariables)));
 
-            Assert.That(() => _driver.GetAppState(UiCatalogAppTestAppBundleId), Is.EqualTo(AppState.RunningInForeground));
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(UiCatalogTestAppElement)));
+            Assert.That(_driver.GetAppState(UiCatalogAppTestAppBundleId), Is.EqualTo(AppState.RunningInForeground));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(UiCatalogTestAppElement))));
         }
 
         #endregion
@@ -122,31 +122,27 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
         [Test]
         public void CanBackgroundApp()
         {
-            Assert.DoesNotThrow(
-                () => _driver.BackgroundApp());
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(IosDockElement)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp()));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(IosDockElement))));
         }
 
         [Test]
         public void CanBackgroundAppForSeconds()
         {
-            Assert.DoesNotThrow(
-                () => _driver.BackgroundApp(TimeSpan.FromSeconds(5)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp(TimeSpan.FromSeconds(5))));
         }
 
         [Test]
         public void CanBackgroundAppForTimeSpan()
         {
-            Assert.DoesNotThrow(
-                () => _driver.BackgroundApp(TimeSpan.FromSeconds(10)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp(TimeSpan.FromSeconds(10))));
         }
 
         [Test]
         public void CanBackgroundAppToDeactivationUsingNegativeSecond()
         {
-            Assert.DoesNotThrow(
-                () => _driver.BackgroundApp(TimeSpan.FromSeconds(-1)));
-            Assert.DoesNotThrow(() => _driver.FindElement(MobileBy.AccessibilityId(IosDockElement)));
+            Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp(TimeSpan.FromSeconds(-1))));
+            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(IosDockElement))));
         }
 
         #endregion

--- a/test/integration/IOS/ElementTest.cs
+++ b/test/integration/IOS/ElementTest.cs
@@ -38,11 +38,11 @@ namespace Appium.Net.Integration.Tests.IOS
         public void FindByAccessibilityIdTest()
         {
             By byAccessibilityId = new ByAccessibilityId("ComputeSumButton");
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(_driver.FindElement(MobileBy.ClassName("UIAWindow")).FindElement(byAccessibilityId).Text, Is.EqualTo("Compute Sum"));
                 Assert.That(_driver.FindElement(MobileBy.ClassName("UIAWindow")).FindElements(byAccessibilityId), Is.Not.Empty);
-            });
+            }
         }
 
         [Test]

--- a/test/integration/IOS/SearchingTest.cs
+++ b/test/integration/IOS/SearchingTest.cs
@@ -41,11 +41,11 @@ namespace Appium.Net.Integration.Tests.IOS
         public void FindByAccessibilityIdTest()
         {
             By byAccessibilityId = new ByAccessibilityId("ComputeSumButton");
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(string.IsNullOrEmpty(_driver.FindElement(byAccessibilityId).Text), Is.False);
                 Assert.That(_driver.FindElements(byAccessibilityId), Is.Not.Empty);
-            });
+            }
         }
     }
 }

--- a/test/integration/IOS/Session/LogTests.cs
+++ b/test/integration/IOS/Session/LogTests.cs
@@ -38,11 +38,11 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
         {
             var logs = _driver.Manage().Logs;
             var availableLogTypes = _driver.Manage().Logs.AvailableLogTypes;
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(logs.AvailableLogTypes, Is.Not.Null);
                 Assert.That(availableLogTypes, Is.Not.Empty, nameof(availableLogTypes));
-            });
+            }
             Console.WriteLine(@"Available log types:");
             foreach (var logType in availableLogTypes)
             {
@@ -57,7 +57,7 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
             Assert.That(availableLogTypes, Is.Not.Null);
             Assert.That(availableLogTypes, Has.Member(SyslogLogType));
 
-            Assert.DoesNotThrow(() => _driver.Manage().Logs.GetLog(SyslogLogType));
+            Assert.DoesNotThrow((System.Action)(() => _driver.Manage().Logs.GetLog(SyslogLogType)));
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace Appium.Net.Integration.Tests.IOS.Session.Logs
             Assert.That(availableLogTypes, Is.Not.Null);
             Assert.That(availableLogTypes, Has.Member(CrashLogType));
 
-            Assert.DoesNotThrow(() => _driver.Manage().Logs.GetLog(CrashLogType));
+            Assert.DoesNotThrow((System.Action)(() => _driver.Manage().Logs.GetLog(CrashLogType)));
         }
 
         [Test]

--- a/test/integration/ServerTests/AppiumLocalServerLaunchingTest.cs
+++ b/test/integration/ServerTests/AppiumLocalServerLaunchingTest.cs
@@ -362,7 +362,7 @@ namespace Appium.Net.Integration.Tests.ServerTests
         {
             var serviceBuilder = new AppiumServiceBuilder();
             string[] nullArray = null;
-            Assert.Throws<ArgumentNullException>((Action)(() => serviceBuilder.WithNodeArguments(nullArray)));
+            Assert.Throws<ArgumentNullException>((System.Action)(() => serviceBuilder.WithNodeArguments(nullArray)));
         }
 
         [TestCase(null)]

--- a/test/integration/ServerTests/AppiumLocalServerLaunchingTest.cs
+++ b/test/integration/ServerTests/AppiumLocalServerLaunchingTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
@@ -236,11 +236,11 @@ namespace Appium.Net.Integration.Tests.ServerTests
             Assert.That(arguments.Count, Is.GreaterThan(capabilitiesIndex + 1), "Capabilities value missing.");
 
             var capabilitiesArgument = arguments[capabilitiesIndex + 1];
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(capabilitiesArgument, Does.Contain("platformName"));
                 Assert.That(capabilitiesArgument, Does.Contain("appPackage"));
-            });
+            }
         }
 
         [Test]
@@ -296,13 +296,13 @@ namespace Appium.Net.Integration.Tests.ServerTests
             service3.Dispose();
             Thread.Sleep(1000);
             service4.Dispose();
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(!service1.IsRunning);
                 Assert.That(!service2.IsRunning);
                 Assert.That(!service3.IsRunning);
                 Assert.That(!service4.IsRunning);
-            });
+            }
         }
 
 
@@ -314,11 +314,11 @@ namespace Appium.Net.Integration.Tests.ServerTests
             try
             {
                 service.Start();
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(log.Exists, Is.True);
                     Assert.That(log.Length, Is.GreaterThan(0)); //There should be Appium greeting messages
-                });
+                }
             }
             finally
             {
@@ -362,7 +362,7 @@ namespace Appium.Net.Integration.Tests.ServerTests
         {
             var serviceBuilder = new AppiumServiceBuilder();
             string[] nullArray = null;
-            Assert.Throws<ArgumentNullException>(() => serviceBuilder.WithNodeArguments(nullArray));
+            Assert.Throws<ArgumentNullException>((Action)(() => serviceBuilder.WithNodeArguments(nullArray)));
         }
 
         [TestCase(null)]
@@ -373,7 +373,7 @@ namespace Appium.Net.Integration.Tests.ServerTests
         public void AddingInvalidNodeArgumentThrowsException(string argument)
         {
             var serviceBuilder = new AppiumServiceBuilder();
-            Assert.Throws<ArgumentException>(() => serviceBuilder.WithNodeArguments(argument));
+            Assert.Throws<ArgumentException>((System.Action)(() => serviceBuilder.WithNodeArguments(argument)));
         }
     }
 }

--- a/test/integration/Windows/ImagesComparisonTest.cs
+++ b/test/integration/Windows/ImagesComparisonTest.cs
@@ -47,11 +47,11 @@ namespace Appium.Net.Integration.Tests.Windows
 
             var similarityResult = _calculatorSession.GetImagesSimilarity(screenshot.AsBase64EncodedString, screenshot.AsBase64EncodedString, options);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(similarityResult.Score, Is.GreaterThan(0));
                 Assert.That(similarityResult.Visualization, Is.Not.Null);
-            });
+            }
         }
 
         [Test]
@@ -62,12 +62,12 @@ namespace Appium.Net.Integration.Tests.Windows
 
             var occurencesResult = _calculatorSession.FindImageOccurence(screenshot.AsBase64EncodedString, screenshot.AsBase64EncodedString, options);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(occurencesResult.Rect.IsEmpty, Is.False);
                 Assert.That(occurencesResult.Rect.Bottom, Is.GreaterThan(0));
                 Assert.That(occurencesResult.Visualization, Is.Not.Null);
-            });
+            }
         }
 
         [Test]
@@ -84,18 +84,18 @@ namespace Appium.Net.Integration.Tests.Windows
 
             var occurencesResult = _calculatorSession.MatchImageFeatures(screenshot.AsBase64EncodedString, screenshot.AsBase64EncodedString, options);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(occurencesResult.Visualization, Is.Not.Null);
                 Assert.That(occurencesResult.TotalCount, Is.GreaterThan(0));
                 Assert.That(occurencesResult.Points1, Is.Not.Empty);
                 Assert.That(occurencesResult.Points2, Is.Not.Empty);
-            });
-            Assert.Multiple(() =>
+            }
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(occurencesResult.Rect1.Width, Is.Positive);
                 Assert.That(occurencesResult.Rect2.Height, Is.Positive);
-            });
+            }
         }
     }
 }


### PR DESCRIPTION
## List of changes

- Resolves CS0121 compiler errors ("The call is ambiguous...") introduced by bumping NUnit from 4.5.1 to 4.6.1.
- Converts 31 occurrences of `Assert.Multiple` lambdas to the modern `using (Assert.EnterMultipleScope())` syntax.
- Adds explicit casts to `System.Action` for lambdas passed to `Assert.DoesNotThrow` and `Assert.Throws<T>`.
- Removes lambdas checking property values immediately in `Assert.That` statements.
- Resolves method group ambiguities in `test/integration/IOS/ClipboardTest.cs` by invoking them as method calls.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 

## Integration tests
- [x] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)
_Note: These are compiler fixes for the integration tests themselves._

## Details

NUnit 4.6.x introduced overloads accepting `System.Action`/`System.Func<T>`. On projects using C# 12 and below, this creates compiler ambiguity for lambdas passed to NUnit assertion helper methods. By migrating `Assert.Multiple` to the recommended `Assert.EnterMultipleScope()` scope pattern, explicitly casting delegate-checking lambdas to `System.Action`, and avoiding delegate evaluation where immediate evaluation is sufficient, the integration tests compile successfully on all target frameworks (`net8.0` and `net48`) using the default project compiler.
