### PR TITLE
test(android): increase adbExecTimeout in ClipboardTest

### DIFF
--- a/test/integration/Android/ClipboardTest.cs
+++ b/test/integration/Android/ClipboardTest.cs
@@ -1,4 +1,4 @@
-﻿using Appium.Net.Integration.Tests.helpers;
+using Appium.Net.Integration.Tests.helpers;
 using NUnit.Framework;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.Enums;
@@ -24,6 +24,7 @@ namespace Appium.Net.Integration.Tests.Android
         {
             var capabilities = Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             capabilities.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, true);
+            capabilities.AddAdditionalAppiumOption("appium:adbExecTimeout", 60000);
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;

--- a/test/integration/Android/ClipboardTest.cs
+++ b/test/integration/Android/ClipboardTest.cs
@@ -24,7 +24,7 @@ namespace Appium.Net.Integration.Tests.Android
         {
             var capabilities = Caps.GetAndroidUIAutomatorCaps(Apps.Get("androidApiDemos"));
             capabilities.AddAdditionalAppiumOption(MobileCapabilityType.FullReset, true);
-            capabilities.AddAdditionalAppiumOption("appium:adbExecTimeout", 60000);
+            capabilities.AddAdditionalAppiumOption("adbExecTimeout", 60000);
             var serverUri = Env.ServerIsRemote() ? AppiumServers.RemoteServerUri : AppiumServers.LocalServiceUri;
             _driver = new AndroidDriver(serverUri, capabilities, Env.InitTimeoutSec);
             _driver.Manage().Timeouts().ImplicitWait = Env.ImplicitTimeoutSec;


### PR DESCRIPTION
## List of changes

- Increased `adbExecTimeout` to 60000ms for the Android Clipboard integration test to prevent CI timeouts during ADB broadcast.
- Removed redundant `appium:` prefix from `"adbExecTimeout"` capability since `AddAdditionalAppiumOption` handles it.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] **Test fix** (non-breaking change that improves test stability or correctness)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Fixes #1078.
The Android integration test `WhenClipboardContentTypeIsPlainTextWithLabelGetClipboardTextShouldReturnActualText` was failing on CI due to an ADB execution timeout. This sets the capability to increase the timeout to 60000ms to allow it to finish reliably.
