### PR TITLE
chore: improve android emulator stability in CI

### DIFF
--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [32]
-        target: [google_apis]
+        target: [google_atd]
 
     env:
       APPIUM_LOG_PATH: '${{ github.workspace }}/appium.log'
@@ -70,6 +70,9 @@ jobs:
         api-level: ${{ matrix.api-level }}
         target: ${{ matrix.target }}
         arch: x86_64
+        profile: Nexus 6
+        ram-size: 4096M
+        heap-size: 1024M
         force-avd-creation: false
         emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: false
@@ -110,6 +113,9 @@ jobs:
         api-level: ${{ matrix.api-level }}
         target: ${{ matrix.target }}
         arch: x86_64
+        profile: Nexus 6
+        ram-size: 4096M
+        heap-size: 1024M
         force-avd-creation: false
         emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
         disable-animations: true

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [32]
-        target: [google_atd]
+        target: [google_apis]
 
     env:
       APPIUM_LOG_PATH: '${{ github.workspace }}/appium.log'
@@ -61,7 +61,7 @@ jobs:
         path: |
           ~/.android/avd/*
           ~/.android/adb*
-        key: avd-${{ matrix.api-level }}-${{ matrix.target }}
+        key: avd-${{ matrix.api-level }}-${{ matrix.target }}-v1-ram4g
 
     - name: Create AVD and generate snapshot for caching
       if: steps.avd-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## List of changes

- Added explicit RAM (4096M) and Heap (1024M) allocation and a profile (Nexus 6) to the `android-emulator-runner` steps to reduce "device offline" crashes for `google_apis`.
- Busted the AVD cache key by appending `-v1-ram4g` to ensure the new hardware configuration is actually applied instead of hitting stale caches with default hardware.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] **Test fix** (non-breaking change that improves test stability or correctness)
- [x] Chore/Maintenance (updates to build scripts, dependencies, or GitHub Actions)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 
#### This can be done by navigating to the documentation section on http://appium.io selecting the appropriate command/endpoint and clicking the 'Edit this doc' link to update the C# example

## Integration tests
- [ ] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

This aims to improve the stability of the Android functional tests CI job by explicitly configuring more resources for the Android emulator. The cache key has been updated to force recreation of the emulator snapshot with the new hardware profile.
