### PR TITLE
chore: remove prerelease identifier from release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,5 +48,4 @@ version-resolver:
   default: patch
   
 prerelease: false
-prerelease-identifier: 'rc'
 contribution-template: '- $NAME contributed via $PULL_REQUEST'


### PR DESCRIPTION
## List of changes

Removed the `prerelease-identifier` property from the `release-drafter.yml` configuration since we are no longer generating pre-releases (RCs) and want release drafts to be named without the `-rc` suffix.
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] **Test fix** (non-breaking change that improves test stability or correctness)
- [x] Chore (updating GitHub Action configuration)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Since `prerelease: false` was set previously to stop creating pre-releases, we also need to remove the `prerelease-identifier: 'rc'` line to prevent Release Drafter from appending the `-rc` suffix to the resolved versions of our draft releases.
