### PR TITLE
test: Fix IndexOutOfRange in ActionsChainsTest by adding explicit WebDriverWait

### DIFF
--- a/test/integration/Android/ActionsChainsTest.cs
+++ b/test/integration/Android/ActionsChainsTest.cs
@@ -16,6 +16,7 @@ using Appium.Net.Integration.Tests.helpers;
 using NUnit.Framework;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium;
+using OpenQA.Selenium.Support.UI;
 using System.Collections.Generic;
 using OpenQA.Selenium.Interactions;
 using System;
@@ -59,6 +60,25 @@ namespace Appium.Net.Integration.Tests.Android
             _ = _driver?.TerminateApp(Apps.GetId(Apps.androidApiDemos));
         }
 
+        private IList<AppiumElement> WaitForTextViewElements(int minimumCount)
+        {
+            var previousImplicitWait = _driver.Manage().Timeouts().ImplicitWait;
+            _driver.Manage().Timeouts().ImplicitWait = TimeSpan.Zero;
+            try
+            {
+                WebDriverWait wait = new WebDriverWait(_driver, previousImplicitWait.TotalSeconds > 0 ? previousImplicitWait : TimeSpan.FromSeconds(10));
+                return wait.Until(d =>
+                {
+                    var els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
+                    return els.Count >= minimumCount ? els : null;
+                });
+            }
+            finally
+            {
+                _driver.Manage().Timeouts().ImplicitWait = previousImplicitWait;
+            }
+        }
+
         [OneTimeTearDown]
         public void AfterAll()
         {
@@ -72,7 +92,7 @@ namespace Appium.Net.Integration.Tests.Android
         [Test]
         public void SimpleTouchActionTestCase()
         {
-            IList<AppiumElement> els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
+            IList<AppiumElement> els = WaitForTextViewElements(3);
 
             var number1 = els.Count;
             var elementToTouch = els[2];
@@ -105,7 +125,7 @@ namespace Appium.Net.Integration.Tests.Android
         [Test]
         public void TouchByCoordinatesTestCase()
         {
-            IList<AppiumElement> els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
+            IList<AppiumElement> els = WaitForTextViewElements(3);
             var number1 = els.Count;
             var elementToTouch = els[2];
 
@@ -164,7 +184,7 @@ namespace Appium.Net.Integration.Tests.Android
 
             _driver.PerformActions(sequence);
 
-            IList<AppiumElement> els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
+            IList<AppiumElement> els = WaitForTextViewElements(8);
             var origin = els[7];
             var loc1 = origin.Location;
             var target = els[1];
@@ -221,7 +241,7 @@ namespace Appium.Net.Integration.Tests.Android
             var sequence = actionBuilder.ToActionSequenceList();
             _driver.PerformActions(sequence);
 
-            IList<AppiumElement> els = _driver.FindElements(MobileBy.ClassName("android.widget.TextView"));
+            IList<AppiumElement> els = WaitForTextViewElements(8);
             var origin = els[7];
             var loc1 = origin.Location;
             var target = els[1];


### PR DESCRIPTION
## List of changes

- Add `WaitForTextViewElements` helper method to temporarily disable `ImplicitWait` during explicit polling.
- Update `ActionsChainsTest` Android integration tests to use the new wait helper instead of indexing into the unverified list immediately.
 
## Types of changes

What types of changes are you proposing/introducing to the .NET client?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change that adds functionality or value)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [x] **Test fix** (non-breaking change that improves test stability or correctness)
- [ ] Chore/Maintenance (updates to build scripts, dependencies, or GitHub Actions)

## Documentation
- [ ] Have you proposed a file change/ PR with Appium to update documentation? 

## Integration tests
- [x] Have you provided integration tests for your changes? (required for Bugfix, New feature, or Test fix)
*This PR specifically fixes existing integration tests.*

## Details

Fixes an issue where `ActionsChainsTest` tests (specifically `SimpleTouchActionTestCase`, `TouchByCoordinatesTestCase`, `ScrollActionTestCase`, and `ScrollUsingAddActionsTestCase`) were failing due to trying to access elements before they were fully loaded in slower environments. 

This adds an explicit wait to make sure the expected number of items is present before attempting to index into them. The helper temporarily disables `ImplicitWait` while running the explicit polling to avoid excessively long delay blocks.
