### PR TITLE
test(ios): fix flaky CanBackgroundAppToDeactivation test

### DIFF
--- a/test/integration/IOS/Device/AppTests.cs
+++ b/test/integration/IOS/Device/AppTests.cs
@@ -145,7 +145,9 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
         public void CanBackgroundAppToDeactivationUsingNegativeSecond()
         {
             Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp(TimeSpan.FromSeconds(-1))));
-            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(IosDockElement))));
+            
+            WebDriverWait wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+            Assert.DoesNotThrow((System.Action)(() => wait.Until(d => d.FindElement(MobileBy.AccessibilityId(IosDockElement)))));
         }
 
         #endregion

--- a/test/integration/IOS/Device/AppTests.cs
+++ b/test/integration/IOS/Device/AppTests.cs
@@ -39,15 +39,16 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
 
         private void WaitForElement(string accessibilityId)
         {
+            var previousImplicitWait = _driver.Manage().Timeouts().ImplicitWait;
             _driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
             try
             {
                 WebDriverWait wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
-                Assert.DoesNotThrow((System.Action)(() => wait.Until(d => d.FindElement(MobileBy.AccessibilityId(accessibilityId)))));
+                wait.Until(d => d.FindElement(MobileBy.AccessibilityId(accessibilityId)));
             }
             finally
             {
-                _driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
+                _driver.Manage().Timeouts().ImplicitWait = previousImplicitWait;
             }
         }
 

--- a/test/integration/IOS/Device/AppTests.cs
+++ b/test/integration/IOS/Device/AppTests.cs
@@ -145,9 +145,16 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
         public void CanBackgroundAppToDeactivationUsingNegativeSecond()
         {
             Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp(TimeSpan.FromSeconds(-1))));
-            
-            WebDriverWait wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
-            Assert.DoesNotThrow((System.Action)(() => wait.Until(d => d.FindElement(MobileBy.AccessibilityId(IosDockElement)))));
+            _driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
+            try
+            {
+                WebDriverWait wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+                Assert.DoesNotThrow((System.Action)(() => wait.Until(d => d.FindElement(MobileBy.AccessibilityId(IosDockElement)))));
+            }
+            finally
+            {
+                _driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
+            }
         }
 
         #endregion

--- a/test/integration/IOS/Device/AppTests.cs
+++ b/test/integration/IOS/Device/AppTests.cs
@@ -43,7 +43,7 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
             _driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
             try
             {
-                WebDriverWait wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+                WebDriverWait wait = new WebDriverWait(_driver, previousImplicitWait.TotalSeconds > 0 ? previousImplicitWait : TimeSpan.FromSeconds(10));
                 wait.Until(d => d.FindElement(MobileBy.AccessibilityId(accessibilityId)));
             }
             finally

--- a/test/integration/IOS/Device/AppTests.cs
+++ b/test/integration/IOS/Device/AppTests.cs
@@ -37,6 +37,20 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
             _driver.Dispose();
         }
 
+        private void WaitForElement(string accessibilityId)
+        {
+            _driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
+            try
+            {
+                WebDriverWait wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
+                Assert.DoesNotThrow((System.Action)(() => wait.Until(d => d.FindElement(MobileBy.AccessibilityId(accessibilityId)))));
+            }
+            finally
+            {
+                _driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
+            }
+        }
+
         #region Activate App
 
         [Test]
@@ -46,7 +60,7 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
             Assert.DoesNotThrow((System.Action)(() => _driver.ActivateApp(IosTestAppBundleId)));
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(IosTestAppElement))));
+            WaitForElement(IosTestAppElement);
         }
 
         [Test]
@@ -56,7 +70,7 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
             Assert.DoesNotThrow((System.Action)(() => _driver.ActivateApp(IosTestAppBundleId, TimeSpan.FromSeconds(20))));
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(IosTestAppElement))));
+            WaitForElement(IosTestAppElement);
         }
 
         [Test]
@@ -69,7 +83,7 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
             Assert.That(_driver.GetAppState(IosTestAppBundleId), Is.EqualTo(AppState.RunningInForeground));
 
             //Verify the expected app was activated
-            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(IosTestAppElement))));
+            WaitForElement(IosTestAppElement);
         }
 
         [Test]
@@ -115,7 +129,7 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
                 _driver.LaunchAppWithArguments(UiCatalogAppTestAppBundleId, processArguments, environmentVariables)));
 
             Assert.That(_driver.GetAppState(UiCatalogAppTestAppBundleId), Is.EqualTo(AppState.RunningInForeground));
-            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(UiCatalogTestAppElement))));
+            WaitForElement(UiCatalogTestAppElement);
         }
 
         #endregion
@@ -126,7 +140,7 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
         public void CanBackgroundApp()
         {
             Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp()));
-            Assert.DoesNotThrow((System.Action)(() => _driver.FindElement(MobileBy.AccessibilityId(IosDockElement))));
+            WaitForElement(IosDockElement);
         }
 
         [Test]
@@ -145,16 +159,7 @@ namespace Appium.Net.Integration.Tests.IOS.Device.App
         public void CanBackgroundAppToDeactivationUsingNegativeSecond()
         {
             Assert.DoesNotThrow((System.Action)(() => _driver.BackgroundApp(TimeSpan.FromSeconds(-1))));
-            _driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
-            try
-            {
-                WebDriverWait wait = new WebDriverWait(_driver, TimeSpan.FromSeconds(10));
-                Assert.DoesNotThrow((System.Action)(() => wait.Until(d => d.FindElement(MobileBy.AccessibilityId(IosDockElement)))));
-            }
-            finally
-            {
-                _driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
-            }
+            WaitForElement(IosDockElement);
         }
 
         #endregion


### PR DESCRIPTION
## List of changes

- Refactored `AppTests.cs` to use a `WaitForElement` helper to fix flakiness across all explicit UI element checks.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] **Test fix** (non-breaking change that improves test stability or correctness)
- [ ] Chore/Maintenance (updates to build scripts, dependencies, or GitHub Actions)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 

## Integration tests
- [x] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)

## Details

Multiple tests in `AppTests.cs` (like `CanBackgroundAppToDeactivationUsingNegativeSecond` and `CanActivateAppTest`) intermittently failed with `NoSuchElementException` because they used an immediate `FindElement` call instead of waiting for the element to render. This PR introduces a `WaitForElement` helper method that temporarily zeroes out the implicit wait, uses an explicit `WebDriverWait` (using the captured implicit wait as the timeout duration) to wait for elements by their Accessibility ID, and restores the implicit wait afterward. All similar explicit assertions in the file have been refactored to use this helper.
